### PR TITLE
chore: release v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+### Changed
+
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [1.3.0] - 2026-05-06
+
 ### Changed
 
 - `bollinger_band` legacy single-array notice reclassified from

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fynance"
-version = "1.2.0"
+version = "1.3.0"
 description = "Python and Cython scripts of machine learning, econometrics and statistical features for financial analysis"
 readme = "README.rst"
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary

Freeze `[Unreleased]` → `[1.3.0]` and bump version to 1.3.0.

## [1.3.0] - 2026-05-06

### Changed

- `bollinger_band` legacy single-array notice reclassified from `UserWarning` to `DeprecationWarning`; the legacy return path is scheduled for removal in fynance 2.0.
- All other internal `warnings.warn(...)` calls now pass `category=` and `stacklevel=` explicitly (no semantic change — same `UserWarning`).

### Added

- Walk-forward cross-validation API on `_RollingBasis`: `cross_validate(model_factory, X, y, metric_fn=None, epochs=1)` accumulates out-of-fold predictions into `CVResult`; `_fold_slices()` exposes the windowing iterator as a reusable generator (`fynance/models/rolling.py`) (#31)
- 1.x **API stability policy** declared in `fynance/__init__.py` and `CONTRIBUTING.md`; public `__all__` of `fynance.models` is now frozen and built from explicit imports.
- Strict pytest `filterwarnings`: any `DeprecationWarning` / `PendingDeprecationWarning` raised from inside `fynance.*` is promoted to a test failure, so internal deprecations cannot ship silently.

## Test plan

- [x] pytest passes locally
- [x] ruff check fynance/ passes
- [ ] CI green