### PR TITLE
fix: remove deprecated numpy aliases for numpy 2.x compatibility

### DIFF
--- a/fynance/models/neural_network.py
+++ b/fynance/models/neural_network.py
@@ -467,7 +467,7 @@ class MultiLayerPerceptron(BaseNeuralNet):
 
 
 def _type_convert(dtype):
-    if dtype is np.float64 or dtype is np.float or dtype is np.double:
+    if dtype is np.float64:
         return torch.float64
 
     elif dtype is np.float32:
@@ -482,13 +482,13 @@ def _type_convert(dtype):
     elif dtype is np.int8:
         return torch.int8
 
-    elif dtype is np.int16 or dtype is np.short:
+    elif dtype is np.int16:
         return torch.int16
 
     elif dtype is np.int32:
         return torch.int32
 
-    elif dtype is np.int64 or dtype is np.int or dtype is np.long:
+    elif dtype is np.int64:
         return torch.int64
 
     else:

--- a/fynance/tests/models/test_neural_network.py
+++ b/fynance/tests/models/test_neural_network.py
@@ -6,7 +6,7 @@ import torch
 import torch.nn as nn
 
 from fynance.models.attention import MultiHeadAttention, ScaledDotProductAttention
-from fynance.models.neural_network import MultiLayerPerceptron
+from fynance.models.neural_network import MultiLayerPerceptron, _type_convert
 from fynance.models.recurrent_neural_network import (
     GatedRecurrentUnit,
     LongShortTermMemory,
@@ -24,6 +24,41 @@ X_np = RNG.standard_normal((T, N_IN)).astype(np.float32)
 y_np = RNG.standard_normal((T, N_OUT)).astype(np.float32)
 X_t = torch.from_numpy(X_np)
 y_t = torch.from_numpy(y_np)
+
+
+# ---------------------------------------------------------------------------
+# Type conversion
+# ---------------------------------------------------------------------------
+
+class TestTypeConvert:
+
+    def test_float64_mapping(self):
+        assert _type_convert(np.float64) == torch.float64
+
+    def test_float32_mapping(self):
+        assert _type_convert(np.float32) == torch.float32
+
+    def test_float16_mapping(self):
+        assert _type_convert(np.float16) == torch.float16
+
+    def test_uint8_mapping(self):
+        assert _type_convert(np.uint8) == torch.uint8
+
+    def test_int8_mapping(self):
+        assert _type_convert(np.int8) == torch.int8
+
+    def test_int16_mapping(self):
+        assert _type_convert(np.int16) == torch.int16
+
+    def test_int32_mapping(self):
+        assert _type_convert(np.int32) == torch.int32
+
+    def test_int64_mapping(self):
+        assert _type_convert(np.int64) == torch.int64
+
+    def test_unknown_type_raises_valueerror(self):
+        with pytest.raises(ValueError, match="Unkwnown type"):
+            _type_convert(object())
 
 
 # ---------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68", "Cython>=3.0", "numpy>=1.26"]
+requires = ["setuptools>=68", "Cython>=3.0", "numpy>=2.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -27,7 +27,7 @@ classifiers = [
 ]
 dependencies = [
     "matplotlib>=3.7",
-    "numpy>=1.26",
+    "numpy>=2.0",
     "pandas>=2.0",
     "scipy>=1.11",
     "seaborn>=0.12",


### PR DESCRIPTION
## Summary
Removes deprecated NumPy 1.x dtype aliases that were removed in numpy 1.24 and cause `AttributeError` on numpy ≥ 2.0.

**Related:** Modernisation plan, long terme section 5.1

## Changes
- Replaced `np.float`, `np.double` with `np.float64` in `_type_convert()`
- Replaced `np.short` with `np.int16` 
- Replaced `np.int`, `np.long` with `np.int64`
- Bumped minimum numpy requirement to `>=2.0` in both `[build-system]` and `[project.dependencies]`
- Added comprehensive test coverage for `_type_convert()` (9 tests covering all dtype mappings)

## Test plan
- [x] Tests added pass locally (`pytest fynance/tests/models/`)
- [x] Ruff lint passes (`ruff check fynance/models/neural_network.py`)
- [x] All 30 model tests pass
- [x] No backward compatibility issues (aliases were already broken on numpy >= 1.24)

## Rationale
The codebase already runs on numpy 2.4.4, so bumping to `>=2.0` is the correct constraint. All major dependencies (PyTorch ≥ 2.0, pandas ≥ 2.0, scipy ≥ 1.11) support numpy 2.x.