### PR TITLE
refactor: extract CVResult, drop dead get_perf (roadmap 5.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `models/rolling.py` slimmed: the `CVResult` dataclass moved to `models/cv_result.py` (re-exported; imports preserved) and the dead `get_perf` helper removed. The coupled `_RollingBasis`/`RollMultiLayerPerceptron` hierarchy is kept together by design
 - `backtest/dynamic_plot_backtest.py` split: the orchestrator `BacktestNeuralNet` moved to a new `backtest/backtest_neural_net.py` (re-exported from `fynance.backtest`; existing imports preserved). The tightly-coupled `DynaPlot*` plot family stays together
 - `estimator.estimation()` now raises `NotImplementedError` (it was an experimental, non-functional placeholder marked "NOT YET WORKING") and points to `models.econometric_models.get_parameters` (the Cython-backed authoritative path); unused `fmin`/`target_function_cy` imports removed
 - **BREAKING**: pandas is replaced by polars at the input edges and by numpy at the output edges. `rolling_allocation` now returns `(numpy.ndarray, numpy.ndarray)` instead of `(pandas.Series, pandas.DataFrame)`, and `RollMultiLayerPerceptron.get_stats` returns a structured `numpy.ndarray` instead of a `pandas.DataFrame` (field access `stats["train_loss"]` is preserved; use `stats.size` instead of `.empty`). `rolling_allocation` was rewritten pandas-free in numpy with exact parity verified against the old implementation

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -106,6 +106,11 @@ fichiers (+ `metrics_cy`). Supprimer `metrics.py`.
 
 ### 5.2 Éclater les fichiers multi-classes de `fynance/models/`
 
+> Décision (audit) : split **léger et sensé** seulement. `attention.py` (174 l,
+> 2 classes couplées), `econometric_models.py` (fonctions cohérentes) et la
+> hiérarchie couplée `_RollingBasis`/`RollMLP` sont **gardés intacts** ; seul
+> `CVResult` (dataclass distincte) a été détaché de `rolling.py`. ✅ PR #69.
+
 Candidats identifiés :
 
 - `attention.py` → `scaled_dot_product_attention.py` + `multi_head_attention.py`
@@ -116,10 +121,11 @@ Candidats identifiés :
 - `lstm.py` et `gru.py` — les hiérarchies internes (`_LSTMCell → LSTMCell →
   LongShortTermMemory`) sont trop couplées pour être séparées : laisser en l'état
 
-- [ ] Éclater `attention.py`
-- [ ] Éclater `econometric_models.py`
-- [ ] Éclater `rolling.py`
-- [ ] Mettre à jour `models/__init__.py` pour chaque éclatement
+- [x] `attention.py` — gardé (174 l, 2 classes couplées). ✅ PR #69
+- [x] `econometric_models.py` — gardé (fonctions cohérentes, pas un god-file). ✅ PR #69
+- [x] `rolling.py` — `CVResult` → `cv_result.py` ; `get_perf` mort retiré ;
+  hiérarchie `_RollingBasis`/`RollMLP` gardée couplée. ✅ PR #69
+- [x] `models/__init__.py` — CVResult re-exporté via `rolling`, imports préservés. ✅ PR #69
 
 ### 5.3 Éclater `fynance/backtest/dynamic_plot_backtest.py` (708 lignes, 6 classes)
 

--- a/fynance/models/cv_result.py
+++ b/fynance/models/cv_result.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Result container for walk-forward cross-validation. """
+
+# Built-in packages
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Third-party packages
+import numpy as np
+
+__all__ = ['CVResult']
+
+
+@dataclass
+class CVResult:
+    """ Results from :meth:`_RollingBasis.cross_validate`.
+
+    Attributes
+    ----------
+    oof_predictions : np.ndarray
+        Out-of-fold predictions, shape ``(T, n_out)``.  Positions that
+        fall before the first test fold are filled with ``NaN``.
+    fold_metrics : list of float
+        Per-fold metric values (empty list when ``metric_fn`` is None).
+    mean_metric : float or None
+        Mean of ``fold_metrics``, or None when no metric was provided.
+    std_metric : float or None
+        Standard deviation of ``fold_metrics``, or None when no metric
+        was provided.
+
+    """
+
+    oof_predictions: np.ndarray
+    fold_metrics: list
+    mean_metric: float | None
+    std_metric: float | None

--- a/fynance/models/rolling.py
+++ b/fynance/models/rolling.py
@@ -27,7 +27,6 @@ Main entry points
 from __future__ import annotations
 
 # Built-in packages
-from dataclasses import dataclass
 from multiprocessing import Process
 from typing import Callable
 
@@ -40,37 +39,13 @@ from numpy.typing import NDArray
 from fynance.backtest.backtest_neural_net import BacktestNeuralNet
 
 # Local packages
+from fynance.models.cv_result import CVResult
 from fynance.models.mlp import MultiLayerPerceptron
 
 plt.style.use('seaborn-v0_8')
 
 
 __all__ = ['CVResult', '_RollingBasis', 'RollMultiLayerPerceptron']
-
-
-@dataclass
-class CVResult:
-    """ Results from :meth:`_RollingBasis.cross_validate`.
-
-    Attributes
-    ----------
-    oof_predictions : np.ndarray
-        Out-of-fold predictions, shape ``(T, n_out)``.  Positions that
-        fall before the first test fold are filled with ``NaN``.
-    fold_metrics : list of float
-        Per-fold metric values (empty list when ``metric_fn`` is None).
-    mean_metric : float or None
-        Mean of ``fold_metrics``, or None when no metric was provided.
-    std_metric : float or None
-        Standard deviation of ``fold_metrics``, or None when no metric
-        was provided.
-
-    """
-
-    oof_predictions: np.ndarray
-    fold_metrics: list
-    mean_metric: float | None
-    std_metric: float | None
 
 
 class _RollingBasis:
@@ -467,10 +442,6 @@ class _RollingBasis:
 
 def get_perf2(ret, signal, v0=100):
     return v0 * np.cumprod(ret * signal + 1, axis=0)
-
-
-def get_perf(signal, underlying, v0=100):
-    return v0 * np.exp(np.cumsum(signal * underlying, axis=0))
 
 
 class RollMultiLayerPerceptron(MultiLayerPerceptron, _RollingBasis):


### PR DESCRIPTION
Roadmap **§5.2**, done as a **light, sensible split** (per the agreed approach — not blind fragmentation).

## Changed
- `CVResult` dataclass → new `models/cv_result.py`. Re-exported from `fynance.models.rolling` and `fynance.models`, so every existing import path still resolves to the same object.
- Removed the **dead** `get_perf()` helper (only `get_perf2` is used).

## Kept intact (splitting would hurt, not help)
- `attention.py` — 174 lines, 2 coupled classes (`MultiHeadAttention` uses `ScaledDotProductAttention`).
- `econometric_models.py` — cohesive function module (MA/ARMA/GARCH…), not a multi-class god-file.
- `_RollingBasis` / `RollMultiLayerPerceptron` — coupled inheritance hierarchy (same rationale the dev docs give for the lstm/gru cells).

## Verification
- `ruff` clean · `pytest` **294 passed** · `sphinx-build -W` ok · CVResult identity verified across all 3 import paths