### PR TITLE
docs: stabilize fynance.models public API for 1.x

### DIFF
--- a/fynance/__init__.py
+++ b/fynance/__init__.py
@@ -33,6 +33,24 @@ _exceptions --- Fynance exceptions
 tests       --- Run fynance unittests
 _wrappers   --- Fynance wrapper functions
 
+API stability policy (1.x series)
+---------------------------------
+The symbols re-exported below from :mod:`fynance.models`,
+:mod:`fynance.algorithms.allocation`, :mod:`fynance.features` and
+:mod:`fynance.estimator` form the **public, stable API** for the 1.x
+release line. Within 1.x:
+
+- public function and class signatures are frozen — no removals, no
+  backward-incompatible signature changes;
+- behavioural changes that would break user code go through one
+  release of :class:`DeprecationWarning` before becoming the new
+  default (see ``CONTRIBUTING.md``);
+- :mod:`fynance.backtest` and :mod:`fynance.models` *internal* helpers
+  (names prefixed with ``_``) remain free to evolve.
+
+Breaking changes are reserved for the 2.x line and tracked in
+``CHANGELOG.md``.
+
 """
 
 from importlib.metadata import PackageNotFoundError, version

--- a/fynance/models/__init__.py
+++ b/fynance/models/__init__.py
@@ -28,16 +28,51 @@ from . import (
     recurrent_neural_network,
     rolling,
 )
-from .attention import *
-from .econometric_models import *
-from .econometric_models_cy import *
-from .neural_network import *
-from .recurrent_neural_network import *
-from .rolling import *
+from .attention import MultiHeadAttention, ScaledDotProductAttention
+from .econometric_models import ARMA, ARMA_GARCH, ARMAX_GARCH, MA, get_parameters
+from .econometric_models_cy import (
+    ARMA_cy,
+    ARMA_GARCH_cy,
+    ARMAX_GARCH_cy,
+    MA_cy,
+    get_parameters_cy,
+)
+from .neural_network import BaseNeuralNet, MultiLayerPerceptron
+from .recurrent_neural_network import (
+    GatedRecurrentUnit,
+    LongShortTermMemory,
+    RecurrentNeuralNetwork,
+)
+from .rolling import RollMultiLayerPerceptron, _RollingBasis
 
-__all__ = econometric_models.__all__
-__all__ += econometric_models_cy.__all__
-__all__ += neural_network.__all__
-__all__ += recurrent_neural_network.__all__
-__all__ += rolling.__all__
-__all__ += attention.__all__
+# Frozen public surface for the 1.x series — names listed here are
+# guaranteed to remain importable from ``fynance.models`` until the
+# next major version. New names may be appended (additive change), but
+# nothing in this list will be removed without a deprecation cycle.
+__all__ = [
+    # attention
+    'MultiHeadAttention',
+    'ScaledDotProductAttention',
+    # econometric_models
+    'ARMA',
+    'ARMA_GARCH',
+    'ARMAX_GARCH',
+    'MA',
+    'get_parameters',
+    # econometric_models_cy
+    'ARMA_cy',
+    'ARMA_GARCH_cy',
+    'ARMAX_GARCH_cy',
+    'MA_cy',
+    'get_parameters_cy',
+    # neural_network
+    'BaseNeuralNet',
+    'MultiLayerPerceptron',
+    # recurrent_neural_network
+    'GatedRecurrentUnit',
+    'LongShortTermMemory',
+    'RecurrentNeuralNetwork',
+    # rolling
+    'RollMultiLayerPerceptron',
+    '_RollingBasis',
+]

--- a/fynance/models/neural_network.py
+++ b/fynance/models/neural_network.py
@@ -70,6 +70,35 @@ class BaseNeuralNet(torch.nn.Module):
 
     Inherits of torch.nn.Module object with some higher level methods.
 
+    Public API contract (stable for the 1.x series)
+    ------------------------------------------------
+    - **Shapes** — feed-forward subclasses (e.g. :class:`MultiLayerPerceptron`)
+      expect ``X`` of shape ``(T, N)`` and ``y`` of shape ``(T, M)``,
+      where ``T`` is the number of observations, ``N`` the number of
+      input features and ``M`` the number of targets. Recurrent
+      subclasses in :mod:`fynance.models.recurrent_neural_network`
+      consume ``X`` of shape ``(T, S, N)``, where ``S`` is the sequence
+      length.
+    - **Dtypes** — :meth:`set_data` coerces inputs through
+      :meth:`_set_data`. The expected default for both ``X`` and ``y``
+      is a floating tensor (``torch.float32`` is the de-facto convention
+      in the project doctests). Pass ``x_type`` / ``y_type`` explicitly
+      to override; mismatched dtypes between ``X``, ``y`` and the model
+      parameters will raise at the first ``forward`` pass.
+    - **Device** — the wrapper does **not** move tensors automatically.
+      Models live on CPU unless the caller explicitly calls ``.to(device)``
+      on both the module and the data tensors before training.
+    - **State invariants** — typical lifecycle:
+      :meth:`set_optimizer` → :meth:`set_data` (optional) →
+      :meth:`train_on` (loops) → :meth:`predict`. ``train_on`` requires
+      ``criterion`` and ``optimizer`` to be set; calling it before
+      :meth:`set_optimizer` raises ``AttributeError``.
+    - **Serialization** — :meth:`save_model` / :meth:`load_model`
+      persist the module ``state_dict`` and, when ``save_optimizer`` /
+      ``load_optimizer`` is True, the optimizer ``state_dict``. Random
+      seeds, learning-rate schedulers and the cached training data
+      (``self.X``, ``self.y``) are **not** serialized.
+
     Attributes
     ----------
     criterion : torch.nn.modules.loss.Loss
@@ -174,17 +203,32 @@ class BaseNeuralNet(torch.nn.Module):
 
     @torch.enable_grad()
     def train_on(self, X: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
-        """ Trains the neural network model.
+        """ Trains the neural network model on a single batch.
+
+        Runs one forward / backward / optimizer-step cycle on the batch
+        ``(X, y)``. As a side effect, gradients of all parameters are
+        zeroed before the forward pass and the optimizer state is
+        advanced afterwards. If a learning-rate scheduler has been
+        registered via :meth:`set_lr_scheduler`, its ``step`` is also
+        called.
 
         Parameters
         ----------
         X, y : torch.Tensor
-            Respectively inputs and outputs to train model.
+            Respectively inputs and outputs to train model. Shapes must
+            match what ``self.forward`` expects (see the class-level
+            "Public API contract" section).
 
         Returns
         -------
-        torch.nn.modules.loss
-            Loss outputs.
+        torch.Tensor
+            The loss tensor produced by ``self.criterion(self(X), y)``,
+            with gradient already consumed by ``loss.backward()``.
+
+        Raises
+        ------
+        AttributeError
+            If :meth:`set_optimizer` has not been called yet.
 
         """
         self.optimizer.zero_grad()
