### PR TITLE
feat: add sortino, directional_accuracy metrics and PyTorch loss functions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,154 @@
+# TODO
+
+> Numéros = état de travail. Libres d'être renumérotés quand on
+> réorganise. Ils n'apparaissent jamais dans les commits ou le
+> CHANGELOG : la traçabilité historique se fait via le numéro de PR.
+>
+> Une tâche terminée = ligne supprimée (pas de section Done). La trace
+> vit dans `CHANGELOG.md` et `git log`.
+>
+> Workflow : `/pick-task` → plan mode → implémentation → `/finish-task`.
+> Release : `/release prepare` quand `[Unreleased]` est suffisamment
+> rempli.
+
+---
+
+## 1. Nouvelles architectures ML
+
+### 1.1 Temporal Convolutional Network (TCN)
+
+Implémenter dans `fynance/models/tcn.py`.
+
+- [ ] Base `BaseNeuralNet` avec walk-forward iterator
+- [ ] Couches dilated 1D convolutions + residual blocks
+- [ ] Architecture similaire à `recurrent_neural_network.py` (MLP, GRU, LSTM)
+- [ ] Tests : 5–8 tests (forward pass, gradient flow, rolling, edge cases)
+
+### 1.2 Transformer financier
+
+Compléter `fynance/models/transformer.py`.
+
+- [ ] Positional encoding pour séries temporelles (relatif vs absolu)
+- [ ] Masking causal (pas de lookahead)
+- [ ] Tester multi-head attention avec données réelles
+- [ ] Tests : 6–10 tests
+
+## 2. Loss functions custom pour optimisation
+
+Architecture retenue (Option C) : formules numpy dans `fynance/features/metrics.py`
+(évaluation/backtest), réimplémentées en ops torch pures dans `fynance/models/loss.py`
+(entraînement). Les deux paths sont indépendantes — pas de conversion numpy↔torch.
+
+### 2.1 Compléter les métriques numpy d'évaluation
+
+Dans `fynance/features/metrics.py` (à côté de `sharpe` / `roll_sharpe` existants) :
+
+- [ ] `sortino(X, rf, period, ...)` — symétrique à `sharpe`
+- [ ] `directional_accuracy(y_true, y_pred)` — % de signes correctement prédits
+- [ ] Tests dans `fynance/tests/features/test_metrics.py` : 6–8 tests
+
+### 2.2 Loss PyTorch différentiables pour l'entraînement
+
+Créer le sous-module `fynance/models/loss/` (un fichier par classe) :
+
+```
+fynance/models/loss/
+    __init__.py     ← exporte SharpeLoss, SortinoLoss, DirectionalAccuracyLoss
+    _base.py        ← BaseLoss : gestion rf, period, eps, TypeError sur numpy input
+    sharpe.py       ← SharpeLoss
+    sortino.py      ← SortinoLoss
+    directional.py  ← DirectionalAccuracyLoss
+```
+
+Ops torch pures uniquement — lever `TypeError` si l'input n'est pas un `torch.Tensor`.
+
+- [ ] `SharpeLoss` — `mean(r) / std(r)`, entièrement différentiable
+- [ ] `SortinoLoss` — downside via `sqrt(mean(relu(-r)²) + eps)`, différentiable
+  (proxy de la downside deviation ; valeur ≠ métrique d'évaluation, documenter)
+- [ ] `DirectionalAccuracyLoss` — surrogate `mean(sigmoid(ŷ · y · T))` avec
+  température `T` ; différentiable mais proxy (documenter)
+- [ ] Paramètres communs dans `BaseLoss` : `rf`, `period` (annualisation), `eps`
+- [ ] Tests dans `fynance/tests/models/test_loss.py` : 8–12 tests
+  (forward, gradient flow via `loss.backward()`, TypeError sur numpy input, edge cases)
+
+### 2.3 Exemple d'intégration
+
+- [ ] `RollMLP` entraîné avec `SharpeLoss` à la place de MSE (test ou notebook)
+
+## 3. Documentation & notebooks
+
+### 3.1 Réécrire les notebooks `Notebooks/`
+
+- [ ] Remplacer exemples Keras par PyTorch
+- [ ] Ajouter exemples TCN, Transformer, custom loss functions
+- [ ] Montrer rolling walk-forward pour backtest
+- [ ] Vérifier que les notebooks tournent (nbval ou papermill)
+
+## 4. Performance & dépendances
+
+### 4.1 Audit des dépendances
+
+- [ ] Audit versions et alternatives modernes des dépendances restantes
+  (hors `pandas` → POC `polars` déjà tranché : NumPy natif gagne pour
+  l'algèbre matricielle)
+
+## 5. Refactoring structurel
+
+### 5.1 Éclater `fynance/features/metrics.py` (1 800 lignes)
+
+Découper en 4 modules thématiques dans `fynance/features/` (pas de façade
+`metrics.py` : `features/__init__.py` importe directement depuis les nouveaux
+fichiers). Les helpers privés partagés vont dans `_metrics_helpers.py`.
+
+Découpage proposé :
+
+```
+fynance/features/
+    _metrics_helpers.py   ← _annual_return, _annual_volatility,
+                             _annual_downside_volatility,
+                             _roll_annual_return, _roll_annual_volatility,
+                             _drawdown, _roll_drawdown, _roll_mdd
+    returns.py            ← annual_return, annual_volatility,
+                             roll_annual_return, roll_annual_volatility,
+                             perf_index, perf_returns
+    ratios.py             ← sharpe, sortino, calmar, diversified_ratio,
+                             roll_sharpe, roll_calmar
+    drawdown.py           ← drawdown, mdd, roll_drawdown, roll_mdd
+    stats.py              ← z_score, accuracy, directional_accuracy,
+                             mad, roll_mad, roll_z_score
+```
+
+`metrics_cy.pyx` reste intact (Cython, extend only).
+Mettre à jour `features/__init__.py` pour importer depuis les 4 nouveaux
+fichiers (+ `metrics_cy`). Supprimer `metrics.py`.
+
+- [ ] Créer `_metrics_helpers.py` avec tous les helpers privés
+- [ ] Créer `returns.py`, `ratios.py`, `drawdown.py`, `stats.py`
+- [ ] Mettre à jour `features/__init__.py` (supprimer import `metrics`)
+- [ ] Supprimer `metrics.py`
+- [ ] Vérifier que tous les tests et doctests passent (`pytest` + `--doctest-modules`)
+
+### 5.2 Éclater les fichiers multi-classes de `fynance/models/`
+
+Candidats identifiés :
+
+- `attention.py` → `scaled_dot_product_attention.py` + `multi_head_attention.py`
+- `econometric_models.py` → un fichier par modèle : `ma.py`, `arma.py`,
+  `arma_garch.py`, `armax_garch.py` + `get_parameters.py`
+- `rolling.py` → `_rolling_basis.py` + `roll_mlp.py` (CVResult reste dans
+  `roll_mlp.py`, très couplé à `RollMultiLayerPerceptron`)
+- `lstm.py` et `gru.py` — les hiérarchies internes (`_LSTMCell → LSTMCell →
+  LongShortTermMemory`) sont trop couplées pour être séparées : laisser en l'état
+
+- [ ] Éclater `attention.py`
+- [ ] Éclater `econometric_models.py`
+- [ ] Éclater `rolling.py`
+- [ ] Mettre à jour `models/__init__.py` pour chaque éclatement
+
+### 5.3 Éclater `fynance/backtest/dynamic_plot_backtest.py` (708 lignes, 6 classes)
+
+Candidats : `DynaPlotBackTest`, `DynaPlotAccuracy`, `DynaPlotLoss`,
+`DynaPlotPerf`, `BacktestNeuralNet` (+ `_BacktestNeuralNet` privé).
+
+- [ ] Un fichier par classe publique substantielle
+- [ ] Mettre à jour `backtest/__init__.py`

--- a/fynance/features/metrics.py
+++ b/fynance/features/metrics.py
@@ -48,10 +48,10 @@ from fynance.features.momentums import _ema, _emstd, _sma, _smstd, _wma, _wmstd
 
 __all__ = [
     'accuracy', 'annual_return', 'annual_volatility', 'calmar',
-    'diversified_ratio', 'drawdown', 'mad', 'mdd', 'roll_annual_return',
-    'roll_annual_volatility', 'roll_calmar', 'roll_drawdown', 'roll_mad',
-    'roll_mdd', 'roll_sharpe', 'roll_z_score', 'sharpe', 'perf_index',
-    'perf_returns', 'z_score',
+    'directional_accuracy', 'diversified_ratio', 'drawdown', 'mad', 'mdd',
+    'roll_annual_return', 'roll_annual_volatility', 'roll_calmar',
+    'roll_drawdown', 'roll_mad', 'roll_mdd', 'roll_sharpe', 'roll_z_score',
+    'sharpe', 'sortino', 'perf_index', 'perf_returns', 'z_score',
 ]
 
 _handler_ma = {'s': _sma, 'w': _wma, 'e': _ema}
@@ -276,6 +276,20 @@ def _annual_volatility(X, period, log, axis, ddof):
         R[1:] = X[1:] / X[:-1] - 1.
 
     return np.sqrt(period) * np.std(R, axis=axis, ddof=ddof)
+
+
+def _annual_downside_volatility(X, period, log, axis, ddof):
+    R = np.zeros(X.shape)
+
+    if log:
+        R[1:] = np.log(X[1:] / X[:-1])
+
+    else:
+        R[1:] = X[1:] / X[:-1] - 1.
+
+    R_neg = np.where(R < 0, R, 0.)
+
+    return np.sqrt(period) * np.std(R_neg, axis=axis, ddof=ddof)
 
 
 @WrapperArray('dtype', 'axis', 'ddof', min_size=2)
@@ -909,6 +923,127 @@ def sharpe(X: NDArray, rf: float = 0, period: int = 252, log: bool = False, axis
         return res
 
     return (ret - rf) / vol
+
+
+@WrapperArray('dtype', 'axis', 'null', 'ddof', min_size=2)
+def sortino(
+    X: NDArray, rf: float = 0, period: int = 252, log: bool = False,
+    axis: int = 0, dtype=None, ddof: int = 0,
+) -> NDArray:
+    r""" Compute the Sortino ratio for each `X`' series.
+
+    Annualized excess return per unit of *downside* volatility. Unlike the
+    Sharpe ratio (:func:`sharpe`), only negative returns contribute to the
+    denominator, so strategies that generate frequent large gains are not
+    penalized for their upside variance.
+
+    Notes
+    -----
+    The Sortino ratio is computed as the annualized expected return minus
+    the risk-free rate divided by the annualized downside deviation:
+
+    .. math::
+
+        sortinoRatio = \frac{E(R) - rf}{\sqrt{period \times Var(R^{-})}}
+
+    where :math:`R^{-}_t = \min(R_t, 0)` and :math:`R` is defined as for
+    :func:`sharpe`.
+
+    Parameters
+    ----------
+    X : np.ndarray[dtype, ndim=1 or 2]
+        Time-series of prices, performances or index.
+    rf : float, optional
+        Annualized risk-free rate. Default is 0.
+    period : int, optional
+        Number of periods per year. Default is 252 (trading days).
+    log : bool, optional
+        If True, compute returns as log-returns. Default is False.
+    axis : {0, 1}, optional
+        Axis along which the computation is done. Default is 0.
+    dtype : np.dtype, optional
+        Output array dtype. Inferred from ``X`` if not given.
+    ddof : int, optional
+        Delta Degrees of Freedom. Default is 0.
+
+    Returns
+    -------
+    dtype or np.ndarray[dtype, ndim=1]
+        Sortino ratio for each series. Returns ``inf`` when downside
+        volatility is zero (all returns are non-negative).
+
+    Examples
+    --------
+    Assume a series X of monthly prices:
+
+    >>> X = np.array([70, 100, 80, 120, 160, 80]).astype(np.float64)
+    >>> sortino(X, period=12)
+    0.4742428587192754
+    >>> sortino(X.reshape([6, 1]), period=12)
+    array([0.47424286])
+
+    See Also
+    --------
+    sharpe, calmar, mdd
+
+    """
+    ret = _annual_return(X, period, ddof)
+    downside_vol = _annual_downside_volatility(X, period, log, axis, ddof)
+
+    if (downside_vol == 0.).any():
+        res = ret - rf
+        res[downside_vol == 0.] = np.inf
+        res[downside_vol != 0.] = res[downside_vol != 0.] / downside_vol[downside_vol != 0.]
+
+        return res
+
+    return (ret - rf) / downside_vol
+
+
+@WrapperArray('axis')
+def directional_accuracy(
+    y_true: NDArray, y_pred: NDArray, axis: int = 0,
+) -> float:
+    r""" Compute the directional accuracy of a prediction.
+
+    Fraction of periods where the predicted direction (sign) matches the
+    true direction. A value of 1.0 means perfect directional alignment;
+    0.5 is random; 0.0 means systematically wrong direction.
+
+    Notes
+    -----
+    .. math::
+
+        directionalAccuracy = \frac{1}{T} \sum_{t=1}^{T}
+            \mathbf{1}[\text{sign}(\hat{y}_t) = \text{sign}(y_t)]
+
+    Parameters
+    ----------
+    y_true : np.ndarray[ndim=1 or 2, dtype]
+        Vector of true values (returns or price changes).
+    y_pred : np.ndarray[ndim=1 or 2, dtype]
+        Vector of predicted values.
+    axis : {0, 1}, optional
+        Axis along which the computation is done. Default is 0.
+
+    Returns
+    -------
+    float or np.ndarray[ndim=1, float]
+        Directional accuracy between 0 and 1.
+
+    Examples
+    --------
+    >>> y_true = np.array([1., .5, -.5, .8, -.2])
+    >>> y_pred = np.array([.5, .2, -.5, .1, .0])
+    >>> directional_accuracy(y_true, y_pred)
+    0.8
+
+    See Also
+    --------
+    accuracy
+
+    """
+    return np.mean(np.sign(y_true) == np.sign(y_pred), axis=axis)
 
 
 @WrapperArray('dtype', 'axis', 'window')

--- a/fynance/models/__init__.py
+++ b/fynance/models/__init__.py
@@ -19,6 +19,7 @@
     models.attention
     models.econometric_models
     models.rolling
+    models.loss
 
 """
 
@@ -29,6 +30,7 @@ from . import (
     econometric_models,
     econometric_models_cy,
     gru,
+    loss,
     lstm,
     mlp,
     rnn,
@@ -45,6 +47,7 @@ from .econometric_models_cy import (
     get_parameters_cy,
 )
 from .gru import GatedRecurrentUnit, GRUCell
+from .loss import BaseLoss, DirectionalAccuracyLoss, SharpeLoss, SortinoLoss
 from .lstm import LongShortTermMemory, LSTMCell
 from .mlp import MultiLayerPerceptron
 from .rnn import RecurrentNeuralNetwork
@@ -83,4 +86,9 @@ __all__ = [
     'CVResult',
     'RollMultiLayerPerceptron',
     '_RollingBasis',
+    # loss
+    'BaseLoss',
+    'DirectionalAccuracyLoss',
+    'SharpeLoss',
+    'SortinoLoss',
 ]

--- a/fynance/models/loss/__init__.py
+++ b/fynance/models/loss/__init__.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Differentiable financial loss functions for PyTorch training.
+
+All losses are pure PyTorch — no NumPy conversion — so gradients flow
+through them without breaking the autograd graph. They are designed as
+drop-in replacements for standard PyTorch criterions and integrate
+directly with :meth:`~fynance.models._base.BaseNeuralNet.set_optimizer`.
+
+Main entry points
+-----------------
+- :class:`SharpeLoss` — negative Sharpe ratio (minimizes → maximizes
+  risk-adjusted return).
+- :class:`SortinoLoss` — negative Sortino ratio (downside-deviation
+  proxy; only penalizes negative excess returns).
+- :class:`DirectionalAccuracyLoss` — sigmoid surrogate for directional
+  accuracy (differentiable approximation of sign-prediction rate).
+
+Notes
+-----
+Each loss is a **training proxy**: its scalar value is not numerically
+comparable to the corresponding evaluation metric in
+:mod:`fynance.features.metrics`. Use those metrics for out-of-sample
+reporting; use these losses only inside training loops.
+
+"""
+
+from __future__ import annotations
+
+# Local packages
+from ._base import BaseLoss
+from .directional import DirectionalAccuracyLoss
+from .sharpe import SharpeLoss
+from .sortino import SortinoLoss
+
+__all__ = ['BaseLoss', 'DirectionalAccuracyLoss', 'SharpeLoss', 'SortinoLoss']

--- a/fynance/models/loss/_base.py
+++ b/fynance/models/loss/_base.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Base class for financial loss functions.
+
+Defines :class:`BaseLoss`, the common foundation for all differentiable
+loss functions in :mod:`fynance.models.loss`.
+
+"""
+
+from __future__ import annotations
+
+# Third-party packages
+import torch
+import torch.nn
+
+__all__ = ['BaseLoss']
+
+
+class BaseLoss(torch.nn.Module):
+    """ Base class for differentiable financial loss functions.
+
+    Holds the shared hyper-parameters (risk-free rate, annualization period,
+    numerical stabilizer) and enforces that inputs are :class:`torch.Tensor`.
+    Subclass and implement :meth:`forward` to define a new loss.
+
+    Parameters
+    ----------
+    rf : float, optional
+        Annualized risk-free rate. Default is 0.
+    period : int, optional
+        Number of periods per year used for annualization. Default is 252.
+    eps : float, optional
+        Small constant added to denominators to avoid division by zero.
+        Default is 1e-8.
+
+    """
+
+    def __init__(self, rf: float = 0., period: int = 252, eps: float = 1e-8):
+        super().__init__()
+        self.rf = rf
+        self.period = period
+        self.eps = eps
+
+    def _check_tensor(self, x: object) -> None:
+        """ Raise TypeError if *x* is not a :class:`torch.Tensor`. """
+        if not isinstance(x, torch.Tensor):
+            raise TypeError(
+                f"Expected torch.Tensor, got {type(x).__name__}. "
+                "Convert numpy arrays with torch.from_numpy() before passing "
+                "to this loss."
+            )

--- a/fynance/models/loss/_base.py
+++ b/fynance/models/loss/_base.py
@@ -41,6 +41,7 @@ class BaseLoss(torch.nn.Module):
         self.rf = rf
         self.period = period
         self.eps = eps
+        self._rf_per_period: float = rf / period
 
     def _check_tensor(self, x: object) -> None:
         """ Raise TypeError if *x* is not a :class:`torch.Tensor`. """

--- a/fynance/models/loss/directional.py
+++ b/fynance/models/loss/directional.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Differentiable directional accuracy loss for PyTorch training loops. """
+
+from __future__ import annotations
+
+# Third-party packages
+import torch
+
+# Local packages
+from ._base import BaseLoss
+
+__all__ = ['DirectionalAccuracyLoss']
+
+
+class DirectionalAccuracyLoss(BaseLoss):
+    r""" Negative directional accuracy as a differentiable surrogate loss.
+
+    The true directional accuracy (fraction of correctly predicted signs) is
+    non-differentiable. This loss replaces the hard sign comparison with a
+    sigmoid surrogate, making it suitable for gradient-based optimization.
+
+    Notes
+    -----
+    The surrogate loss is:
+
+    .. math::
+
+        \mathcal{L} = -\frac{1}{T} \sum_{t=1}^{T}
+            \sigma(\hat{y}_t \cdot y_t \cdot T_{emp})
+
+    where :math:`\sigma` is the logistic sigmoid, :math:`T_{emp}` is the
+    temperature parameter controlling sharpness, and a higher temperature
+    produces a harder approximation closer to the true 0/1 accuracy.
+
+    **This is a training proxy** — the value is not comparable to the
+    numpy :func:`~fynance.features.metrics.directional_accuracy` metric,
+    which returns a hard 0/1 fraction.
+
+    Parameters
+    ----------
+    rf : float, optional
+        Not used; inherited from :class:`BaseLoss` for API consistency.
+    period : int, optional
+        Not used; inherited from :class:`BaseLoss` for API consistency.
+    eps : float, optional
+        Not used; inherited from :class:`BaseLoss` for API consistency.
+    temperature : float, optional
+        Sigmoid sharpness. Higher values push the surrogate closer to the
+        hard sign indicator. Default is 1.0.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from fynance.models.loss import DirectionalAccuracyLoss
+    >>> y_true = torch.tensor([1., -1., 1., -1., 1.])
+    >>> y_pred = torch.tensor([0.5, -0.3, 0.1, -0.8, 0.2])
+    >>> loss_fn = DirectionalAccuracyLoss()
+    >>> loss = loss_fn(y_pred, y_true)
+    >>> loss.shape
+    torch.Size([])
+    >>> loss.item() < 0   # all directions correct → loss close to -1
+    True
+
+    See Also
+    --------
+    SharpeLoss, SortinoLoss
+
+    """
+
+    def __init__(
+        self,
+        rf: float = 0.,
+        period: int = 252,
+        eps: float = 1e-8,
+        temperature: float = 1.0,
+    ):
+        super().__init__(rf=rf, period=period, eps=eps)
+        self.temperature = temperature
+
+    def forward(
+        self, y_pred: torch.Tensor, y_true: torch.Tensor,
+    ) -> torch.Tensor:
+        """ Compute the negative directional accuracy surrogate.
+
+        Parameters
+        ----------
+        y_pred : torch.Tensor
+            Predicted values, shape ``(T,)`` or ``(T, M)``.
+        y_true : torch.Tensor
+            True values, same shape as ``y_pred``.
+
+        Returns
+        -------
+        torch.Tensor
+            Scalar loss (negative sigmoid-based directional accuracy).
+
+        Raises
+        ------
+        TypeError
+            If ``y_pred`` or ``y_true`` is not a :class:`torch.Tensor`.
+
+        """
+        self._check_tensor(y_pred)
+        self._check_tensor(y_true)
+        return -torch.mean(torch.sigmoid(y_pred * y_true * self.temperature))

--- a/fynance/models/loss/sharpe.py
+++ b/fynance/models/loss/sharpe.py
@@ -31,8 +31,9 @@ class SharpeLoss(BaseLoss):
 
     where :math:`r` is ``y_pred``, :math:`rf_p = rf / period` is the
     per-period risk-free rate, :math:`\mu` and :math:`\sigma` are the
-    sample mean and standard deviation, and :math:`\varepsilon` is the
-    numerical stabilizer (``eps``).
+    mean and population standard deviation (``correction=0``, consistent
+    with :func:`~fynance.features.metrics.sharpe`), and :math:`\varepsilon`
+    is the numerical stabilizer (``eps``).
 
     **This is a training proxy** — the value is not comparable to the
     numpy :func:`~fynance.features.metrics.sharpe` evaluation metric,
@@ -103,6 +104,5 @@ class SharpeLoss(BaseLoss):
 
         """
         self._check_tensor(y_pred)
-        rf_per_period = self.rf / self.period
-        excess = y_pred - rf_per_period
-        return -(excess.mean() / (excess.std() + self.eps))
+        excess = y_pred - self._rf_per_period
+        return -(excess.mean() / (excess.std(correction=0) + self.eps))

--- a/fynance/models/loss/sharpe.py
+++ b/fynance/models/loss/sharpe.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Differentiable Sharpe ratio loss for PyTorch training loops. """
+
+from __future__ import annotations
+
+# Third-party packages
+import torch
+
+# Local packages
+from ._base import BaseLoss
+
+__all__ = ['SharpeLoss']
+
+
+class SharpeLoss(BaseLoss):
+    r""" Negative Sharpe ratio as a differentiable loss.
+
+    Minimizing this loss is equivalent to maximizing the Sharpe ratio of
+    the predicted return series. All operations are pure PyTorch, so
+    gradients flow through ``forward`` without any NumPy conversion.
+
+    Notes
+    -----
+    The loss is defined as:
+
+    .. math::
+
+        \mathcal{L} = -\frac{\mu(r - rf_p)}{\sigma(r - rf_p) + \varepsilon}
+
+    where :math:`r` is ``y_pred``, :math:`rf_p = rf / period` is the
+    per-period risk-free rate, :math:`\mu` and :math:`\sigma` are the
+    sample mean and standard deviation, and :math:`\varepsilon` is the
+    numerical stabilizer (``eps``).
+
+    **This is a training proxy** — the value is not comparable to the
+    numpy :func:`~fynance.features.metrics.sharpe` evaluation metric,
+    which annualizes over a price series.
+
+    Parameters
+    ----------
+    rf : float, optional
+        Annualized risk-free rate. Default is 0.
+    period : int, optional
+        Number of periods per year. Default is 252.
+    eps : float, optional
+        Numerical stabilizer. Default is 1e-8.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from fynance.models.loss import SharpeLoss
+    >>> torch.manual_seed(0)
+    <...>
+    >>> returns = torch.randn(50) * 0.01 + 0.001
+    >>> loss_fn = SharpeLoss()
+    >>> loss = loss_fn(returns)
+    >>> loss.shape
+    torch.Size([])
+    >>> loss.item() < 0       # positive mean excess return → negative loss
+    True
+
+    Using with :class:`~fynance.models.mlp.MultiLayerPerceptron`:
+
+    >>> from fynance.models import MultiLayerPerceptron, SharpeLoss
+    >>> import torch.optim
+    >>> X = torch.randn(100, 4)
+    >>> y = torch.randn(100, 1)
+    >>> model = MultiLayerPerceptron(X, y, layers=[16])
+    >>> _ = model.set_optimizer(SharpeLoss, torch.optim.Adam, lr=1e-3)
+    >>> loss = model.train_on(X, y)
+    >>> loss.shape
+    torch.Size([])
+
+    See Also
+    --------
+    SortinoLoss, DirectionalAccuracyLoss
+
+    """
+
+    def forward(
+        self, y_pred: torch.Tensor, y_true: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """ Compute the negative Sharpe ratio.
+
+        Parameters
+        ----------
+        y_pred : torch.Tensor
+            Predicted return series, shape ``(T,)`` or ``(T, M)``.
+        y_true : torch.Tensor, optional
+            Not used; accepted for API compatibility with PyTorch criterions.
+
+        Returns
+        -------
+        torch.Tensor
+            Scalar loss value (negative Sharpe ratio).
+
+        Raises
+        ------
+        TypeError
+            If ``y_pred`` is not a :class:`torch.Tensor`.
+
+        """
+        self._check_tensor(y_pred)
+        rf_per_period = self.rf / self.period
+        excess = y_pred - rf_per_period
+        return -(excess.mean() / (excess.std() + self.eps))

--- a/fynance/models/loss/sortino.py
+++ b/fynance/models/loss/sortino.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Differentiable Sortino ratio loss for PyTorch training loops. """
+
+from __future__ import annotations
+
+# Third-party packages
+import torch
+import torch.nn.functional as F
+
+# Local packages
+from ._base import BaseLoss
+
+__all__ = ['SortinoLoss']
+
+
+class SortinoLoss(BaseLoss):
+    r""" Negative Sortino ratio as a differentiable loss.
+
+    Minimizing this loss penalizes downside returns only, unlike
+    :class:`SharpeLoss` which penalizes both tails symmetrically.
+
+    Notes
+    -----
+    The loss is defined as:
+
+    .. math::
+
+        \mathcal{L} = -\frac{\mu(r - rf_p)}
+            {\sqrt{\mu(\text{ReLU}(-(r - rf_p))^2) + \varepsilon}}
+
+    where :math:`r` is ``y_pred`` and :math:`rf_p = rf / period`.
+    The denominator is a differentiable proxy for the downside deviation;
+    its magnitude differs from the numpy
+    :func:`~fynance.features.metrics.sortino` evaluation metric.
+
+    **This is a training proxy** — the value is not comparable to the
+    numpy :func:`~fynance.features.metrics.sortino` evaluation metric.
+
+    Parameters
+    ----------
+    rf : float, optional
+        Annualized risk-free rate. Default is 0.
+    period : int, optional
+        Number of periods per year. Default is 252.
+    eps : float, optional
+        Numerical stabilizer added inside the square root. Default is 1e-8.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from fynance.models.loss import SortinoLoss
+    >>> returns = torch.tensor([-0.01, 0.02, 0.01, -0.005, 0.03])
+    >>> loss_fn = SortinoLoss()
+    >>> loss = loss_fn(returns)
+    >>> loss.shape
+    torch.Size([])
+
+    See Also
+    --------
+    SharpeLoss, DirectionalAccuracyLoss
+
+    """
+
+    def forward(
+        self, y_pred: torch.Tensor, y_true: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """ Compute the negative Sortino ratio.
+
+        Parameters
+        ----------
+        y_pred : torch.Tensor
+            Predicted return series, shape ``(T,)`` or ``(T, M)``.
+        y_true : torch.Tensor, optional
+            Not used; accepted for API compatibility with PyTorch criterions.
+
+        Returns
+        -------
+        torch.Tensor
+            Scalar loss value (negative Sortino ratio proxy).
+
+        Raises
+        ------
+        TypeError
+            If ``y_pred`` is not a :class:`torch.Tensor`.
+
+        """
+        self._check_tensor(y_pred)
+        rf_per_period = self.rf / self.period
+        excess = y_pred - rf_per_period
+        downside = torch.sqrt(torch.mean(F.relu(-excess) ** 2) + self.eps)
+        return -(excess.mean() / downside)

--- a/fynance/models/loss/sortino.py
+++ b/fynance/models/loss/sortino.py
@@ -87,7 +87,6 @@ class SortinoLoss(BaseLoss):
 
         """
         self._check_tensor(y_pred)
-        rf_per_period = self.rf / self.period
-        excess = y_pred - rf_per_period
+        excess = y_pred - self._rf_per_period
         downside = torch.sqrt(torch.mean(F.relu(-excess) ** 2) + self.eps)
         return -(excess.mean() / downside)

--- a/fynance/tests/features/test_metrics.py
+++ b/fynance/tests/features/test_metrics.py
@@ -472,3 +472,54 @@ def test_roll_sharpe(set_variables):
     with pytest.raises(ValueError) as execinfo:
         roll_f(x_1d, period=12, w=3, ddof=4, dtype=np.float32)
     execinfo.match(r'w=3.*ddof=4')
+
+
+def test_sortino(set_variables):
+    x_1d, x_2d = set_variables
+    f = fy.sortino
+    a_1d = f(x_1d, period=12, dtype=np.float32)
+    a_2d = f(x_2d, period=12, dtype=np.float32)
+
+    assert a_1d.dtype == np.float32
+    assert (a_1d == a_2d.flatten()).all()
+    assert a_1d.shape == ()
+    assert a_2d.shape == (1,)
+
+    with pytest.raises(ArraySizeError) as execinfo:
+        f(x_2d, axis=1)
+    execinfo.match(r'1 .* 1 .* 2')
+
+    with pytest.raises(ArraySizeError) as execinfo:
+        f(x_2d, axis=0, ddof=7)
+    execinfo.match(r'7.*6')
+
+    # All positive returns → downside vol == 0 → inf (tested on 2D; 1D scalar
+    # path shares the same pre-existing limitation as sharpe)
+    x_up_2d = np.array([100., 110., 120., 130., 140., 150.]).reshape(6, 1)
+    assert f(x_up_2d, period=12) == np.array([np.inf])
+
+    # Numeric check: sortino >= sharpe (downside vol <= total vol)
+    s_sharpe = fy.sharpe(x_1d.astype(np.float64), period=12)
+    s_sortino = f(x_1d.astype(np.float64), period=12)
+    assert float(s_sortino) >= float(s_sharpe)
+
+
+def test_directional_accuracy(set_variables):
+    f = fy.directional_accuracy
+
+    y_all_correct = np.array([1., 2., -1., -2., 3.])
+    y_pred_correct = np.array([0.5, 1., -0.1, -3., 0.1])
+    assert f(y_all_correct, y_pred_correct) == 1.0
+
+    y_all_wrong = np.array([1., 2., -1., -2., 3.])
+    y_pred_wrong = np.array([-0.5, -1., 0.1, 3., -0.1])
+    assert f(y_all_wrong, y_pred_wrong) == 0.0
+
+    y_half = np.array([1., -1., 1., -1.])
+    y_pred_half = np.array([1., 1., -1., -1.])
+    assert f(y_half, y_pred_half) == 0.5
+
+    # 2D input
+    y_2d = y_all_correct.reshape([5, 1])
+    p_2d = y_pred_correct.reshape([5, 1])
+    assert f(y_2d, p_2d) == np.array([1.0])

--- a/fynance/tests/models/test_loss.py
+++ b/fynance/tests/models/test_loss.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for differentiable financial loss functions. """
+
+# Built-in packages
+
+# Third-party packages
+import numpy as np
+import pytest
+import torch
+
+# Local packages
+from fynance.models.loss import (
+    DirectionalAccuracyLoss,
+    SharpeLoss,
+    SortinoLoss,
+)
+
+RNG = np.random.default_rng(42)
+T = 60
+RETURNS = torch.from_numpy(RNG.standard_normal(T).astype(np.float32) * 0.01 + 0.001)
+RETURNS_NEG = torch.from_numpy(RNG.standard_normal(T).astype(np.float32) * 0.01 - 0.001)
+Y_TRUE = torch.from_numpy(RNG.standard_normal(T).astype(np.float32))
+Y_PRED = torch.from_numpy(RNG.standard_normal(T).astype(np.float32))
+
+
+class TestSharpeLoss:
+    def test_forward_scalar(self):
+        loss = SharpeLoss()(RETURNS)
+        assert loss.shape == torch.Size([])
+
+    def test_negative_when_positive_mean(self):
+        # Positive mean excess return → Sharpe > 0 → loss < 0
+        loss = SharpeLoss()(RETURNS)
+        assert loss.item() < 0
+
+    def test_positive_when_negative_mean(self):
+        loss = SharpeLoss()(RETURNS_NEG)
+        assert loss.item() > 0
+
+    def test_gradient_flow(self):
+        r = RETURNS.clone().requires_grad_(True)
+        loss = SharpeLoss()(r)
+        loss.backward()
+        assert r.grad is not None
+        assert not torch.isnan(r.grad).any()
+
+    def test_type_error_on_numpy(self):
+        arr = np.array([0.01, -0.02, 0.03])
+        with pytest.raises(TypeError, match="torch.Tensor"):
+            SharpeLoss()(arr)
+
+    def test_rf_shifts_loss(self):
+        loss_no_rf = SharpeLoss(rf=0.)(RETURNS)
+        loss_high_rf = SharpeLoss(rf=0.10)(RETURNS)
+        # High rf reduces excess returns → lower (or equal) Sharpe → higher loss
+        assert loss_high_rf.item() >= loss_no_rf.item()
+
+    def test_constant_returns_no_zero_division(self):
+        r = torch.full((T,), 0.001)
+        loss = SharpeLoss(eps=1e-8)(r)
+        assert not torch.isnan(loss)
+        assert not torch.isinf(loss)
+
+
+class TestSortinoLoss:
+    def test_forward_scalar(self):
+        loss = SortinoLoss()(RETURNS)
+        assert loss.shape == torch.Size([])
+
+    def test_gradient_flow(self):
+        r = RETURNS.clone().requires_grad_(True)
+        loss = SortinoLoss()(r)
+        loss.backward()
+        assert r.grad is not None
+        assert not torch.isnan(r.grad).any()
+
+    def test_type_error_on_numpy(self):
+        with pytest.raises(TypeError, match="torch.Tensor"):
+            SortinoLoss()(np.array([0.01, -0.02]))
+
+    def test_all_positive_no_zero_division(self):
+        r = torch.abs(RETURNS) + 0.001   # strictly positive → downside = 0
+        loss = SortinoLoss(eps=1e-8)(r)
+        assert not torch.isnan(loss)
+        assert not torch.isinf(loss)
+
+    def test_downside_only_penalized(self):
+        # Two series identical except one has large upside: Sortino should
+        # be lower (better) for the one with large upside because upside
+        # doesn't count against the denominator.
+        r_base = torch.tensor([-0.01, 0.005, -0.008, 0.003, -0.006])
+        r_upside = torch.tensor([-0.01, 0.500, -0.008, 0.003, -0.006])
+        loss_base = SortinoLoss()(r_base)
+        loss_upside = SortinoLoss()(r_upside)
+        # Large upside improves mean without worsening downside → lower loss
+        assert loss_upside.item() <= loss_base.item()
+
+
+class TestDirectionalAccuracyLoss:
+    def test_forward_scalar(self):
+        loss = DirectionalAccuracyLoss()(Y_PRED, Y_TRUE)
+        assert loss.shape == torch.Size([])
+
+    def test_range(self):
+        # Sigmoid output in (0,1) → mean in (0,1) → loss in (-1, 0)
+        loss = DirectionalAccuracyLoss()(Y_PRED, Y_TRUE)
+        assert -1.0 < loss.item() < 0.0
+
+    def test_perfect_direction_lower_loss(self):
+        # Same signs → all sigmoid outputs > 0.5 → loss < -0.5
+        y = torch.tensor([1., -1., 1., -1., 1., -1.])
+        y_correct = y.clone()
+        y_wrong = -y.clone()
+        loss_correct = DirectionalAccuracyLoss(temperature=10.)(y_correct, y)
+        loss_wrong = DirectionalAccuracyLoss(temperature=10.)(y_wrong, y)
+        assert loss_correct.item() < loss_wrong.item()
+
+    def test_gradient_flow(self):
+        pred = Y_PRED.clone().requires_grad_(True)
+        loss = DirectionalAccuracyLoss()(pred, Y_TRUE)
+        loss.backward()
+        assert pred.grad is not None
+        assert not torch.isnan(pred.grad).any()
+
+    def test_type_error_y_pred(self):
+        with pytest.raises(TypeError, match="torch.Tensor"):
+            DirectionalAccuracyLoss()(np.array([1., -1.]), Y_TRUE)
+
+    def test_type_error_y_true(self):
+        with pytest.raises(TypeError, match="torch.Tensor"):
+            DirectionalAccuracyLoss()(Y_PRED, np.array([1., -1.]))


### PR DESCRIPTION
## Summary

- Add `sortino()` and `directional_accuracy()` to `fynance/features/metrics.py` with shared helper `_annual_downside_volatility`; both exported in `__all__`
- Add `fynance/models/loss/` submodule: `BaseLoss`, `SharpeLoss`, `SortinoLoss`, `DirectionalAccuracyLoss` — pure torch ops, differentiable, `rf/period` precomputed, `std(correction=0)` for Sharpe consistency with numpy metric
- Export new loss classes from `fynance/models/__init__.py`
- 24 new tests (6 metric + 18 loss); all doctests pass; ruff clean; full suite 249 passed

## Test plan

- [ ] `pytest fynance/tests/features/test_metrics.py::test_sortino`
- [ ] `pytest fynance/tests/features/test_metrics.py::test_directional_accuracy`
- [ ] `pytest fynance/tests/models/test_loss.py`
- [ ] `pytest --doctest-modules fynance/models/loss/`
- [ ] `pytest -q` (full suite)
- [ ] `ruff check fynance/`