### PR TITLE
chore: track doc/dev + CLAUDE.md publicly (mirror dccd)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ build/
 fynance.egg-info/
 dist/
 old_scripts/
-dev/
 
 # Cache to ignore
 __pycache__/
@@ -28,11 +27,15 @@ __pycache__/
 .coverage
 htmlcov/
 
-# Claude Code (local only, not pushed)
+# Claude Code harness settings stay local; CLAUDE.md is tracked (mirrors dccd)
 .claude/
-CLAUDE.md
 
 # Task tracking (local only)
 todo/
 done/
 TODO.md
+
+# Developer docs: descriptive pack + roadmap are tracked (mirrors dccd);
+# only the plan trees and archived snapshots stay local
+doc/dev/plans/*/
+doc/dev/_archive/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,145 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+> **Claude-oriented developer brief**: [`doc/dev/`](doc/dev/) is an orientation
+> pack written for Claude Code — overview, architecture, design decisions &
+> rationale, the per-subpackage matrix, testing methodology, and current status.
+> Start at [`doc/dev/README.md`](doc/dev/README.md). `CLAUDE.md` stays
+> authoritative for commands and invariants.
+
+## Commands
+
+```bash
+# Dev setup from scratch
+pip install -e ".[dev]" && python setup.py build_ext --inplace
+
+# Activate git hooks (run once per clone)
+git config core.hooksPath .githooks
+
+# Build Cython extensions (required after editing any .pyx file)
+python setup.py build_ext --inplace
+
+# Run full test suite (--doctest-modules --exitfirst -vv configured in pyproject.toml)
+pytest
+
+# Run a single test function
+pytest fynance/tests/features/test_metrics.py::test_accuracy -v
+
+# Run only doctests for a subpackage
+pytest --doctest-modules fynance/features/
+
+# Run with coverage
+pytest --cov=fynance --cov-report=term-missing
+
+# Lint
+ruff check fynance/
+
+# Build Sphinx docs
+cd doc && make html
+```
+
+## Git Flow
+
+**Branch model:**
+```
+master          ← stable releases only (tagged vX.Y.Z)
+  └── develop   ← integration branch
+        ├── feat/<topic>   new feature or modernization axis
+        ├── fix/<topic>    bug fix
+        ├── chore/<topic>  tooling, CI, deps
+        └── docs/<topic>   documentation only
+```
+
+**Rules — always follow these before committing or pushing:**
+1. **Never commit directly to `master`.**
+2. **Never commit directly to `develop`** — always use a feature branch + PR, even for small changes.
+3. Branch off `develop` (not `master`): `git checkout develop && git checkout -b feat/my-topic`
+4. Open a PR into `develop` when done.
+5. `develop` → `master` only at release time.
+
+**Commit style (Conventional Commits):**
+```
+feat: add TCN model
+fix: replace ** in momentums_cy.pyx for Cython 3 compat
+chore: migrate to pyproject.toml
+docs: update CONTRIBUTING
+```
+
+Do not add `Co-Authored-By` trailers to commits — this is a personal repo.
+
+**Before every commit:** run `pytest` and `ruff check fynance/`. Both must pass.
+
+**One PR = one concern, small and disposable.** Even a large plan ships as
+*several* small atomic PRs — never one fourre-tout branch.
+
+### Dev loop & docs of record
+
+The iterative loop is tooled by user-level skills, with four tracked docs as the
+sources of truth:
+
+| Doc | Holds | Updated by |
+|-----|-------|-----------|
+| `doc/dev/07-roadmap.md` | open work — single source *index* (**tracked**, mirrors dccd) | `/pick-task` reads · `/finish-task`, `/abandon-task` update |
+| `doc/dev/plans/<epic>/` | open work *detail* — durable plan trees (**local/gitignored**; the format `README.md` is tracked) | `/plan` writes · `/execute-leaf` reads · `/finish-task` archives |
+| `doc/dev/03-decisions.md` | the *why* — ADR journal (+ settled rationale) | `/finish-task` (accepted), `/abandon-task` (rejected/tombstone) |
+| `doc/dev/06-status.md` | where things stand | `/finish-task`, `/groom-docs` |
+
+`CHANGELOG.md` + git log stay authoritative for *what* shipped. The loop:
+
+`/pick-task` (smallest coherent slice) → `/plan` (decompose into a
+`doc/dev/plans/<epic>/` tree — single leaf for a trivial task, a global
+`00-plan.md` + leaves otherwise) → `/execute-leaf <epic> next` (implement +
+test + verify) → `/finish-task` (tests, ADR, CHANGELOG, PR, archive the leaf) →
+… per leaf … → last leaf removes the roadmap line → `/release`.
+`/abandon-task` salvages the lesson + closes a bad PR; `/groom-docs` keeps
+`doc/dev/` lean and true.
+
+**Model per task** (advisory — set via `/model` or a plan leaf's `complexity`:
+`low→haiku`, `medium→sonnet`, `high→opus`):
+
+| Model | For |
+|-------|-----|
+| `opus` | judgement, design, decisions, planning, review |
+| `sonnet` | implementation — code, tests, docstrings |
+| `haiku` | mechanical fan-out (doc scans, checklists) |
+
+## Architecture
+
+### Cython / Python dual-implementation (features)
+
+`fynance/features/` has two files per computation: `metrics_cy.pyx` (Cython, compiled) and `metrics.py` (pure Python). The `__init__.py` imports both. New performance-critical code should use **Numba `@njit`** — not new Cython — and live in the Python file alongside the existing implementation.
+
+The `USE_CYTHON='auto'` guard in `setup.py` tries to compile `.pyx` sources with Cython; if unavailable it falls back to pre-compiled `.c` files. Do not break this fallback when touching `setup.py`.
+
+### Rolling / walk-forward pattern
+
+`_RollingBasis` in `fynance/models/rolling.py` is the base for all walk-forward evaluation. It behaves as an iterator: `__call__` sets window parameters (`n` = train length, `s` = test length, `r` = roll step), and each `__next__` call trains on `X[t-n:t]` and predicts on `X[t:t+s]`. `RollMultiLayerPerceptron` subclasses this. `rolling_allocation()` in `fynance/algorithms/` replicates the same pattern as a function decorator for portfolio methods.
+
+### Estimator → models pipeline
+
+`fynance/estimator/estimator_cy.pyx` is the Cython ARMA/GARCH parameter estimator. `fynance/models/econometric_models.py` wraps it via `get_parameters()`. Do not duplicate parameter estimation logic in the Python layer.
+
+## Modernization constraints
+
+- **Performance**: Numba `@njit` for new numerical code. No new Cython unless wrapping a C library.
+- **ML**: PyTorch only. Do not extend Keras/TensorFlow code.
+- **Architecture targets**: LSTM, TCN, Transformers over rolling MLP; walk-forward CV in training loops; custom loss functions targeting Sharpe/Sortino/directional accuracy.
+- **Build**: `pyproject.toml` is the authoritative build config. `setup.py` handles Cython extensions only.
+- **CI**: GitHub Actions (`.github/workflows/ci.yml`). Travis-CI removed.
+
+## Stable vs. in-progress subpackages
+
+| Subpackage | Policy |
+|---|---|
+| `fynance.features` | Extend only — never rewrite Cython code |
+| `fynance.algorithms.allocation` | Stable public API — deprecation path required for breaking changes |
+| `fynance.estimator` | Do not duplicate logic in Python — Cython is authoritative |
+| `fynance.backtest` | Improve freely |
+| `fynance.models` | Modernize ML architecture freely |
+
+## Testing conventions
+
+Tests live in `fynance/tests/` mirroring the subpackage structure. They use `pytest` fixtures and plain `assert` statements. The suite also runs all doctest examples via `--doctest-modules`, so keep docstring examples correct and runnable.
+
+No lookahead bias: any test involving time-series data must respect strict temporal ordering — no shuffling, no future data leaking into training windows.

--- a/doc/dev/01-overview.md
+++ b/doc/dev/01-overview.md
@@ -1,0 +1,63 @@
+# 1 — Overview
+
+## What fynance is
+
+**fynance** is a Python + Cython library of machine-learning, econometric, and
+statistical tools for **financial time-series analysis**. It bundles four things
+that usually live in separate packages:
+
+- **Features** — financial indicators, metrics, filters, momentums, scaling
+  (Sharpe/Sortino/Calmar, drawdowns, rolling stats, …), with Cython-accelerated
+  hot paths.
+- **Algorithms** — portfolio allocation (ERC, HRP, IVP, MDP, MVP) and a generic
+  rolling/walk-forward driver.
+- **Models** — econometric (ARMA/GARCH via a Cython estimator) and neural
+  (MLP, RNN/GRU/LSTM, attention) with a walk-forward training base, plus custom
+  financial loss functions (Sharpe/Sortino/directional) in PyTorch.
+- **Backtest** — evaluation, P&L/perf plotting (static + dynamic), stat printing.
+
+The throughline is **strict temporal causality**: every rolling feature and every
+training window is computed from the past only — no lookahead. This is the
+library's core invariant, enforced in tests.
+
+## Current state (snapshot)
+
+- **Version `1.3.4`** (in `pyproject.toml`, static), released on `master` and
+  published to PyPI; `Development Status :: 5 - Production/Stable`.
+- **Python 3.10–3.13** (CI matrix). Build is `setuptools` + **Cython 3** +
+  **NumPy 2**.
+- **~250 tests** under `fynance/tests/` (mirrors the package), **plus doctests**
+  run on every module via `--doctest-modules` — docstring examples are part of
+  the suite and must stay runnable. `ruff` + `mypy` configured; Sphinx docs build
+  (furo).
+- **Core stack**: NumPy 2, pandas 2, SciPy, Numba (`@njit`), **PyTorch** (the ML
+  backend — Keras/TensorFlow is being retired), XGBoost, matplotlib/seaborn.
+
+## Repo map
+
+```
+fynance/
+  features/      # indicators, metrics, momentums, filters, scale, roll_functions
+                 #   (each hot path has a .py + a compiled *_cy.pyx twin)
+  algorithms/    # allocation (ERC/HRP/IVP/MDP/MVP), rolling_allocation, browsers
+  models/        # econometric_models (ARMA/GARCH) + neural (mlp/rnn/gru/lstm/
+                 #   attention) on a rolling/walk-forward base; loss/ (torch losses)
+  estimator/     # estimator_cy.pyx — ARMA/GARCH parameter estimation (Cython)
+  backtest/      # plotting (static + dynamic), loss, print_stats
+  core/          # series helpers
+  tests/         # mirrors the package; pytest + doctests
+doc/
+  source/        # Sphinx (furo) end-user docs
+  dev/           # THIS folder — agent-facing brief
+setup.py         # Cython extension build only (metadata is in pyproject.toml)
+```
+
+## Three things an agent should never break
+
+1. **No lookahead bias** — any feature at `t` must be `f(data[..t])`; any training
+   window trains on the strict past. See `03-decisions.md` and `05-testing.md`.
+2. **The Cython fallback** — `setup.py` compiles `.pyx` if Cython is present, else
+   falls back to shipped `.c`. New numeric code uses **Numba `@njit`**, not new
+   Cython.
+3. **Doctests are tests** — every docstring example runs under
+   `--doctest-modules`; a broken example fails CI.

--- a/doc/dev/02-architecture.md
+++ b/doc/dev/02-architecture.md
@@ -1,0 +1,80 @@
+# 2 — Architecture
+
+fynance is a **layered numerical library**, not a service. There's no I/O layer
+and no daemon: callers pass arrays/DataFrames in and get arrays/models out. The
+structure is by *concern* (features → algorithms/models → backtest), with a
+shared causal-windowing pattern running through all of them.
+
+```
+backtest        evaluate + plot results
+   │  consumes
+   ▼
+algorithms · models      allocation, walk-forward training, econometrics
+   │  build on
+   ▼
+features · estimator     indicators, metrics, ARMA/GARCH params (hot paths in Cython)
+   │  operate on
+   ▼
+core                     series helpers, array wrappers
+```
+
+## Subpackage by subpackage
+
+(See [`04-subpackages.md`](04-subpackages.md) for the public API surface and the
+stability policy per package.)
+
+- **`features/`** — the numerical kernels: `metrics` (Sharpe/Sortino/Calmar,
+  drawdowns, accuracy, z-score…), `momentums` (EMA/SMA/…), `indicators`,
+  `filters`, `roll_functions`, `scale`, `money_management`. The heavy ones ship a
+  `.py` *and* a compiled `*_cy.pyx` twin (see below).
+- **`algorithms/`** — `allocation.py` (ERC, HRP, IVP, MDP, MVP portfolio methods;
+  stable public API), `rolling.py` / `rolling_allocation()` (walk-forward driver
+  for allocation), `browsers` (+ `browsers_cy.pyx`).
+- **`estimator/`** — `estimator_cy.pyx`: the Cython ARMA/GARCH parameter
+  estimator. **Authoritative** — parameter logic lives here, not duplicated in
+  Python.
+- **`models/`** — econometric (`econometric_models.py` wrapping the estimator) and
+  neural (`mlp`, `rnn`, `gru`, `lstm`, `attention`) on a rolling/walk-forward
+  base; `loss/` holds custom PyTorch losses.
+- **`backtest/`** — `plot_backtest`, `dynamic_plot_backtest`, `print_stats`,
+  `loss`; evaluation and visualisation. Improve freely.
+- **`core/`** — `series.py` array/series helpers shared across packages.
+
+## Three cross-cutting patterns
+
+### 1. Cython / Python dual implementation (`features/`)
+
+Each performance-critical computation exists twice: `metrics_cy.pyx` (Cython,
+compiled to a `.so`) and `metrics.py` (pure Python). `features/__init__.py`
+imports both. `setup.py`'s `USE_CYTHON='auto'` guard compiles the `.pyx` if Cython
+is available, else falls back to pre-compiled `.c` files — **do not break this
+fallback**.
+
+> **Going forward**: new performance-critical code uses **Numba `@njit`** in the
+> Python file, *not* new Cython. The Cython twins are kept (extend-only), not
+> grown. See [`03-decisions.md`](03-decisions.md).
+
+### 2. Rolling / walk-forward (the causal core)
+
+`_RollingBasis` (`models/rolling.py`) is the base for all walk-forward evaluation.
+It is an **iterator**: `__call__` sets the window (`n` = train length, `s` = test
+length, `r` = roll step); each `__next__` trains on `X[t-n:t]` and predicts on
+`X[t:t+s]`. `RollMultiLayerPerceptron` subclasses it; `rolling_allocation()`
+(`algorithms/`) replicates the same shape as a decorator for portfolio methods.
+
+This pattern is *the* lookahead guard: a window can only ever see its own past.
+Any new model or feature must preserve it.
+
+### 3. Estimator → models pipeline
+
+`estimator/estimator_cy.pyx` estimates ARMA/GARCH parameters; `models/
+econometric_models.py` wraps it via `get_parameters()`. The Python layer never
+re-implements parameter estimation — the Cython estimator is the single source.
+
+## ML backend
+
+PyTorch is the ML backend. Legacy Keras/TensorFlow code is being **retired, not
+extended**: new architectures (TCN, Transformer, custom losses) target PyTorch,
+with `nn.Module` models trained through the walk-forward base and financial loss
+functions (Sharpe/Sortino/directional) implemented as pure torch ops in
+`models/loss/`.

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -1,0 +1,120 @@
+# 3 — Design decisions & rationale
+
+The *why* behind the structure. Each entry is a choice that shapes the code; if
+you're about to change one, read the rationale first. The prose below is the
+*settled* rationale (standing decisions); the **Decision journal** at the bottom
+is the running, dated ADR log.
+
+## Numerical core
+
+- **Cython for the existing hot paths, kept extend-only.** `features/` and
+  `estimator/` ship compiled `*_cy.pyx` kernels with pure-Python twins and a `.c`
+  fallback. They're fast and correct; we don't rewrite them.
+- **Numba `@njit` for *new* numerical code, not new Cython.** New kernels live in
+  the Python file alongside the existing implementation. Rationale: `@njit` gives
+  near-C speed without a compile step, a `.pyx`/`.c` pair to maintain, or breaking
+  the build fallback. New Cython is only acceptable when wrapping a C library.
+- **NumPy at the core; polars only at the I/O edges (pandas removed).** The
+  linear-algebra-heavy core (allocation, rolling windows) is raw NumPy — fastest
+  and the natural input for torch. Array-like *inputs* are accepted as
+  numpy / torch / **polars** and immediately coerced to numpy/torch; table-shaped
+  *outputs* are plain numpy (e.g. a structured array for the training log). See
+  the dated ADR entry below — this reverses an earlier polars rejection.
+
+## ML modernisation
+
+- **PyTorch is the only ML backend.** Keras/TensorFlow code is retired, not
+  extended. New architectures (LSTM/TCN/Transformer over the rolling MLP) and all
+  training target `torch`.
+- **Loss functions: two independent paths (the "Option C" split).** Evaluation/
+  backtest metrics (Sharpe/Sortino/…) stay as NumPy formulas in
+  `features/metrics.py`; the *training* losses are re-implemented as pure torch
+  ops in `models/loss/`. The two paths never convert numpy↔torch — each is native
+  to its context. Cost: the formula exists twice; benefit: no autograd-breaking
+  conversions, no numpy in the training graph.
+
+## Causality (the core invariant)
+
+- **No lookahead, structurally.** Every feature at `t` is `f(data[..t])`; every
+  training window trains on the strict past via the `_RollingBasis` iterator. This
+  isn't a style preference — a single leaked future value invalidates a backtest.
+  New features get a causal audit; tests forbid shuffling / future leakage.
+
+## Build & packaging
+
+- **`pyproject.toml` is the authoritative build config; `setup.py` only compiles
+  Cython.** Single static `version` in `pyproject.toml` (one source of truth for
+  `/release`). Wheels are built with `cibuildwheel` (manylinux) + an sdist, then
+  trusted-published to PyPI on a `v*` tag.
+
+## Decision journal (ADR)
+
+Append-only, dated log of choices made since the dev-loop was set up — fed by
+`/finish-task` (accepted) and `/abandon-task` (rejected / tombstone). The prose
+above is the *settled* rationale; this journal is the *running* one. **Newest
+first.**
+
+Conventions:
+- One entry per significant choice; skip the trivial (those live in
+  git/`CHANGELOG.md`).
+- `[tombstone]` = a feature was removed. Keep one line on *why it's gone* here and
+  **purge its implementation rationale from the prose above** — negative knowledge
+  so it isn't silently re-added later.
+
+Template:
+```
+### YYYY-MM-DD — <short title> (PR #NN)  [accepted|rejected|tombstone]
+- **Choice**: …
+- **Why**: …
+- **Rejected alternatives**: …
+```
+
+<!-- new entries below, newest first -->
+
+### 2026-06-14 — Track doc/dev + CLAUDE.md publicly, mirroring dccd (PR #62)  [accepted]
+- **Choice**: stop gitignoring `doc/dev`. The descriptive pack `01–07` (including
+  the roadmap), `README.md`, `plans/README.md` **and `CLAUDE.md`** are now tracked,
+  mirroring dccd. Only the plan trees (`doc/dev/plans/<epic>/`), any `_archive`
+  snapshot and the Claude harness settings (`.claude/`) stay local.
+- **Why**: the `.gitignore` `dev/` rule (meant for a scratch dir) was accidentally
+  swallowing **all** of `doc/dev/`, so the "docs of record" the dev loop writes to
+  (this ADR journal, the status file) were never actually shared — directly
+  contradicting CLAUDE.md, which claimed `01–06` were tracked. dccd publishes the
+  full pack + roadmap + `CLAUDE.md`; the roadmap was reviewed and holds only
+  engineering tasks (TCN / Transformer / refactors), no secrets or proprietary
+  strategy, so the earlier privacy concern does not apply.
+- **Reverses**: the 2026-06-13 decision to keep the roadmap private and reject full
+  dccd parity — superseded; full dccd parity adopted at maintainer request.
+
+### 2026-06-14 — Replace pandas with polars at the edges, numpy at the core (PR #61)  [accepted]
+- **Choice**: drop the `pandas` dependency. Inputs that accepted pandas
+  (`BaseNeuralNet.set_data` / `_set_data`, `econometric_models.MA`) now accept
+  **polars** (plus numpy/torch), coerced via `to_numpy()`. Outputs that returned
+  pandas now return plain **numpy**: `rolling_allocation` → `(ndarray, ndarray)`,
+  `RollMultiLayerPerceptron.get_stats` → a structured `ndarray`. Core computation
+  stays numpy.
+- **Why**: a single torch/numpy-native data path; pandas only ever lived at the
+  I/O edges. polars is lighter and the maintainer's preferred frame. The risky
+  piece — `rolling_allocation` (previously untested) — was rewritten pandas-free
+  in numpy and verified for **exact parity** against the old pandas implementation
+  across MVP/ERC/IVP/HRP (various `ret`/`drift`) before pandas was removed; a
+  golden-value regression test now guards it.
+- **Reverses**: the earlier "polars POC evaluated and rejected; pandas at the
+  edges" rationale (purged from the prose above).
+- **Note**: technically API-breaking for the 1.x frozen API (return types
+  pandas → numpy) — flagged in `CHANGELOG.md`; accepted per maintainer direction.
+
+### 2026-06-13 — Adopt the tracked dev-loop docs (doc/dev) with a private roadmap  [accepted]
+- **Choice**: mirror the dccd tooled loop — `doc/dev/{01..06}` descriptive docs +
+  an ADR journal + a `06-status` + plan trees, wired through
+  `.claude/workflow.json` (`decisions`/`status`/`plans_dir`). The **roadmap
+  (`07-roadmap.md`) and the plan trees stay gitignored** (local only), continuing
+  the existing choice to keep `TODO.md` out of git.
+- **Why**: `/finish-task` and `/groom-docs` need real target docs (an ADR journal
+  and a status file) to write to; without them the loop ran half-blind. Keeping
+  the roadmap private preserves the prior posture — the R&D section holds strategy
+  ideas not meant for a public repo. The descriptive docs carry no secrets, so
+  they're tracked.
+- **Rejected alternatives**: full public parity with dccd (would publish the R&D
+  roadmap — rejected on privacy); doing nothing (leaves `/finish-task`'s ADR/status
+  steps with nowhere to write).

--- a/doc/dev/04-subpackages.md
+++ b/doc/dev/04-subpackages.md
@@ -1,0 +1,46 @@
+# 4 — Subpackages: map & stability policy
+
+What each subpackage exposes, and the **policy** that governs changes to it — the
+single most useful thing to know before touching code here, because the packages
+have very different change budgets (some are frozen public API, some are open for
+modernisation).
+
+## Policy matrix
+
+| Subpackage | Policy | Why |
+|---|---|---|
+| `features` (`.py` + `*_cy.pyx`) | **Extend only** — never rewrite the Cython kernels | Fast, correct, depended on; new code goes in the `.py` twin via Numba |
+| `algorithms.allocation` | **Stable public API** — deprecation path required for breaking changes | Users call ERC/HRP/IVP/MDP/MVP directly |
+| `estimator` | **Cython is authoritative** — do not duplicate parameter logic in Python | One source for ARMA/GARCH estimation |
+| `models` | **Modernise freely** (PyTorch) | The active R&D surface |
+| `backtest` | **Improve freely** | Plotting/eval, no external API contract |
+| `core` | Shared helpers — change with care (wide blast radius) | Used everywhere |
+
+## Public API surface (what callers import)
+
+- **`features`** — `sharpe`, `sortino`, `calmar`, `drawdown`/`mdd`,
+  `roll_*` rolling variants, `z_score`, `accuracy`, momentums (EMA/SMA…),
+  filters, `scale`, `roll_functions`. Re-exported from `features/__init__.py`
+  (which pulls both the Python and `_cy` implementations).
+- **`algorithms`** — portfolio allocation: `ERC`, `HRP`, `IVP`, `MDP`, `MVP`, and
+  `rolling_allocation()` for walk-forward application.
+- **`models`** — econometric (`ARMA`/`GARCH` family via `get_parameters`) and
+  neural (`MultiLayerPerceptron`, `RollMultiLayerPerceptron`, RNN/`GRU`/`LSTM`,
+  attention); custom losses under `models/loss/`.
+- **`backtest`** — `BackTest`/plotting objects (`PlotBackTest`,
+  `DynaPlotBackTest`, …), `print_stats`.
+
+## Known sharp edges (by design or pending)
+
+- **`models/basis.py`** — `SignalModel`/`MagnitudeModel` are stubs (`pass` /
+  `y_pred` never assigned), unreferenced. Slated for removal (see roadmap §6.1).
+- **`backtest/dynamic_plot_backtest.py`** — carries a deprecated
+  `__BacktestNeuralNet` ("OLD VERSION") and an unused `_BacktestNeuralNet` stub.
+- **Large modules pending a split** — `features/metrics.py` (~1 800 lines),
+  `models/{attention,econometric_models,rolling}.py`,
+  `backtest/dynamic_plot_backtest.py` (~708 lines, 6 classes). See roadmap §5.
+- **`lstm.py`/`gru.py` internal hierarchies** (`_LSTMCell → LSTMCell →
+  LongShortTermMemory`) are intentionally **not** split — too tightly coupled.
+
+> The "pending" items above live in the (local) `07-roadmap.md`; this file only
+> notes them so an agent doesn't mistake a known stub for a bug.

--- a/doc/dev/05-testing.md
+++ b/doc/dev/05-testing.md
@@ -1,0 +1,43 @@
+# 5 — Testing
+
+## Layers
+
+| Layer | Command | Catches |
+|-------|---------|---------|
+| **Unit** | `pytest` | logic, shapes, regressions (~250 tests under `fynance/tests/`) |
+| **Doctests** | `pytest --doctest-modules` (on by default in `pyproject.toml`) | every docstring `>>>` example — they are part of the suite |
+| **Benchmarks** | `pytest-benchmark` (e.g. `test_filters_benchmark.py`) | perf regressions on hot paths |
+| **Coverage** | `pytest --cov=fynance --cov-report=term-missing` | untested branches |
+| **Type** | `mypy` | type drift |
+| **Lint** | `ruff check fynance/` | style, dead imports |
+| **Docs** | `cd doc && make html` | Sphinx (furo) builds |
+
+`addopts` in `pyproject.toml` is `--doctest-modules --exitfirst -vv
+--capture=no --ignore=fynance/dev`, so **a single failure (incl. a doctest)
+aborts the run**. `conftest.py` sets NumPy legacy scalar repr
+(`np.set_printoptions(legacy='1.25')`) so NumPy-2 scalar reprs don't break
+existing doctests.
+
+> **Build first.** The suite imports compiled extensions — run
+> `python setup.py build_ext --inplace` after a fresh clone or any `.pyx` edit,
+> or collection fails at `import fynance`.
+
+## Conventions (do not regress)
+
+- **No lookahead bias.** Any test on time-series data must respect strict temporal
+  ordering — no shuffling, no future data leaking into a training window. This is
+  the library's core correctness property; a feature that passes its unit test but
+  peeks at the future is still a bug.
+- **Doctests are runnable, not decorative.** Keep every `>>>` example correct and
+  deterministic (seed RNGs; mind NumPy-2 reprs).
+- **Tests mirror the package.** `fynance/tests/<subpkg>/test_*.py`. Use fixtures +
+  plain `assert`.
+- **New features get a causal audit.** For any new rolling indicator, verify the
+  computation is strictly past (`f(data[t-window:t])`) — not
+  `rolling(center=True)`, not a global/whole-dataset normalisation.
+
+## CI
+
+GitHub Actions (`.github/workflows/ci.yml`) runs the suite across the Python
+matrix; `release.yml` builds `cibuildwheel` manylinux wheels + sdist, publishes
+to PyPI, and creates the GitHub Release on a `v*` tag. Badges via `badges.yml`.

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -1,0 +1,56 @@
+# 6 — Current status
+
+A snapshot of what's done, what's in progress, and what's deliberately deferred —
+so an agent doesn't re-investigate settled ground or assume a known stub is a bug.
+
+## Done & working
+
+- **Stable numerical core**: `features` (metrics/momentums/filters/scale/roll) with
+  Cython kernels + Python twins; `algorithms.allocation` (ERC/HRP/IVP/MDP/MVP) with
+  a stable public API; `estimator` (Cython ARMA/GARCH).
+- **Walk-forward base**: `_RollingBasis` iterator + `RollMultiLayerPerceptron` and
+  `rolling_allocation()` — the causal windowing used everywhere.
+- **Models**: econometric (ARMA/GARCH) + neural (MLP, RNN/GRU/LSTM, attention) on
+  PyTorch; custom financial losses (Sharpe/Sortino/directional) in `models/loss/`.
+- **Backtest**: static + dynamic plotting, perf/stat printing.
+- **Quality gates**: ~250 unit tests + doctests on every module
+  (`--doctest-modules`); `ruff`, `mypy`, `pytest-benchmark`; Sphinx (furo) docs.
+- **Released**: `v1.3.4` on `master` + PyPI; `Production/Stable`. CI matrix
+  3.10–3.13; release builds manylinux wheels + sdist and (now) creates the GitHub
+  Release from the CHANGELOG on tag.
+
+## In progress / active surface
+
+- **ML modernisation** (`models/`): migrating off Keras/TensorFlow to PyTorch;
+  new architectures (TCN, Transformer) and custom multi-objective losses are the
+  active R&D axis. See the (local) roadmap.
+- **Structural refactors**: splitting the large modules (`features/metrics.py`,
+  several `models/` and `backtest/` files). Tracked, not started.
+
+## Known gaps / sharp edges (by design or deferred)
+
+- **Dead stubs awaiting removal**: `models/basis.py`
+  (`SignalModel`/`MagnitudeModel`), the deprecated `__BacktestNeuralNet` and the
+  unused `_BacktestNeuralNet` in `backtest/dynamic_plot_backtest.py`.
+- **Large modules** not yet split (see `04-subpackages.md`).
+- **Notebooks** (`Notebooks/`) still carry Keras examples — to be rewritten in
+  PyTorch.
+- **Docs hosting**: GitHub Pages today; RTD migration is an open question.
+
+## Tooling & process
+
+- **Dev loop**: tooled by user-level skills (`/pick-task → /plan → /execute-leaf
+  → /finish-task → /release`, plus `/abandon-task`, `/groom-docs`). Docs of record
+  wired in `.claude/workflow.json` (`roadmap`/`decisions`/`status`/`plans_dir`).
+- **Privacy posture**: the full descriptive pack `01–07` (including the
+  roadmap), `README.md`, `plans/README.md` **and `CLAUDE.md`** are tracked,
+  mirroring dccd. Only the plan trees (`doc/dev/plans/<epic>/`), any `_archive`
+  snapshot and the Claude harness settings (`.claude/`) stay local.
+- **Git Flow**: `master`/`develop` + `feat/fix/chore/docs` branches, one PR per
+  concern (see `CLAUDE.md`).
+
+## Deferred
+
+Larger axes parked until the active modernisation lands: realistic backtesting
+(transaction costs, position sizing), market-regime conditioning, multi-resolution
+features, and the docs-hosting decision. Not started; do not treat as bugs.

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -1,0 +1,273 @@
+# 7 — Roadmap / next steps
+
+This file is the **single source of truth** for open work — read by `/pick-task`,
+updated by `/finish-task` / `/abandon-task`. **Local / gitignored** (R&D stays
+private). Finished work is *removed* from here: git log + `CHANGELOG.md` are
+authoritative for *what* shipped, `03-decisions.md` for *why*. Keep it short and
+true.
+
+> Les numéros de section = état de travail, librement renumérotables. Ils
+> n'apparaissent jamais dans les commits/CHANGELOG — la traçabilité passe par le
+> numéro de PR. Tâche terminée = ligne supprimée (pas de section Done).
+>
+> Loop : `/pick-task` → `/plan` (arbre dans `plans/`) → `/execute-leaf` →
+> `/finish-task`. Release : `/release` quand `[Unreleased]` est suffisamment rempli.
+
+---
+
+## 1. Nouvelles architectures ML
+
+### 1.1 Temporal Convolutional Network (TCN)
+
+Implémenter dans `fynance/models/tcn.py`.
+
+- [ ] Base `BaseNeuralNet` avec walk-forward iterator
+- [ ] Couches dilated 1D convolutions + residual blocks
+- [ ] Architecture similaire à `recurrent_neural_network.py` (MLP, GRU, LSTM)
+- [ ] Tests : 5–8 tests (forward pass, gradient flow, rolling, edge cases)
+
+### 1.2 Transformer financier
+
+Compléter `fynance/models/transformer.py`.
+
+- [ ] Positional encoding pour séries temporelles (relatif vs absolu)
+- [ ] Masking causal (pas de lookahead)
+- [ ] Tester multi-head attention avec données réelles
+- [ ] Tests : 6–10 tests
+
+## 2. Loss functions custom pour optimisation
+
+Architecture retenue (Option C) : formules numpy dans `fynance/features/metrics.py`
+(évaluation/backtest), réimplémentées en ops torch pures dans `fynance/models/loss.py`
+(entraînement). Les deux paths sont indépendantes — pas de conversion numpy↔torch.
+
+### 2.3 Exemple d'intégration
+
+- [ ] `RollMLP` entraîné avec `SharpeLoss` à la place de MSE (test ou notebook)
+
+## 3. Documentation & notebooks
+
+### 3.0 URL de la documentation
+
+- [ ] Évaluer remplacement de GitHub Pages par RTD (URL `fynance.readthedocs.io`)
+  via trigger manuel de build RTD depuis le workflow GitHub Actions à chaque merge
+  sur `master` (API RTD webhook), ou custom domain sur GitHub Pages.
+
+### 3.1 Réécrire les notebooks `Notebooks/`
+
+- [ ] Remplacer exemples Keras par PyTorch
+- [ ] Ajouter exemples TCN, Transformer, custom loss functions
+- [ ] Montrer rolling walk-forward pour backtest
+- [ ] Vérifier que les notebooks tournent (nbval ou papermill)
+
+## 4. Performance & dépendances
+
+### 4.1 Audit des dépendances
+
+- [ ] Audit versions et alternatives modernes des dépendances restantes
+  (hors `pandas` → POC `polars` déjà tranché : NumPy natif gagne pour
+  l'algèbre matricielle)
+
+## 5. Refactoring structurel
+
+### 5.1 Éclater `fynance/features/metrics.py` (1 800 lignes)
+
+Découper en 4 modules thématiques dans `fynance/features/` (pas de façade
+`metrics.py` : `features/__init__.py` importe directement depuis les nouveaux
+fichiers). Les helpers privés partagés vont dans `_metrics_helpers.py`.
+
+Découpage proposé :
+
+```
+fynance/features/
+    _metrics_helpers.py   ← _annual_return, _annual_volatility,
+                             _annual_downside_volatility,
+                             _roll_annual_return, _roll_annual_volatility,
+                             _drawdown, _roll_drawdown, _roll_mdd
+    returns.py            ← annual_return, annual_volatility,
+                             roll_annual_return, roll_annual_volatility,
+                             perf_index, perf_returns
+    ratios.py             ← sharpe, sortino, calmar, diversified_ratio,
+                             roll_sharpe, roll_calmar
+    drawdown.py           ← drawdown, mdd, roll_drawdown, roll_mdd
+    stats.py              ← z_score, accuracy, directional_accuracy,
+                             mad, roll_mad, roll_z_score
+```
+
+`metrics_cy.pyx` reste intact (Cython, extend only).
+Mettre à jour `features/__init__.py` pour importer depuis les 4 nouveaux
+fichiers (+ `metrics_cy`). Supprimer `metrics.py`.
+
+- [ ] Créer `_metrics_helpers.py` avec tous les helpers privés
+- [ ] Créer `returns.py`, `ratios.py`, `drawdown.py`, `stats.py`
+- [ ] Mettre à jour `features/__init__.py` (supprimer import `metrics`)
+- [ ] Supprimer `metrics.py`
+- [ ] Vérifier que tous les tests et doctests passent (`pytest` + `--doctest-modules`)
+
+### 5.2 Éclater les fichiers multi-classes de `fynance/models/`
+
+Candidats identifiés :
+
+- `attention.py` → `scaled_dot_product_attention.py` + `multi_head_attention.py`
+- `econometric_models.py` → un fichier par modèle : `ma.py`, `arma.py`,
+  `arma_garch.py`, `armax_garch.py` + `get_parameters.py`
+- `rolling.py` → `_rolling_basis.py` + `roll_mlp.py` (CVResult reste dans
+  `roll_mlp.py`, très couplé à `RollMultiLayerPerceptron`)
+- `lstm.py` et `gru.py` — les hiérarchies internes (`_LSTMCell → LSTMCell →
+  LongShortTermMemory`) sont trop couplées pour être séparées : laisser en l'état
+
+- [ ] Éclater `attention.py`
+- [ ] Éclater `econometric_models.py`
+- [ ] Éclater `rolling.py`
+- [ ] Mettre à jour `models/__init__.py` pour chaque éclatement
+
+### 5.3 Éclater `fynance/backtest/dynamic_plot_backtest.py` (708 lignes, 6 classes)
+
+Candidats : `DynaPlotBackTest`, `DynaPlotAccuracy`, `DynaPlotLoss`,
+`DynaPlotPerf`, `BacktestNeuralNet` (+ `_BacktestNeuralNet` privé).
+
+- [ ] Un fichier par classe publique substantielle
+- [ ] Mettre à jour `backtest/__init__.py`
+
+## 7. R&D — Loss, architecture, données
+
+Objectif : identifier empiriquement la meilleure combinaison loss / architecture / features
+pour les séries temporelles financières. Chaque sous-tâche est exploratoire :
+elle peut déboucher sur du code dans `fynance/models/` ou rester à l'état de
+notebook/rapport.
+
+### 7.1 Nouvelles loss functions
+
+- [ ] **Calmar loss** — proxy différentiable du max drawdown
+  (`max_drawdown ≈ max(cumsum(-r)) − min(cumsum(-r))` via `torch.cumsum` + `torch.max`).
+  Valeur à annualiser pour comparer avec la métrique d'évaluation.
+- [ ] **Omega loss** — ratio gains/pertes pondérés au-delà d'un seuil `L` :
+  `Ω = E[max(r−L, 0)] / E[max(L−r, 0) + ε]`, entièrement différentiable avec `F.relu`.
+- [ ] **Loss hybride multi-objectif** — combiner deux objectifs avec un poids `α` :
+  `L = α·SharpeLoss + (1−α)·DirectionalAccuracyLoss`. Chercher `α` optimal
+  par grid-search ou en le rendant learnable (paramètre `nn.Parameter`).
+- [ ] **Benchmark empirique** : comparer les 5 loss sur un jeu de données réel
+  (même walk-forward, mêmes features) — métriques out-of-sample : Sharpe, Sortino,
+  Calmar, accuracy directionnelle, drawdown max.
+
+### 7.2 Architecture : ensemble direction + magnitude avec meta-modèle
+
+Suite de la discussion sur le stacking à trois niveaux :
+
+- [ ] **Modèle 1 (direction)** : entraîné avec `DirectionalAccuracyLoss`,
+  sortie = probabilité de signe positif (sigmoid).
+- [ ] **Modèle 2 (magnitude)** : entraîné avec MSE ou `SortinoLoss`,
+  sortie = estimation du return.
+- [ ] **Meta-modèle** : prend `[signal_1, magnitude_2]` en entrée,
+  entraîné avec `SharpeLoss` ou `SortinoLoss`.
+  Entraîner sur les prédictions out-of-fold (walk-forward OOF) pour éviter
+  la fuite de données — jamais sur les mêmes fenêtres que les sous-modèles.
+- [ ] Comparer vs. modèle unique entraîné directement avec `SharpeLoss`.
+
+### 7.3 Régimes de marché
+
+- [ ] Identifier des régimes (bull/bear/sideways/high-vol) via HMM ou k-means
+  sur les features de volatilité réalisée.
+- [ ] Conditionner l'architecture : soit un modèle par régime (mixture of experts),
+  soit un embedding de régime concaténé aux features d'entrée.
+- [ ] Évaluer si la détection de régime améliore le Sharpe out-of-sample.
+
+### 7.4 Features / indicateurs techniques
+
+- [ ] **Indicateurs de tendance** : EMA, MACD, ADX.
+- [ ] **Indicateurs de momentum** : RSI, ROC, Williams %R.
+- [ ] **Indicateurs de volatilité** : ATR, Bollinger Band width, vol réalisée glissante.
+- [ ] **Indicateurs de volume** : OBV, VWAP (si données intraday disponibles).
+- [ ] **Features statistiques glissantes** : autocorrélation, skewness, kurtosis
+  des returns sur fenêtres multiples (5, 10, 21, 63 jours).
+- [ ] **Vol conditionnelle** : GARCH(1,1) comme feature de régime de vol
+  (utiliser `fynance.estimator`).
+- [ ] Implémenter dans `fynance/features/` avec décorateurs `@WrapperArray` existants.
+
+### 7.5 Normalisation des features
+
+- [ ] **Rolling z-score** : `(x − μ_t) / σ_t` avec fenêtre glissante strictement
+  passée — évite toute fuite de données.
+- [ ] **Rank-based normalization** : transformer les features en rangs percentiles
+  sur la fenêtre passée — robuste aux outliers.
+- [ ] **Vol-targeting** : normaliser les returns en entrée par la vol réalisée
+  passée (target = vol annuelle constante, ex. 15 %).
+- [ ] Comparer empiriquement les trois approches sur le Sharpe out-of-sample.
+
+### 7.6 Protocole d'entraînement robuste
+
+**Construction causale des features** (protection primaire contre la fuite) :
+toute feature à `t` doit s'écrire `f(data[t-window:t])` — jamais de données futures.
+C'est ce que font déjà `roll_sharpe`, `roll_mdd`, etc. ; le vérifier systématiquement
+pour les nouveaux indicateurs de 7.4 et 7.5.
+
+- [ ] **Audit causal de chaque feature** : pour chaque indicateur implémenté,
+  vérifier que le calcul est strictement passé (pas de `df.rolling(window, center=True)`,
+  pas de normalisation globale sur tout le dataset, pas de z-score calculé sur la
+  fenêtre test incluse).
+- [ ] **Purged walk-forward CV** : dans un contexte multi-fold (k-fold temporel),
+  les features adjacentes au bord train/test partagent `window-1` jours de données
+  sous-jacentes → les premières `window` observations du fold test sont corrélées
+  avec les dernières du fold train. Exclure cette zone de bordure (purging) quand
+  le nombre de folds est grand ou que la fenêtre feature >> horizon de prédiction.
+  En walk-forward linéaire classique (un seul train → test avançant), ce problème
+  est moins critique si les features sont causales.
+- [ ] **Pondération des échantillons** : down-weighter les observations anciennes
+  (decay exponentiel) ou celles en régime de faible vol (signal moins informatif).
+- [ ] **Early stopping sur métrique financière** : arrêter l'entraînement sur
+  la validation en maximisant le Sharpe plutôt qu'en minimisant la loss.
+
+### 7.8 R&D rolling — features multi-résolution et efficacité
+
+- [ ] **Multi-résolution** : construire les mêmes features (vol, momentum, z-score)
+  sur plusieurs fenêtres simultanément (5, 10, 21, 63 jours) et concaténer —
+  laisser le modèle apprendre l'horizon pertinent plutôt que de le fixer.
+- [ ] **Streaming / mises à jour incrémentales** : évaluer si les features les plus
+  coûteuses (GARCH, corrélations croisées) peuvent être mises à jour en O(1) par
+  pas de temps plutôt que recalculées en O(window). Implémenter un prototype
+  `IncrementalFeature` basé sur une formule récursive.
+- [ ] **Fenêtres adaptatives** : faire varier `window` en fonction du régime de
+  vol (courte en haute vol, longue en basse vol) pour que les features capturent
+  une quantité d'information constante plutôt qu'une durée fixe.
+- [ ] **Test de causalité de Granger** : pour chaque feature candidate, mesurer
+  empiriquement si elle prédit le return à t+1 au-delà de l'autocorrélation des
+  returns — filtrer les features sans signal avant d'entraîner.
+
+### 7.7 Backtest réaliste
+
+- [ ] **Coûts de transaction** : intégrer spread bid-ask + slippage dans le calcul
+  du P&L de backtest (paramétrable : BPS par trade, impact de marché linéaire).
+- [ ] **Position sizing** : implémenter Kelly fractionnel et vol-targeting comme
+  modules de `fynance/algorithms/` ; tester leur impact sur le Sharpe net.
+- [ ] **Métriques de robustesse** : taux de calmar, Omega ratio, tail ratio,
+  % de mois positifs — compléter `fynance/features/metrics.py`.
+
+## 6. Optimisations et nettoyage
+
+### 6.1 Supprimer code obsolète dans models/ et backtest/
+
+- [ ] Supprimer `fynance/models/basis.py` — `SignalModel` (stub, `self.y_pred`
+  jamais assigné) et `MagnitudeModel` (juste `pass`). Aucune référence ailleurs.
+- [ ] Supprimer `class __BacktestNeuralNet` dans `dynamic_plot_backtest.py`
+  (marqué "OLD VERSION => DEPRECIATED")
+- [ ] Décider du sort de `class _BacktestNeuralNet` (stub TODO, jamais utilisé)
+
+### 6.2 Optimisations allocation.py
+
+- [ ] `HRP()` : remplacer le loop Python de réordonnancement par du fancy indexing
+  NumPy (`w[np.array(sortIx)] = w_sorted`)
+- [ ] `rolling_allocation()` : nettoyer le double `.bfill()` (lignes ~705, 719)
+- [ ] Évaluer cache de la matrice de covariance entre steps consécutifs dans
+  `rolling_allocation()` (O(N²) par step, 100 steps × 250 assets = coûteux)
+
+### 6.3 Optimisations rolling.py / _base.py
+
+- [ ] `rolling.py _training()` : supprimer les `print` de debug dans le hot loop
+- [ ] `_base.py _set_data()` : utiliser `X.to_numpy(dtype=np.float64, copy=False)`
+  pour les DataFrames afin d'éviter les copies accidentelles
+
+### 6.4 Migrer les TODO inline
+
+- [ ] Passer en revue les ~15 commentaires `# TODO` / `# FIXME` dans le code
+  (metrics.py, _base.py, allocation.py, _wrappers.py, backtest/) et fermer
+  ou migrer vers TODO.md ceux qui restent pertinents

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -246,28 +246,65 @@ pour les nouveaux indicateurs de 7.4 et 7.5.
 
 ### 6.1 Supprimer code obsolète dans models/ et backtest/
 
-- [ ] Supprimer `fynance/models/basis.py` — `SignalModel` (stub, `self.y_pred`
-  jamais assigné) et `MagnitudeModel` (juste `pass`). Aucune référence ailleurs.
-- [ ] Supprimer `class __BacktestNeuralNet` dans `dynamic_plot_backtest.py`
-  (marqué "OLD VERSION => DEPRECIATED")
-- [ ] Décider du sort de `class _BacktestNeuralNet` (stub TODO, jamais utilisé)
+- [x] Supprimer `fynance/models/basis.py` — `SignalModel` (stub, `self.y_pred`
+  jamais assigné) et `MagnitudeModel` (juste `pass`). ✅ PR #58.
+- [x] Supprimer `class __BacktestNeuralNet` dans `dynamic_plot_backtest.py`
+  (marqué "OLD VERSION => DEPRECIATED"). ✅ PR #58.
+- [x] Décider du sort de `class _BacktestNeuralNet` (stub TODO) — supprimé. ✅ PR #58.
 
 ### 6.2 Optimisations allocation.py
 
 - [ ] `HRP()` : remplacer le loop Python de réordonnancement par du fancy indexing
   NumPy (`w[np.array(sortIx)] = w_sorted`)
-- [ ] `rolling_allocation()` : nettoyer le double `.bfill()` (lignes ~705, 719)
+- [x] `rolling_allocation()` : réécrit pandas-free en numpy (le double `.bfill()` est désormais un seul helper `_bfill`). ✅ PR #61.
 - [ ] Évaluer cache de la matrice de covariance entre steps consécutifs dans
   `rolling_allocation()` (O(N²) par step, 100 steps × 250 assets = coûteux)
 
 ### 6.3 Optimisations rolling.py / _base.py
 
-- [ ] `rolling.py _training()` : supprimer les `print` de debug dans le hot loop
-- [ ] `_base.py _set_data()` : utiliser `X.to_numpy(dtype=np.float64, copy=False)`
-  pour les DataFrames afin d'éviter les copies accidentelles
+- [x] `rolling.py _training()` : `print` de debug supprimés. ✅ PR #58.
+- [x] `_base.py _set_data()` : entrée pandas remplacée par polars (`X.to_numpy()`).
+  ✅ PR #61. (Reste optionnel : passer `dtype=np.float64` à `to_numpy`.)
 
 ### 6.4 Migrer les TODO inline
 
 - [ ] Passer en revue les ~15 commentaires `# TODO` / `# FIXME` dans le code
   (metrics.py, _base.py, allocation.py, _wrappers.py, backtest/) et fermer
   ou migrer vers TODO.md ceux qui restent pertinents
+
+
+## 8. Qualité & dette technique (audit 2026-06-14)
+
+Items issus de l'audit complet du dépôt **non couverts ailleurs** dans cette
+roadmap. Le reste de l'audit a déjà été traité (PRs #58–#62) ou figure dans les
+sections 3, 5 et 6 ci-dessus.
+
+### 8.1 `estimator/estimator.py` — décider du sort
+- [ ] `estimation()` est annoncée « NOT YET WORKING ! » / « NEED TO FIND AN
+  OPTIMIZER » mais reste exposée. La finir (brancher un optimiseur correct) **ou**
+  la marquer explicitement expérimentale / la retirer.
+
+### 8.2 Typage : résorber les 104 erreurs mypy puis ajouter le gate CI
+- [ ] `mypy fynance/` = 104 erreurs (bruit numpy-2 `Returning Any`, hiérarchies
+  torch `predict`/`train_on` incompatibles, `print_stats.py` variable `bool`
+  réassignée en `ndarray`). Les corriger par lots.
+- [ ] Une fois à 0, ajouter un job `mypy` dans `ci.yml` (à côté de
+  ruff / interrogate / docs).
+
+### 8.3 Couverture du cœur causal
+- [ ] `models/rolling.py` (64 %) — couvrir la boucle d'entraînement `_training`.
+- [ ] `algorithms/rolling.py` (22 %) — walk-forward allocation.
+- [ ] `models/econometric_models.py` (54 %) — chemins ARMA/GARCH.
+- [ ] `algorithms/browsers.py` (0 %) — clarifier le rôle puis tester ou retirer.
+
+### 8.4 Tests de propriété (transformer des conventions en garde-fous)
+- [ ] **Parité py ↔ cy** : suite paramétrée
+  `assert np.allclose(py_impl(x), cy_impl(x))` pour chaque paire
+  `metrics` / `momentums` / `roll_functions` (aurait attrapé le faux-FIXME
+  `momentums_cy.pyx:26`).
+- [ ] **Non-lookahead générique** : perturber `X[t+1:]` et vérifier que `f(X)[t]`
+  est inchangé, pour chaque feature rolling.
+
+### 8.5 Compléter les inventaires de doc/dev
+- [ ] Ajouter `features/money_management.py`, `_exceptions.py` et le sous-package
+  `models/loss/` aux inventaires de `01-overview.md` / `04-subpackages.md`.

--- a/doc/dev/README.md
+++ b/doc/dev/README.md
@@ -1,0 +1,47 @@
+# fynance — developer brief (for Claude Code)
+
+This folder is an **orientation pack written for Claude Code** (not end users). Its
+job is to give an agent a fast, faithful overview of the repository: what exists,
+how it fits together, why it was built that way, and what is and isn't done.
+End-user docs live in `doc/source/` (Sphinx); the authoritative working rules
+live in the repo-root `CLAUDE.md`.
+
+> **Relationship to `CLAUDE.md`**: `CLAUDE.md` is the source of truth for
+> *commands, the layer map, and the hard invariants you must not regress*. This
+> folder is the *narrative and depth* around it — rationale, per-area detail,
+> current status, testing methodology. When the two disagree, trust `CLAUDE.md`
+> and fix this folder.
+
+## Read in this order
+
+1. [`01-overview.md`](01-overview.md) — what fynance is, the current state, the
+   repo map, the subpackages.
+2. [`02-architecture.md`](02-architecture.md) — the package layout, the
+   Cython/Python dual implementation, the rolling/walk-forward pattern, the
+   estimator→models pipeline.
+3. [`03-decisions.md`](03-decisions.md) — the design choices and *why* (Numba over
+   new Cython, PyTorch over Keras, the loss-function split, NumPy over polars),
+   plus the running ADR journal.
+4. [`04-subpackages.md`](04-subpackages.md) — the per-subpackage map, public API
+   surface, and the stability/modernisation policy that governs each.
+5. [`05-testing.md`](05-testing.md) — the testing layers (pytest + doctests +
+   benchmarks), how to run each, and the conventions (no lookahead bias).
+6. [`06-status.md`](06-status.md) — what's done, what's in progress, known gaps,
+   tooling, and deferred work.
+
+## Tools kept here
+
+- [`plans/`](plans/) — **active plan trees** (durable, hierarchical task plans).
+  Each roadmap item being worked on expands into a `plans/<epic>/` tree of a
+  global map + precise leaf specs that drive `/plan` → `/execute-leaf` →
+  `/finish-task`. See [`plans/README.md`](plans/README.md). **The trees and the
+  roadmap (`07-roadmap.md`) are gitignored** (kept local — R&D / strategy stays
+  private); only this format reference and the descriptive docs above are tracked.
+
+## Conventions for keeping this current
+
+- This is descriptive, not aspirational: write what the repo **is**, not what it
+  should become. Open work goes in `07-roadmap.md` (local) and its executable
+  expansion in `plans/`; history stays in git/`CHANGELOG.md`; the *why* in
+  `03-decisions.md`.
+- Finished plan trees move to `_archive/plans/` (gitignored).

--- a/doc/dev/plans/README.md
+++ b/doc/dev/plans/README.md
@@ -1,0 +1,76 @@
+# Plan trees — durable, hierarchical task plans
+
+This directory holds **active plan trees**: the file-based expansion of a roadmap
+item into an executable plan. The `/plan`, `/execute-leaf` and `/finish-task`
+skills read and write it. This `README.md` (the format reference) is **tracked**;
+the actual plan trees are **gitignored** (local — they may contain R&D/strategy
+detail), as is the roadmap they expand. Finished trees move to
+`../_archive/plans/`.
+
+## Why this exists
+
+Plan mode writes to `~/.claude/plans/*.md` (outside the repo), so a plan is lost on
+`/compact`, and nothing records *whether we planned one slice or the whole set*.
+Plan trees fix both: plans are **files** (durable, reviewable) and **hierarchical**
+(a global map + precise leaves).
+
+## Layout
+
+```
+doc/dev/plans/<epic-slug>/
+  00-plan.md            # global: goal, decomposition, leaf checklist, deps
+  01-<leaf-slug>.md     # leaf: precise, agent-executable spec
+  02-<leaf-slug>.md
+  ...
+```
+
+**Depth is adaptive — never forced.**
+
+- Trivial task → a *single* leaf file, **no global** `00-plan.md`.
+- Normal task → a global `00-plan.md` + N leaves.
+- A leaf still too big → its own sub-directory with a `00-plan.md` + sub-leaves
+  (recursion). The deepest level must be precise enough that an agent executes it
+  without re-deciding anything.
+
+## Lifecycle
+
+```
+/pick-task → /plan (build tree)
+  → /execute-leaf <epic> next   (model from the leaf's `complexity`; implement + test + verify)
+  → /finish-task                (tests, ADR, PR, archive leaf, tick global)
+  → … repeat per leaf (deps respected) …
+  → last leaf → roadmap line removed, global done → /release
+```
+
+> Because the trees are gitignored here, there is **no "plan PR"** step (unlike a
+> repo that tracks its plans): the tree lives locally and the work lands through
+> the normal feature-branch PRs that `/finish-task` opens. To track plans in git,
+> remove the `doc/dev/plans/*` lines from `.gitignore`.
+
+## Frontmatter
+
+### Global `00-plan.md`
+```yaml
+---
+plan: <epic-slug>
+kind: global
+status: planning | executing | done
+roadmap: "<verbatim roadmap line this expands>"
+release_on_done: true
+---
+```
+
+### Leaf `NN-<slug>.md`
+```yaml
+---
+plan: <epic-slug>
+kind: leaf
+status: todo | doing | done
+complexity: low | medium | high     # derives the execution model (haiku/sonnet/opus)
+deps: []                            # leaf numbers that must finish first
+parallel: false                     # may run concurrently with sibling leaves
+---
+```
+
+A leaf body is a precise spec: files to touch, the change, how to test, and the
+real-data/numerical check that proves it works.


### PR DESCRIPTION
Discovered during the audit work: **`doc/dev/` was entirely gitignored** (zero tracked files), because the `.gitignore` `dev/` rule — meant for a scratch dir — matches `doc/dev/` too. This contradicted CLAUDE.md, which claimed the `01–06` descriptive docs were tracked, and meant the dev-loop "docs of record" (the ADR journal, the status file) were never actually shared.

Per maintainer direction, **mirror dccd** (which tracks the full pack + roadmap + `CLAUDE.md`).

## .gitignore
- Drop the over-broad `dev/` rule (its only match was `doc/dev/`).
- Stop ignoring `CLAUDE.md` (now tracked); keep `.claude/` local.
- Add precise rules so only the **plan trees** (`doc/dev/plans/*/`) and an `_archive/` snapshot stay local — the descriptive pack + roadmap + `plans/README.md` are tracked.

## Now tracked (first commit)
`doc/dev/01..07` (incl. the roadmap), `doc/dev/README.md`, `doc/dev/plans/README.md`, and `CLAUDE.md`.

The roadmap was reviewed before publishing — it holds only engineering tasks (TCN/Transformer/refactors/notebooks), **no secrets or proprietary strategy**.

## Doc refresh (avoid publishing stale facts)
- `~198 tests` → `~250` (01, 05, 06)
- privacy-posture note in `06-status.md` updated to the new reality
- dev-loop table in `CLAUDE.md`: roadmap marked **tracked**
- two ADR entries recorded in `03-decisions.md`: this change, and the pandas→polars migration (its ADR couldn't land in #61 because doc/dev wasn't trackable yet)

## ⚠️ Note
This publishes the previously-local dev docs to the public repo (outward-facing). Scope is limited to docs/config — **no code changes**, so `pytest`/`ruff` are unaffected.