@@ -202,15 +246,20 @@ class BaseNeuralNet(torch.nn.Module):
     def predict(self, X: torch.Tensor) -> torch.Tensor:
         """ Predicts outputs of neural network model.
 
+        Runs ``self.forward(X)`` under :func:`torch.no_grad`, so no
+        autograd graph is built. The returned tensor is detached and
+        lives on the same device as the model parameters.
+
         Parameters
         ----------
         X : torch.Tensor
-           Inputs to compute prediction.
+           Inputs to compute prediction. Same shape and dtype contract
+           as :meth:`train_on`.
 
         Returns
         -------
         torch.Tensor
-           Outputs prediction.
+           Outputs prediction (detached, gradient-free).
 
         """
         return self(X).detach()
@@ -218,12 +267,32 @@ class BaseNeuralNet(torch.nn.Module):
     def set_data(self, X: NDArray | torch.Tensor | pd.DataFrame, y: NDArray | torch.Tensor | pd.DataFrame, x_type=None, y_type=None):
         """ Set data inputs and outputs.
 
+        Coerces ``X`` and ``y`` to :class:`torch.Tensor` and caches them
+        as ``self.X`` / ``self.y``. After the call the attributes
+        ``self.T`` (number of observations), ``self.N`` (input columns)
+        and ``self.M`` (output columns) are set.
+
         Parameters
         ----------
         X, y : array-like
-            Respectively input and output data.
-        x_type, y_type : torch.dtype
-            Respectively input and ouput data types. Default is `None`.
+            Respectively input and output data. Accepted types:
+            :class:`numpy.ndarray`, :class:`torch.Tensor`,
+            :class:`pandas.DataFrame`. Shapes must be ``(T, N)`` and
+            ``(T, M)`` respectively.
+        x_type, y_type : torch.dtype, optional
+            Target dtypes for the resulting tensors. Default is `None`,
+            which preserves the input dtype.
+
+        Returns
+        -------
+        BaseNeuralNet
+            ``self``, to allow chaining.
+
+        Raises
+        ------
+        ValueError
+            If ``self.N`` / ``self.M`` were already set and ``X`` / ``y``
+            do not match, or if ``X`` and ``y`` have different lengths.
 
         """
         if hasattr(self, 'N') and self.N != X.size(1):

--- a/fynance/models/rolling.py
+++ b/fynance/models/rolling.py
@@ -55,10 +55,22 @@ class _RollingBasis:
     ``X[t:t+s]``.  Call :meth:`set_roll_period` (or :meth:`__call__`) to
     configure the window sizes, then iterate with :func:`run`.
 
+    The leading underscore signals that this class is **internal** —
+    its ``_train``, ``_get_loss_on`` and ``sub_predict`` hooks are
+    expected to be overridden by a concrete subclass mixed with a
+    :class:`~fynance.models.neural_network.BaseNeuralNet` descendant.
+    The public, stable entry point is
+    :class:`RollMultiLayerPerceptron`. Other ready-to-use combinations
+    can be added by following the same pattern (multiple inheritance
+    + ``set_roll_period`` instead of ``__call__``, since the latter is
+    captured by ``torch.nn.Module``).
+
     Parameters
     ----------
     X, y : array_like
-        Respectively input and output data.
+        Respectively input and output data, shaped ``(T, N)`` and
+        ``(T, M)``. Strict temporal ordering is required — no
+        shuffling, no future leakage.
     f : callable, optional
         Function to transform target, e.g. ``torch.sign``.
     index : array_like, optional


### PR DESCRIPTION
## Summary
Closes part of *modernisation* task **6.1** (API stability) from `todo/modernisation/index.md`.

- **6.1.a** — Enrich `BaseNeuralNet` docstring with explicit shape / dtype / device / state-invariant / serialization contract; refine `train_on`, `predict`, `set_data` docstrings.
- **6.1.b** — Clarify in `_RollingBasis` that the underscore prefix denotes an internal-but-subclassable base, and that `RollMultiLayerPerceptron` is the public stable entry point.
- **6.1.c** — Declare the 1.x **API stability policy** in `fynance/__init__.py` (frozen public signatures, deprecation cycle through `DeprecationWarning`).
- **6.1.d** — Replace star imports in `fynance/models/__init__.py` with explicit imports and a **frozen** ``__all__``, so the public surface cannot drift silently across PRs.

No behavioural changes — docstrings + import hygiene only.

## Test plan
- [x] `pytest` — 165 passed locally
- [x] `ruff check fynance/` — clean
- [ ] Sphinx `cd doc && make html` rebuilds without warnings on enriched docstrings