### PR TITLE
chore: create GitHub Release on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,3 +71,28 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: Create GitHub Release
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract release notes from CHANGELOG
+        id: notes
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          NOTES=$(awk "/^## \[${VERSION}\]/{found=1; next} found && /^## \[/{exit} found{print}" CHANGELOG.md)
+          echo "notes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$NOTES" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body: ${{ steps.notes.outputs.notes }}
+          make_latest: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Release workflow now creates a **GitHub Release** on a `v*` tag (a
+  `github-release` job that extracts the matching `CHANGELOG.md` section and
+  publishes it via `softprops/action-gh-release`, `make_latest`), alongside the
+  existing PyPI publish.
+
 ### Changed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Release workflow now creates a **GitHub Release** on a `v*` tag (a
   `github-release` job that extracts the matching `CHANGELOG.md` section and
   publishes it via `softprops/action-gh-release`, `make_latest`), alongside the
-  existing PyPI publish.
+  existing PyPI publish. (#57)
 
 ### Changed
 


### PR DESCRIPTION
Adds the final missing step of the release pipeline (parity with dccd): a
`github-release` job in `.github/workflows/release.yml` that, after the PyPI
publish, extracts the matching `## [X.Y.Z]` section from `CHANGELOG.md` and
publishes it as a GitHub Release (`softprops/action-gh-release`, `make_latest`).

The build (`cibuildwheel` wheels + sdist) and `publish` jobs are unchanged.

> Scope note: the rest of the "dev-loop" parity (the `doc/dev/` brief — overview,
> architecture, ADR journal, status; the `.claude/workflow.json` wiring for
> `decisions`/`status`/`plans_dir`; the CLAUDE.md loop section) was set up **locally
> only**, because this repo deliberately gitignores the whole Claude layer
> (`.claude/`, `CLAUDE.md`, `dev/`). So this PR is intentionally just the public CI
> piece. See the discussion on the branch for how to make the dev docs public if
> desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)