### PR TITLE
docs: groom dev docs pre-release

### DIFF
--- a/doc/dev/01-overview.md
+++ b/doc/dev/01-overview.md
@@ -26,7 +26,7 @@ library's core invariant, enforced in tests.
   published to PyPI; `Development Status :: 5 - Production/Stable`.
 - **Python 3.10–3.13** (CI matrix). Build is `setuptools` + **Cython 3** +
   **NumPy 2**.
-- **~250 tests** under `fynance/tests/` (mirrors the package), **plus doctests**
+- **~300 tests** under `fynance/tests/` (mirrors the package), **plus doctests**
   run on every module via `--doctest-modules` — docstring examples are part of
   the suite and must stay runnable. `ruff` + `mypy` configured; Sphinx docs build
   (furo).

--- a/doc/dev/02-architecture.md
+++ b/doc/dev/02-architecture.md
@@ -36,19 +36,26 @@ stability policy per package.)
 - **`models/`** — econometric (`econometric_models.py` wrapping the estimator) and
   neural (`mlp`, `rnn`, `gru`, `lstm`, `attention`) on a rolling/walk-forward
   base; `loss/` holds custom PyTorch losses.
-- **`backtest/`** — `plot_backtest`, `dynamic_plot_backtest`, `print_stats`,
-  `loss`; evaluation and visualisation. Improve freely.
+- **`backtest/`** — `plot_backtest`, `dynamic_plot_backtest`,
+  `backtest_neural_net`, `print_stats`, `loss`; evaluation and visualisation.
+  Improve freely.
 - **`core/`** — `series.py` array/series helpers shared across packages.
 
 ## Three cross-cutting patterns
 
 ### 1. Cython / Python dual implementation (`features/`)
 
-Each performance-critical computation exists twice: `metrics_cy.pyx` (Cython,
-compiled to a `.so`) and `metrics.py` (pure Python). `features/__init__.py`
-imports both. `setup.py`'s `USE_CYTHON='auto'` guard compiles the `.pyx` if Cython
+Each performance-critical kernel exists twice: a compiled `*_cy.pyx` (e.g.
+`momentums_cy`, `roll_functions_cy`, `metrics_cy`) and a thin Python wrapper that
+calls it (`momentums.py`, `roll_functions.py`, …). `features/__init__.py` imports
+both layers. `setup.py`'s `USE_CYTHON='auto'` guard compiles the `.pyx` if Cython
 is available, else falls back to pre-compiled `.c` files — **do not break this
-fallback**.
+fallback**. Kernel correctness is cross-checked against independent NumPy
+references by the property tests (`tests/features/test_property.py`).
+
+> The metrics surface is now split across `returns.py`, `ratios.py`,
+> `drawdown.py`, `stats.py` + `_metrics_helpers.py`, with `metrics.py` kept as a
+> thin re-export aggregator (public API unchanged).
 
 > **Going forward**: new performance-critical code uses **Numba `@njit`** in the
 > Python file, *not* new Cython. The Cython twins are kept (extend-only), not

--- a/doc/dev/04-subpackages.md
+++ b/doc/dev/04-subpackages.md
@@ -30,17 +30,19 @@ modernisation).
 - **`backtest`** — `BackTest`/plotting objects (`PlotBackTest`,
   `DynaPlotBackTest`, …), `print_stats`.
 
-## Known sharp edges (by design or pending)
+## Known sharp edges (by design)
 
