### PR TITLE
test: cover causal core — econometric + RollMLP training (roadmap 8.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Tests for the causal core: econometric `MA`/`ARMA` recurrences and `ARMAX_GARCH` properties; `RollMultiLayerPerceptron._training` (loss update) and `get_stats` (populated structured array)
 - Property test suite `tests/features/test_property.py`: independent NumPy-reference parity for the rolling kernels (`sma`/`wma`/`smstd`/`ema`/`roll_min`/`roll_max`) and a generic no-lookahead (causality) check
 - `polars` is now accepted as an input frame wherever pandas was (`BaseNeuralNet.set_data`, `econometric_models.MA`), alongside numpy/torch
 - Golden-value regression test for `rolling_allocation` (previously untested)

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -292,9 +292,9 @@ sections 3, 5 et 6 ci-dessus.
   ruff / interrogate / docs).
 
 ### 8.3 Couverture du cœur causal
-- [ ] `models/rolling.py` (64 %) — couvrir la boucle d'entraînement `_training`.
-- [ ] `algorithms/rolling.py` (22 %) — walk-forward allocation.
-- [ ] `models/econometric_models.py` (54 %) — chemins ARMA/GARCH.
+- [x] `models/rolling.py` — `_training` (loss update) + `get_stats` couverts. ✅ PR #67.
+- [x] `algorithms/rolling.py` — supprimé (code mort `_RollingMechanism`). ✅ PR #66.
+- [x] `models/econometric_models.py` — `MA`/`ARMA`/`ARMAX_GARCH` testés. ✅ PR #67.
 - [x] `algorithms/browsers.py` (0 %) — code mort, **supprimé** (+ `browsers_cy`,
   + `algorithms/rolling.py`/`_RollingMechanism` orphelin). ✅ PR #66.
 

--- a/fynance/tests/models/test_econometric_models.py
+++ b/fynance/tests/models/test_econometric_models.py
@@ -64,3 +64,44 @@ def test_ARMA_GARCH(set_variables):
         )
         assert u[t] == u_est[t]
         assert h[t] == h_est[t]
+
+
+def test_MA_recurrence():
+    # MA(q): u[0] = y[0] - c ; u[t] = y[t] - c - sum_j theta[j] * u[t-1-j]
+    y = np.array([60., 100., 80., 120., 160., 80.])
+    theta, c = np.array([0.8]), 3.0
+    u_est = np.asarray(fy.MA(y=y, theta=theta, c=c, q=1))
+    u = np.zeros(y.size)
+    u[0] = y[0] - c
+    for t in range(1, y.size):
+        u[t] = y[t] - c - theta[0] * u[t - 1]
+    assert np.allclose(u_est, u)
+
+
+def test_ARMA_recurrence():
+    # ARMA(1,1): u[t] = y[t] - c - phi*y[t-1] - theta*u[t-1]
+    y = np.array([60., 100., 80., 120., 160., 80.])
+    phi, theta, c = np.array([0.5]), np.array([-0.3]), 0.2
+    u_est = np.asarray(fy.ARMA(y=y, phi=phi, theta=theta, c=c, p=1, q=1))
+    u = np.zeros(y.size)
+    u[0] = y[0] - c
+    for t in range(1, y.size):
+        u[t] = y[t] - c - phi[0] * y[t - 1] - theta[0] * u[t - 1]
+    assert np.allclose(u_est, u)
+
+
+def test_ARMAX_GARCH_shapes_and_positive_vol(set_variables):
+    # Property-level coverage: residuals/vol have length T, are finite, and the
+    # conditional standard deviation stays strictly positive.
+    y, params, p, q, P, Q = set_variables
+    y = y.astype(float)
+    x = np.zeros((y.size, 1))
+    u, h = fy.ARMAX_GARCH(
+        y, x, phi=params[1:2], psi=np.array([0.1]), theta=params[2:3],
+        alpha=params[4:5], beta=params[5:6], c=params[0], omega=params[3],
+        p=1, q=1, P=1, Q=1,
+    )
+    u, h = np.asarray(u), np.asarray(h)
+    assert u.shape == (y.size,) and h.shape == (y.size,)
+    assert np.all(np.isfinite(u)) and np.all(np.isfinite(h))
+    assert np.all(h > 0)

--- a/fynance/tests/models/test_neural_network.py
+++ b/fynance/tests/models/test_neural_network.py
@@ -456,3 +456,24 @@ class TestRollMLP:
         # Prediction on eval window should work
         pred = model.sub_predict(model.X[eval_set])
         assert pred.shape[1] == N_OUT
+
+    def test_get_stats_populated(self):
+        model = self._make_roll_mlp()
+        model.log = [
+            {"step": 0, "train_loss": 1.0, "eval_loss": 2.0, "test_loss": 3.0},
+            {"step": 1, "train_loss": 0.5, "eval_loss": 1.5, "test_loss": 2.5},
+        ]
+        stats = model.get_stats()
+        assert stats.dtype.names == (
+            "step", "train_loss", "eval_loss", "test_loss"
+        )
+        assert stats.size == 2
+        assert stats["step"].tolist() == [0, 1]
+        assert np.isclose(stats["train_loss"][1], 0.5)
+
+    def test_training_updates_loss_train(self):
+        model = self._make_roll_mlp()
+        it = iter(model)
+        next(it)
+        model._training()
+        assert np.isfinite(model.loss_train[model.i])


### PR DESCRIPTION
Roadmap **§8.3** (the "add tests" part; the dead-code part shipped in #66).

## econometric_models
- `test_MA_recurrence`, `test_ARMA_recurrence` — recompute the residual recurrence independently and assert equality with the Cython-backed functions.
- `test_ARMAX_GARCH_shapes_and_positive_vol` — property coverage (shapes, finiteness, `h > 0`).

## RollMultiLayerPerceptron
- `test_get_stats_populated` — the non-empty `get_stats()` path now returns a structured `ndarray` (fields + values).
- `test_training_updates_loss_train` — one `_training()` step updates `loss_train`.

`ruff` clean · `pytest` **289 → 294**.