### PR TITLE
docs: fix header nav — lowercase fynance, User Guide link

### DIFF
--- a/doc/source/_templates/page.html
+++ b/doc/source/_templates/page.html
@@ -9,11 +9,11 @@
     <a class="page-logo-header__brand" href="{{ pathto(master_doc) }}">
       <img class="only-light" src="{{ pathto('_static/logo-light-transparent.svg', 1) }}" alt="Fynance logo">
       <img class="only-dark"  src="{{ pathto('_static/logo-dark-transparent.svg',  1) }}" alt="Fynance logo">
-      <span class="page-logo-header__name">Fynance</span>
+      <span class="page-logo-header__name">fynance</span>
     </a>
     <nav class="page-logo-header__nav">
-      <a class="page-logo-header__nav-link page-logo-header__nav-link--text" href="{{ pathto('index') }}">
-        API Reference
+      <a class="page-logo-header__nav-link page-logo-header__nav-link--text" href="{{ pathto('quickstart') }}">
+        User Guide
       </a>
       <a class="page-logo-header__nav-link page-logo-header__nav-link--text" href="https://download-crypto-currencies-data.readthedocs.io/en/latest/" target="_blank" rel="noopener noreferrer">
         DCCD


### PR DESCRIPTION
## Summary

- `Fynance` → `fynance` in the sticky header brand name
- "API Reference" button → "User Guide" linking to `quickstart`

## Test plan

- [x] `make html` zero warnings
- [ ] CI green