### PR TITLE
chore: create GitHub Release automatically on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,3 +71,28 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: Create GitHub Release
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract release notes from CHANGELOG
+        id: notes
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          NOTES=$(awk "/^## \[${VERSION}\]/{found=1; next} found && /^## \[/{exit} found{print}" CHANGELOG.md)
+          echo "notes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$NOTES" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body: ${{ steps.notes.outputs.notes }}
+          make_latest: true


### PR DESCRIPTION
## Summary

- Adds a `github-release` job à `release.yml`, déclenché après `publish` (PyPI)
- Extrait les notes de la version depuis `CHANGELOG.md` (section `[X.Y.Z]`)
- Crée la GitHub Release avec ces notes et la marque comme latest

## Test plan

- [ ] Merger cette PR dans `develop`
- [ ] Vérifier que le workflow passe en dry-run (CI sur PR)
- [ ] Lors de la prochaine release, vérifier que la GitHub Release est créée automatiquement avec les bonnes notes