### PR TITLE
chore: add interrogate + Sphinx docs gates to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,36 @@ jobs:
           python-version: "3.12"
           cache: pip
 
-      - name: Install ruff
-        run: pip install ruff>=0.4
+      - name: Install ruff + interrogate
+        run: pip install "ruff>=0.4" "interrogate>=1.5"
 
       - name: Run ruff
         run: ruff check fynance/
+
+      - name: Check docstring coverage (interrogate, fail-under 80)
+        run: interrogate fynance/
+
+
+  docs:
+    name: Docs (Sphinx, warnings as errors)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -e ".[doc]"
+
+      - name: Build Cython extensions
+        run: python setup.py build_ext --inplace
+
+      - name: Build HTML docs
+        run: sphinx-build -W --keep-going -b html doc/source doc/build/html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- CI now enforces two extra gates on every PR: docstring coverage (`interrogate`, fail-under 80%) in the lint job, and a Sphinx HTML build with warnings-as-errors (`sphinx-build -W`) in a new `docs` job
+
 ### Fixed
 
 ### Deprecated


### PR DESCRIPTION
From the repo audit (findings #4, #11).

The audit found that `mypy`, `interrogate` and the docs build were configured but **not enforced** in CI — only `ruff` ran. This PR adds two of those gates (the `mypy` gate is deferred until its 104 errors are resolved):

## Added gates
- **`interrogate`** (docstring coverage) added to the `lint` job — `fail-under 80%`, currently **88.6%**. Docstring coverage can no longer silently regress.
- **`docs`** job — builds the Sphinx site with `sphinx-build -W --keep-going` (warnings as errors). A broken docstring example or cross-reference now fails CI instead of only surfacing on Read the Docs.

## Verification (local)
- `interrogate fynance/` → PASSED (88.6% ≥ 80%)
- `sphinx-build -W -b html doc/source doc/build/html` → build succeeded, **0 warnings**