### PR TITLE
chore: CI concurrency fix and interrogate badge fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Generate docstring coverage badge
         run: |
           mkdir -p badges
-          interrogate fynance/ --generate-badge badges/ --quiet
+          interrogate fynance/ --generate-badge badges/ --quiet --fail-under 0
 
       - name: Commit badge if changed
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master, develop]
 
+concurrency:
+  group: ci-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Test — Python ${{ matrix.python-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- CI now triggers on push and pull_request to both `master` and `develop`
+- CI now triggers on push and pull_request to both `master` and `develop`; concurrency group added to cancel redundant runs on `develop → master` PR
 - README reorganised: badges split onto two lines (package / quality), content updated to reflect current subpackages (Kalman filter, LSTM, MultiHeadAttention)
 - Split `fynance/models/` into one-file-per-class: `neural_network.py` →
   `_base.py` + `mlp.py`; `recurrent_neural_network.py` → `rnn.py`, `gru.py`,


### PR DESCRIPTION
Commits missed by #40 (pushed after merge):

- Add CI concurrency group to cancel redundant runs on `develop → master` PR
- Fix interrogate badge generation failing with exit code 1 (add `--fail-under 0`)
- Update CHANGELOG to mention concurrency fix

## Test plan

- [ ] CI green
- [ ] `badges` job succeeds and generates `badges/interrogate.svg`