### PR TITLE
docs: complete doc/dev inventories (roadmap 8.5)

### DIFF
--- a/doc/dev/01-overview.md
+++ b/doc/dev/01-overview.md
@@ -37,7 +37,8 @@ library's core invariant, enforced in tests.
 
 ```
 fynance/
-  features/      # indicators, metrics, momentums, filters, scale, roll_functions
+  features/      # indicators, metrics, momentums, filters, scale,
+                 #   roll_functions, money_management
                  #   (each hot path has a .py + a compiled *_cy.pyx twin)
   algorithms/    # allocation (ERC/HRP/IVP/MDP/MVP), rolling_allocation, browsers
   models/        # econometric_models (ARMA/GARCH) + neural (mlp/rnn/gru/lstm/
@@ -45,6 +46,7 @@ fynance/
   estimator/     # estimator_cy.pyx — ARMA/GARCH parameter estimation (Cython)
   backtest/      # plotting (static + dynamic), loss, print_stats
   core/          # series helpers
+  _exceptions.py # ArraySizeError and friends (shared error types)
   tests/         # mirrors the package; pytest + doctests
 doc/
   source/        # Sphinx (furo) end-user docs

--- a/doc/dev/04-subpackages.md
+++ b/doc/dev/04-subpackages.md
@@ -20,8 +20,8 @@ modernisation).
 
 - **`features`** — `sharpe`, `sortino`, `calmar`, `drawdown`/`mdd`,
   `roll_*` rolling variants, `z_score`, `accuracy`, momentums (EMA/SMA…),
-  filters, `scale`, `roll_functions`. Re-exported from `features/__init__.py`
-  (which pulls both the Python and `_cy` implementations).
+  filters, `scale`, `roll_functions`, `money_management`. Re-exported from
+  `features/__init__.py` (which pulls both the Python and `_cy` implementations).
 - **`algorithms`** — portfolio allocation: `ERC`, `HRP`, `IVP`, `MDP`, `MVP`, and
   `rolling_allocation()` for walk-forward application.
 - **`models`** — econometric (`ARMA`/`GARCH` family via `get_parameters`) and

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -306,5 +306,5 @@ sections 3, 5 et 6 ci-dessus.
   est inchangé, pour chaque feature rolling.
 
 ### 8.5 Compléter les inventaires de doc/dev
-- [ ] Ajouter `features/money_management.py`, `_exceptions.py` et le sous-package
-  `models/loss/` aux inventaires de `01-overview.md` / `04-subpackages.md`.
+- [x] Ajouter `features/money_management.py`, `_exceptions.py` et le sous-package
+  `models/loss/` aux inventaires de `01-overview.md` / `04-subpackages.md`. ✅ PR #64.


### PR DESCRIPTION
Roadmap **§8.5**. Adds the modules the audit found missing from the dev-doc inventories: `features/money_management.py` and `_exceptions.py` to the 01-overview repo map, and `money_management` to the 04-subpackages features API surface (`models/loss/` was already listed). Docs-only.