-- **`models/basis.py`** — `SignalModel`/`MagnitudeModel` are stubs (`pass` /
-  `y_pred` never assigned), unreferenced. Slated for removal (see roadmap §6.1).
-- **`backtest/dynamic_plot_backtest.py`** — carries a deprecated
-  `__BacktestNeuralNet` ("OLD VERSION") and an unused `_BacktestNeuralNet` stub.
-- **Large modules pending a split** — `features/metrics.py` (~1 800 lines),
-  `models/{attention,econometric_models,rolling}.py`,
-  `backtest/dynamic_plot_backtest.py` (~708 lines, 6 classes). See roadmap §5.
+- **`features/metrics.py`** is a thin **re-export aggregator** — the
+  implementations live in `returns.py`, `ratios.py`, `drawdown.py`, `stats.py`
+  and `_metrics_helpers.py`. Import from `fynance.features` (or
+  `fynance.features.metrics`) as before; the split is transparent.
+- **`estimator.estimation()`** is an experimental stub that raises
+  `NotImplementedError` — use `models.econometric_models.get_parameters`
+  (Cython-backed) for ARMA/GARCH estimation.
 - **`lstm.py`/`gru.py` internal hierarchies** (`_LSTMCell → LSTMCell →
-  LongShortTermMemory`) are intentionally **not** split — too tightly coupled.
+  LongShortTermMemory`) and `_RollingBasis`/`RollMultiLayerPerceptron` are
+  intentionally **not** split — too tightly coupled.
+- **Inputs** accept numpy / torch / **polars**; **outputs** are numpy (no pandas).
 
-> The "pending" items above live in the (local) `07-roadmap.md`; this file only
-> notes them so an agent doesn't mistake a known stub for a bug.
+> Open work lives in `07-roadmap.md`; this file only notes settled design points
+> so an agent doesn't mistake one for a bug.

--- a/doc/dev/05-testing.md
+++ b/doc/dev/05-testing.md
@@ -4,11 +4,12 @@
 
 | Layer | Command | Catches |
 |-------|---------|---------|
-| **Unit** | `pytest` | logic, shapes, regressions (~250 tests under `fynance/tests/`) |
+| **Unit** | `pytest` | logic, shapes, regressions (~300 tests under `fynance/tests/`) |
 | **Doctests** | `pytest --doctest-modules` (on by default in `pyproject.toml`) | every docstring `>>>` example — they are part of the suite |
 | **Benchmarks** | `pytest-benchmark` (e.g. `test_filters_benchmark.py`) | perf regressions on hot paths |
 | **Coverage** | `pytest --cov=fynance --cov-report=term-missing` | untested branches |
-| **Type** | `mypy` | type drift |
+| **Property** | `pytest tests/features/test_property.py` | kernel parity vs NumPy refs + no-lookahead |
+| **Type** | `mypy` | type drift (0 errors, enforced) |
 | **Lint** | `ruff check fynance/` | style, dead imports |
 | **Docs** | `cd doc && make html` | Sphinx (furo) builds |
 
@@ -38,6 +39,9 @@ existing doctests.
 
 ## CI
 
-GitHub Actions (`.github/workflows/ci.yml`) runs the suite across the Python
-matrix; `release.yml` builds `cibuildwheel` manylinux wheels + sdist, publishes
-to PyPI, and creates the GitHub Release on a `v*` tag. Badges via `badges.yml`.
+GitHub Actions (`.github/workflows/ci.yml`) runs **four gates** on every PR:
+the test suite across the Python matrix (`test`), `ruff` + `interrogate`
+(docstring coverage ≥ 80%) in `lint`, a Sphinx build with warnings-as-errors
+(`docs`, `sphinx-build -W`), and `mypy` (`typecheck`, 0 errors). `release.yml`
+builds `cibuildwheel` manylinux wheels + sdist, publishes to PyPI, and creates
+the GitHub Release on a `v*` tag. Badges via `badges.yml`.

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -6,51 +6,59 @@ so an agent doesn't re-investigate settled ground or assume a known stub is a bu
 ## Done & working
 
 - **Stable numerical core**: `features` (metrics/momentums/filters/scale/roll) with
-  Cython kernels + Python twins; `algorithms.allocation` (ERC/HRP/IVP/MDP/MVP) with
-  a stable public API; `estimator` (Cython ARMA/GARCH).
+  Cython kernels + Python wrappers; `algorithms.allocation` (ERC/HRP/IVP/MDP/MVP)
+  with a stable public API; `estimator` (Cython ARMA/GARCH).
+- **`features/metrics.py` split** by concern into `returns.py`, `ratios.py`,
+  `drawdown.py`, `stats.py` + `_metrics_helpers.py`; `metrics.py` kept as a thin
+  re-export aggregator (public API + import paths unchanged).
 - **Walk-forward base**: `_RollingBasis` iterator + `RollMultiLayerPerceptron` and
   `rolling_allocation()` — the causal windowing used everywhere.
 - **Models**: econometric (ARMA/GARCH) + neural (MLP, RNN/GRU/LSTM, attention) on
   PyTorch; custom financial losses (Sharpe/Sortino/directional) in `models/loss/`.
-- **Backtest**: static + dynamic plotting, perf/stat printing.
-- **Quality gates**: ~250 unit tests + doctests on every module
-  (`--doctest-modules`); `ruff`, `mypy`, `pytest-benchmark`; Sphinx (furo) docs.
+- **Data frames**: **polars** at the input edges (`set_data`, `MA`), **numpy** at
+  the output edges (`rolling_allocation`, `get_stats`); pandas removed.
+- **Backtest**: static + dynamic plotting (orchestrator `BacktestNeuralNet` split
+  into `backtest/backtest_neural_net.py`), perf/stat printing.
+- **Quality gates (all 4 enforced in CI)**: ~300 unit tests + doctests on every
+  module (`--doctest-modules`) incl. property tests (kernel parity + no-lookahead);
+  `ruff`; `interrogate` (docstring coverage ≥ 80%); Sphinx build `-W`; **`mypy`
+  clean (0 errors)**.
 - **Released**: `v1.3.4` on `master` + PyPI; `Production/Stable`. CI matrix
-  3.10–3.13; release builds manylinux wheels + sdist and (now) creates the GitHub
+  3.10–3.13; release builds manylinux wheels + sdist and creates the GitHub
   Release from the CHANGELOG on tag.
 
 ## In progress / active surface
 
-- **ML modernisation** (`models/`): migrating off Keras/TensorFlow to PyTorch;
-  new architectures (TCN, Transformer) and custom multi-objective losses are the
-  active R&D axis. See the (local) roadmap.
-- **Structural refactors**: splitting the large modules (`features/metrics.py`,
-  several `models/` and `backtest/` files). Tracked, not started.
+- **ML modernisation** (`models/`): Keras/TensorFlow fully retired (no TF/Keras in
+  the package); new architectures (TCN, Transformer) and custom multi-objective
+  losses are the active R&D axis. See the roadmap (§1, §5).
 
 ## Known gaps / sharp edges (by design or deferred)
 
-- **Dead stubs awaiting removal**: `models/basis.py`
-  (`SignalModel`/`MagnitudeModel`), the deprecated `__BacktestNeuralNet` and the
-  unused `_BacktestNeuralNet` in `backtest/dynamic_plot_backtest.py`.
-- **Large modules** not yet split (see `04-subpackages.md`).
+- **`estimator.estimation()`** is an explicit experimental stub: it raises
+  `NotImplementedError` and points to `models.econometric_models.get_parameters`
+  (the Cython-backed authoritative path).
 - **Notebooks** (`Notebooks/`) still carry Keras examples — to be rewritten in
-  PyTorch.
-- **Docs hosting**: GitHub Pages today; RTD migration is an open question.
+  PyTorch (roadmap §3.2).
+- **Docs hosting**: GitHub Pages today; RTD migration is an open question (§3.1).
+- **`# type: ignore`** markers exist for genuinely-unmodellable cases (torch
+  multiple-inheritance mixins, decorator-filled `w`, star-imported Cython names);
+  `warn_return_any` is off (numpy/Cython return `Any` pervasively).
 
 ## Tooling & process
 
 - **Dev loop**: tooled by user-level skills (`/pick-task → /plan → /execute-leaf
   → /finish-task → /release`, plus `/abandon-task`, `/groom-docs`). Docs of record
   wired in `.claude/workflow.json` (`roadmap`/`decisions`/`status`/`plans_dir`).
