### PR TITLE
chore: release v1.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Harmonise Sphinx doc with DCCD: sticky header with logo, hero on homepage, badge
-  row, `installation.rst`, `changelog.rst`, `sidebar/related-projects`, favicons,
-  light/dark logos, `sphinx.ext.viewcode`, toctrees with captions (#52)
-- `quickstart.rst` — new Getting Started page covering metrics, indicators,
-  portfolio allocation, rolling neural network, and custom loss functions (#53)
-
 ### Changed
 
 ### Fixed
@@ -21,6 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 ### Removed
+
+## [1.3.4] - 2026-05-31
+
+### Added
+
+- Harmonise Sphinx doc with DCCD: sticky header with logo, hero on homepage, badge
+  row, `installation.rst`, `changelog.rst`, `sidebar/related-projects`, favicons,
+  light/dark logos, `sphinx.ext.viewcode`, toctrees with captions (#52)
+- `quickstart.rst` — new Getting Started page covering metrics, indicators,
+  portfolio allocation, rolling neural network, and custom loss functions (#53)
 
 ## [1.3.3] - 2026-05-11
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fynance"
-version = "1.3.3"
+version = "1.3.4"
 description = "Python and Cython scripts of machine learning, econometrics and statistical features for financial analysis"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary

Bump version `1.3.3` → `1.3.4` and freeze `[Unreleased]` into `[1.3.4] - 2026-05-31`.

## Changes in v1.3.4

### Added

- Harmonise Sphinx doc with DCCD: sticky header with logo, hero on homepage, badge row, `installation.rst`, `changelog.rst`, `sidebar/related-projects`, favicons, light/dark logos, `sphinx.ext.viewcode`, toctrees with captions (#52)
- `quickstart.rst` — new Getting Started page covering metrics, indicators, portfolio allocation, rolling neural network, and custom loss functions (#53)

## Test plan

- [x] `pytest` passes
- [x] `ruff check fynance/` passes
- [ ] CI green