-- **Privacy posture**: the full descriptive pack `01–07` (including the
-  roadmap), `README.md`, `plans/README.md` **and `CLAUDE.md`** are tracked,
-  mirroring dccd. Only the plan trees (`doc/dev/plans/<epic>/`), any `_archive`
-  snapshot and the Claude harness settings (`.claude/`) stay local.
+- **Tracked docs**: the full descriptive pack `01–07` (including the roadmap),
+  `README.md`, `plans/README.md` and `CLAUDE.md` are tracked, mirroring dccd. Only
+  the plan trees (`doc/dev/plans/<epic>/`), any `_archive` snapshot and the Claude
+  harness settings (`.claude/`) stay local.
 - **Git Flow**: `master`/`develop` + `feat/fix/chore/docs` branches, one PR per
   concern (see `CLAUDE.md`).
 
 ## Deferred
 
-Larger axes parked until the active modernisation lands: realistic backtesting
-(transaction costs, position sizing), market-regime conditioning, multi-resolution
-features, and the docs-hosting decision. Not started; do not treat as bugs.
+Larger axes parked for later: realistic backtesting (transaction costs, position
+sizing), market-regime conditioning, multi-resolution features, and the
+docs-hosting decision. Tracked in the roadmap; not bugs.

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -1,10 +1,9 @@
 # 7 — Roadmap / next steps
 
 This file is the **single source of truth** for open work — read by `/pick-task`,
-updated by `/finish-task` / `/abandon-task`. **Local / gitignored** (R&D stays
-private). Finished work is *removed* from here: git log + `CHANGELOG.md` are
-authoritative for *what* shipped, `03-decisions.md` for *why*. Keep it short and
-true.
+updated by `/finish-task` / `/abandon-task`. **Tracked** (mirrors dccd). Finished
+work is *removed* from here: git log + `CHANGELOG.md` are authoritative for *what*
+shipped, `03-decisions.md` for *why*. Keep it short and true.
 
 > Les numéros de section = état de travail, librement renumérotables. Ils
 > n'apparaissent jamais dans les commits/CHANGELOG — la traçabilité passe par le
@@ -37,23 +36,21 @@ Compléter `fynance/models/transformer.py`.
 
 ## 2. Loss functions custom pour optimisation
 
-Architecture retenue (Option C) : formules numpy dans `fynance/features/metrics.py`
-(évaluation/backtest), réimplémentées en ops torch pures dans `fynance/models/loss.py`
+Architecture retenue (Option C) : formules numpy dans `fynance/features/` (métriques
+d'évaluation/backtest), réimplémentées en ops torch pures dans `fynance/models/loss/`
 (entraînement). Les deux paths sont indépendantes — pas de conversion numpy↔torch.
-
-### 2.3 Exemple d'intégration
 
 - [ ] `RollMLP` entraîné avec `SharpeLoss` à la place de MSE (test ou notebook)
 
 ## 3. Documentation & notebooks
 
-### 3.0 URL de la documentation
+### 3.1 URL de la documentation
 
 - [ ] Évaluer remplacement de GitHub Pages par RTD (URL `fynance.readthedocs.io`)
   via trigger manuel de build RTD depuis le workflow GitHub Actions à chaque merge
   sur `master` (API RTD webhook), ou custom domain sur GitHub Pages.
 
-### 3.1 Réécrire les notebooks `Notebooks/`
+### 3.2 Réécrire les notebooks `Notebooks/`
 
 - [ ] Remplacer exemples Keras par PyTorch
 - [ ] Ajouter exemples TCN, Transformer, custom loss functions
@@ -62,90 +59,18 @@ Architecture retenue (Option C) : formules numpy dans `fynance/features/metrics.
 
 ## 4. Performance & dépendances
 
-### 4.1 Audit des dépendances
+- [ ] Audit versions et alternatives modernes des dépendances restantes.
+  (pandas a été remplacé par polars en entrée + numpy en sortie ; le cœur
+  algébrique reste NumPy natif.)
 
-- [ ] Audit versions et alternatives modernes des dépendances restantes
-  (hors `pandas` → POC `polars` déjà tranché : NumPy natif gagne pour
-  l'algèbre matricielle)
-
-## 5. Refactoring structurel
-
-### 5.1 Éclater `fynance/features/metrics.py` (1 800 lignes)
-
-Découper en 4 modules thématiques dans `fynance/features/` (pas de façade
-`metrics.py` : `features/__init__.py` importe directement depuis les nouveaux
-fichiers). Les helpers privés partagés vont dans `_metrics_helpers.py`.
-
-Découpage proposé :
-
-```
-fynance/features/
-    _metrics_helpers.py   ← _annual_return, _annual_volatility,
-                             _annual_downside_volatility,
-                             _roll_annual_return, _roll_annual_volatility,
-                             _drawdown, _roll_drawdown, _roll_mdd
-    returns.py            ← annual_return, annual_volatility,
-                             roll_annual_return, roll_annual_volatility,
-                             perf_index, perf_returns
-    ratios.py             ← sharpe, sortino, calmar, diversified_ratio,
-                             roll_sharpe, roll_calmar
-    drawdown.py           ← drawdown, mdd, roll_drawdown, roll_mdd
-    stats.py              ← z_score, accuracy, directional_accuracy,
-                             mad, roll_mad, roll_z_score
-```
-
-`metrics_cy.pyx` reste intact (Cython, extend only).
-Mettre à jour `features/__init__.py` pour importer depuis les 4 nouveaux
-fichiers (+ `metrics_cy`). Supprimer `metrics.py`.
-
-- [x] Créer `_metrics_helpers.py` avec tous les helpers privés. ✅ PR #70
-- [x] Créer `returns.py`, `ratios.py`, `drawdown.py`, `stats.py`. ✅ PR #70
-- [~] `features/__init__.py` inchangé : `metrics.py` gardé comme **agrégateur**
-  mince (re-export) plutôt que supprimé — sinon 6 modules + la page Sphinx
-  `features.metrics.rst` casseraient. Déviation justifiée. ✅ PR #70
-- [~] `metrics.py` **non supprimé** (devenu shim de re-export, ~30 lignes). ✅ PR #70
-- [x] Tests + doctests + parité + `sphinx-build -W` verts. ✅ PR #70
-
-### 5.2 Éclater les fichiers multi-classes de `fynance/models/`
-
-> Décision (audit) : split **léger et sensé** seulement. `attention.py` (174 l,
-> 2 classes couplées), `econometric_models.py` (fonctions cohérentes) et la
-> hiérarchie couplée `_RollingBasis`/`RollMLP` sont **gardés intacts** ; seul
-> `CVResult` (dataclass distincte) a été détaché de `rolling.py`. ✅ PR #69.
-
-Candidats identifiés :
-
-- `attention.py` → `scaled_dot_product_attention.py` + `multi_head_attention.py`
-- `econometric_models.py` → un fichier par modèle : `ma.py`, `arma.py`,
-  `arma_garch.py`, `armax_garch.py` + `get_parameters.py`
-- `rolling.py` → `_rolling_basis.py` + `roll_mlp.py` (CVResult reste dans
-  `roll_mlp.py`, très couplé à `RollMultiLayerPerceptron`)
-- `lstm.py` et `gru.py` — les hiérarchies internes (`_LSTMCell → LSTMCell →
-  LongShortTermMemory`) sont trop couplées pour être séparées : laisser en l'état
-
-- [x] `attention.py` — gardé (174 l, 2 classes couplées). ✅ PR #69
-- [x] `econometric_models.py` — gardé (fonctions cohérentes, pas un god-file). ✅ PR #69
-- [x] `rolling.py` — `CVResult` → `cv_result.py` ; `get_perf` mort retiré ;
-  hiérarchie `_RollingBasis`/`RollMLP` gardée couplée. ✅ PR #69
-- [x] `models/__init__.py` — CVResult re-exporté via `rolling`, imports préservés. ✅ PR #69
-
-### 5.3 Éclater `fynance/backtest/dynamic_plot_backtest.py` (708 lignes, 6 classes)
-
-Candidats : `DynaPlotBackTest`, `DynaPlotAccuracy`, `DynaPlotLoss`,
-`DynaPlotPerf`, `BacktestNeuralNet` (+ `_BacktestNeuralNet` privé).
-
-- [x] Séparé l'orchestrateur `BacktestNeuralNet` (→ `backtest_neural_net.py`)
-  des primitives `DynaPlot*` (famille couplée gardée ensemble). ✅ PR #68
-- [x] `backtest/__init__.py` mis à jour (re-export). ✅ PR #68
-
-## 7. R&D — Loss, architecture, données
+## 5. R&D — Loss, architecture, données
 
 Objectif : identifier empiriquement la meilleure combinaison loss / architecture / features
 pour les séries temporelles financières. Chaque sous-tâche est exploratoire :
 elle peut déboucher sur du code dans `fynance/models/` ou rester à l'état de
 notebook/rapport.
 
-### 7.1 Nouvelles loss functions
+### 5.1 Nouvelles loss functions
 
 - [ ] **Calmar loss** — proxy différentiable du max drawdown
   (`max_drawdown ≈ max(cumsum(-r)) − min(cumsum(-r))` via `torch.cumsum` + `torch.max`).
@@ -155,166 +80,84 @@ notebook/rapport.
 - [ ] **Loss hybride multi-objectif** — combiner deux objectifs avec un poids `α` :
   `L = α·SharpeLoss + (1−α)·DirectionalAccuracyLoss`. Chercher `α` optimal
   par grid-search ou en le rendant learnable (paramètre `nn.Parameter`).
-- [ ] **Benchmark empirique** : comparer les 5 loss sur un jeu de données réel
+- [ ] **Benchmark empirique** : comparer les loss sur un jeu de données réel
   (même walk-forward, mêmes features) — métriques out-of-sample : Sharpe, Sortino,
   Calmar, accuracy directionnelle, drawdown max.
 
-### 7.2 Architecture : ensemble direction + magnitude avec meta-modèle
-
-Suite de la discussion sur le stacking à trois niveaux :
+### 5.2 Architecture : ensemble direction + magnitude avec meta-modèle
 
 - [ ] **Modèle 1 (direction)** : entraîné avec `DirectionalAccuracyLoss`,
   sortie = probabilité de signe positif (sigmoid).
 - [ ] **Modèle 2 (magnitude)** : entraîné avec MSE ou `SortinoLoss`,
   sortie = estimation du return.
 - [ ] **Meta-modèle** : prend `[signal_1, magnitude_2]` en entrée,
-  entraîné avec `SharpeLoss` ou `SortinoLoss`.
-  Entraîner sur les prédictions out-of-fold (walk-forward OOF) pour éviter
-  la fuite de données — jamais sur les mêmes fenêtres que les sous-modèles.
+  entraîné avec `SharpeLoss` ou `SortinoLoss`, sur les prédictions out-of-fold
+  (walk-forward OOF) pour éviter la fuite de données.
 - [ ] Comparer vs. modèle unique entraîné directement avec `SharpeLoss`.
 
-### 7.3 Régimes de marché
+### 5.3 Régimes de marché
 
 - [ ] Identifier des régimes (bull/bear/sideways/high-vol) via HMM ou k-means
   sur les features de volatilité réalisée.
-- [ ] Conditionner l'architecture : soit un modèle par régime (mixture of experts),
-  soit un embedding de régime concaténé aux features d'entrée.
+- [ ] Conditionner l'architecture : un modèle par régime (mixture of experts),
+  ou un embedding de régime concaténé aux features d'entrée.
 - [ ] Évaluer si la détection de régime améliore le Sharpe out-of-sample.
 
-### 7.4 Features / indicateurs techniques
+### 5.4 Features / indicateurs techniques
 
-- [ ] **Indicateurs de tendance** : EMA, MACD, ADX.
-- [ ] **Indicateurs de momentum** : RSI, ROC, Williams %R.
-- [ ] **Indicateurs de volatilité** : ATR, Bollinger Band width, vol réalisée glissante.
-- [ ] **Indicateurs de volume** : OBV, VWAP (si données intraday disponibles).
-- [ ] **Features statistiques glissantes** : autocorrélation, skewness, kurtosis
+- [ ] **Tendance** : EMA, MACD, ADX.
+- [ ] **Momentum** : RSI, ROC, Williams %R.
+- [ ] **Volatilité** : ATR, Bollinger Band width, vol réalisée glissante.
+- [ ] **Volume** : OBV, VWAP (si données intraday disponibles).
+- [ ] **Statistiques glissantes** : autocorrélation, skewness, kurtosis
   des returns sur fenêtres multiples (5, 10, 21, 63 jours).
-- [ ] **Vol conditionnelle** : GARCH(1,1) comme feature de régime de vol
-  (utiliser `fynance.estimator`).
+- [ ] **Vol conditionnelle** : GARCH(1,1) comme feature (via `fynance.estimator`).
 - [ ] Implémenter dans `fynance/features/` avec décorateurs `@WrapperArray` existants.
 
-### 7.5 Normalisation des features
+### 5.5 Normalisation des features
 
-- [ ] **Rolling z-score** : `(x − μ_t) / σ_t` avec fenêtre glissante strictement
-  passée — évite toute fuite de données.
-- [ ] **Rank-based normalization** : transformer les features en rangs percentiles
-  sur la fenêtre passée — robuste aux outliers.
-- [ ] **Vol-targeting** : normaliser les returns en entrée par la vol réalisée
-  passée (target = vol annuelle constante, ex. 15 %).
+- [ ] **Rolling z-score** : `(x − μ_t) / σ_t` avec fenêtre strictement passée.
+- [ ] **Rank-based normalization** : rangs percentiles sur la fenêtre passée.
+- [ ] **Vol-targeting** : normaliser les returns par la vol réalisée passée.
 - [ ] Comparer empiriquement les trois approches sur le Sharpe out-of-sample.
 
-### 7.6 Protocole d'entraînement robuste
+### 5.6 Protocole d'entraînement robuste
 
-**Construction causale des features** (protection primaire contre la fuite) :
-toute feature à `t` doit s'écrire `f(data[t-window:t])` — jamais de données futures.
-C'est ce que font déjà `roll_sharpe`, `roll_mdd`, etc. ; le vérifier systématiquement
-pour les nouveaux indicateurs de 7.4 et 7.5.
+Construction causale des features (protection primaire contre la fuite) : toute
+feature à `t` doit s'écrire `f(data[t-window:t])`. Garantie côté kernels par les
+tests de propriété (parité + non-lookahead) ; à étendre aux nouvelles features.
 
-- [ ] **Audit causal de chaque feature** : pour chaque indicateur implémenté,
-  vérifier que le calcul est strictement passé (pas de `df.rolling(window, center=True)`,
-  pas de normalisation globale sur tout le dataset, pas de z-score calculé sur la
-  fenêtre test incluse).
-- [ ] **Purged walk-forward CV** : dans un contexte multi-fold (k-fold temporel),
-  les features adjacentes au bord train/test partagent `window-1` jours de données
-  sous-jacentes → les premières `window` observations du fold test sont corrélées
-  avec les dernières du fold train. Exclure cette zone de bordure (purging) quand
-  le nombre de folds est grand ou que la fenêtre feature >> horizon de prédiction.
-  En walk-forward linéaire classique (un seul train → test avançant), ce problème
-  est moins critique si les features sont causales.
-- [ ] **Pondération des échantillons** : down-weighter les observations anciennes
-  (decay exponentiel) ou celles en régime de faible vol (signal moins informatif).
-- [ ] **Early stopping sur métrique financière** : arrêter l'entraînement sur
-  la validation en maximisant le Sharpe plutôt qu'en minimisant la loss.
+- [ ] **Audit causal de chaque feature** (pas de `rolling(center=True)`, pas de
+  normalisation globale, pas de z-score incluant la fenêtre test).
+- [ ] **Purged walk-forward CV** : exclure la zone de bordure train/test quand le
+  nombre de folds est grand ou la fenêtre feature >> horizon.
+- [ ] **Pondération des échantillons** : decay exponentiel / down-weight basse vol.
+- [ ] **Early stopping sur métrique financière** (maximiser le Sharpe de validation).
 
-### 7.8 R&D rolling — features multi-résolution et efficacité
+### 5.7 R&D rolling — features multi-résolution et efficacité
 
-- [ ] **Multi-résolution** : construire les mêmes features (vol, momentum, z-score)
-  sur plusieurs fenêtres simultanément (5, 10, 21, 63 jours) et concaténer —
-  laisser le modèle apprendre l'horizon pertinent plutôt que de le fixer.
-- [ ] **Streaming / mises à jour incrémentales** : évaluer si les features les plus
-  coûteuses (GARCH, corrélations croisées) peuvent être mises à jour en O(1) par
-  pas de temps plutôt que recalculées en O(window). Implémenter un prototype
-  `IncrementalFeature` basé sur une formule récursive.
-- [ ] **Fenêtres adaptatives** : faire varier `window` en fonction du régime de
-  vol (courte en haute vol, longue en basse vol) pour que les features capturent
-  une quantité d'information constante plutôt qu'une durée fixe.
-- [ ] **Test de causalité de Granger** : pour chaque feature candidate, mesurer
-  empiriquement si elle prédit le return à t+1 au-delà de l'autocorrélation des
-  returns — filtrer les features sans signal avant d'entraîner.
+- [ ] **Multi-résolution** : mêmes features sur plusieurs fenêtres (5/10/21/63) concaténées.
+- [ ] **Streaming / mises à jour incrémentales** : prototype `IncrementalFeature`
+  (formule récursive O(1) par pas pour GARCH, corrélations).
+- [ ] **Fenêtres adaptatives** : `window` variable selon le régime de vol.
+- [ ] **Test de causalité de Granger** : filtrer les features sans signal prédictif.
 
-### 7.7 Backtest réaliste
+### 5.8 Backtest réaliste
 
-- [ ] **Coûts de transaction** : intégrer spread bid-ask + slippage dans le calcul
-  du P&L de backtest (paramétrable : BPS par trade, impact de marché linéaire).
-- [ ] **Position sizing** : implémenter Kelly fractionnel et vol-targeting comme
-  modules de `fynance/algorithms/` ; tester leur impact sur le Sharpe net.
-- [ ] **Métriques de robustesse** : taux de calmar, Omega ratio, tail ratio,
-  % de mois positifs — compléter `fynance/features/metrics.py`.
+- [ ] **Coûts de transaction** : spread bid-ask + slippage dans le P&L (BPS/trade, impact linéaire).
+- [ ] **Position sizing** : Kelly fractionnel + vol-targeting dans `fynance/algorithms/`.
+- [ ] **Métriques de robustesse** : tail ratio, % de mois positifs, etc. — compléter `fynance/features/`.
 
-## 6. Optimisations et nettoyage
+## 6. Optimisations & nettoyage
 
-### 6.1 Supprimer code obsolète dans models/ et backtest/
-
-- [x] Supprimer `fynance/models/basis.py` — `SignalModel` (stub, `self.y_pred`
-  jamais assigné) et `MagnitudeModel` (juste `pass`). ✅ PR #58.
-- [x] Supprimer `class __BacktestNeuralNet` dans `dynamic_plot_backtest.py`
-  (marqué "OLD VERSION => DEPRECIATED"). ✅ PR #58.
-- [x] Décider du sort de `class _BacktestNeuralNet` (stub TODO) — supprimé. ✅ PR #58.
-
-### 6.2 Optimisations allocation.py
+### 6.1 Optimisations allocation.py
 
 - [ ] `HRP()` : remplacer le loop Python de réordonnancement par du fancy indexing
-  NumPy (`w[np.array(sortIx)] = w_sorted`)
-- [x] `rolling_allocation()` : réécrit pandas-free en numpy (le double `.bfill()` est désormais un seul helper `_bfill`). ✅ PR #61.
-- [ ] Évaluer cache de la matrice de covariance entre steps consécutifs dans
-  `rolling_allocation()` (O(N²) par step, 100 steps × 250 assets = coûteux)
+  NumPy (`w[np.array(sortIx)] = w_sorted`).
+- [ ] Évaluer un cache de la matrice de covariance entre steps consécutifs dans
+  `rolling_allocation()` (O(N²) par step, coûteux à grande échelle).
 
-### 6.3 Optimisations rolling.py / _base.py
+### 6.2 Migrer les TODO inline
 
-- [x] `rolling.py _training()` : `print` de debug supprimés. ✅ PR #58.
-- [x] `_base.py _set_data()` : entrée pandas remplacée par polars (`X.to_numpy()`).
-  ✅ PR #61. (Reste optionnel : passer `dtype=np.float64` à `to_numpy`.)
-
-### 6.4 Migrer les TODO inline
-
-- [ ] Passer en revue les ~15 commentaires `# TODO` / `# FIXME` dans le code
-  (metrics.py, _base.py, allocation.py, _wrappers.py, backtest/) et fermer
-  ou migrer vers TODO.md ceux qui restent pertinents
-
-
-## 8. Qualité & dette technique (audit 2026-06-14)
-
-Items issus de l'audit complet du dépôt **non couverts ailleurs** dans cette
-roadmap. Le reste de l'audit a déjà été traité (PRs #58–#62) ou figure dans les
-sections 3, 5 et 6 ci-dessus.
-
-### 8.1 `estimator/estimator.py` — décider du sort
-- [x] `estimation()` est annoncée « NOT YET WORKING ! » / « NEED TO FIND AN
-  OPTIMIZER » mais reste exposée. → lève désormais `NotImplementedError` +
-  docstring « experimental », pointe vers `get_parameters`. ✅ PR #63.
-
-### 8.2 Typage : résorber les 104 erreurs mypy puis ajouter le gate CI
-- [x] `mypy fynance/` = **0 erreur** (était 103). ✅ PR #71. Détail : 104 erreurs (bruit numpy-2 `Returning Any`, hiérarchies
-  torch `predict`/`train_on` incompatibles, `print_stats.py` variable `bool`
-  réassignée en `ndarray`). → vrais bugs corrigés ; bruit numpy via
-  `warn_return_any=false` ; reste en `# type: ignore` ciblés. ✅ PR #71
-- [x] Job `typecheck` (mypy) ajouté à `ci.yml`. ✅ PR #71
-
-### 8.3 Couverture du cœur causal
-- [x] `models/rolling.py` — `_training` (loss update) + `get_stats` couverts. ✅ PR #67.
-- [x] `algorithms/rolling.py` — supprimé (code mort `_RollingMechanism`). ✅ PR #66.
-- [x] `models/econometric_models.py` — `MA`/`ARMA`/`ARMAX_GARCH` testés. ✅ PR #67.
-- [x] `algorithms/browsers.py` (0 %) — code mort, **supprimé** (+ `browsers_cy`,
-  + `algorithms/rolling.py`/`_RollingMechanism` orphelin). ✅ PR #66.
-
-### 8.4 Tests de propriété (transformer des conventions en garde-fous)
-- [x] **Parité py ↔ cy** (vs référence numpy indépendante). ✅ PR #65. Suite paramétrée
-  `assert np.allclose(py_impl(x), cy_impl(x))` pour chaque paire
-  `metrics` / `momentums` / `roll_functions` (aurait attrapé le faux-FIXME
-  `momentums_cy.pyx:26`).
-- [x] **Non-lookahead générique** ✅ PR #65 : perturber `X[t+1:]` et vérifier que `f(X)[t]`
-  est inchangé, pour chaque feature rolling.
-
-### 8.5 Compléter les inventaires de doc/dev
-- [x] Ajouter `features/money_management.py`, `_exceptions.py` et le sous-package
-  `models/loss/` aux inventaires de `01-overview.md` / `04-subpackages.md`. ✅ PR #64.
+- [ ] Revue des `# TODO` / `# FIXME` restants dans le code (metrics submodules,
+  `_base.py`, `allocation.py`, `_wrappers.py`, `backtest/`) — fermer ou tracer.


### PR DESCRIPTION
Housekeeping pass before cutting the release (requested alongside `/release`).

- **07-roadmap**: removed every completed item (the whole §5 refactor + §8 quality-debt epics + done cleanup items from PRs #58-71), renumbered survivors, fixed the stale "local/gitignored" header (the pack is tracked now) and the "polars rejected" note (polars was adopted). Leaves 51 open R&D/feature items.
- **06-status**: refreshed to current reality — metrics split, pandas→polars/numpy, mypy clean + 4 CI gates, dead stubs gone, ~300 tests.
- **04-subpackages / 02-architecture**: sharp-edges + dual-impl sections updated; removed-stub mentions dropped; `backtest_neural_net` added.
- **01 / 05**: test count ~300; CI section now lists the four enforced gates (test / ruff+interrogate / docs -W / mypy) + property tests.

README reviewed — already accurate, no change. Docs-only; `sphinx-build -W` still green.