### PR TITLE
perf: HRP fancy-indexing (roadmap 6.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `HRP()` scatters cluster-ordered weights via NumPy fancy-indexing instead of a Python loop
+
 ### Fixed
 
 ### Deprecated

--- a/PLAN-6.1-allocation-optims.md
+++ b/PLAN-6.1-allocation-optims.md
@@ -1,0 +1,26 @@
+# Plan — §6.1 Optimisations allocation.py
+
+> Plan jetable laissé à la racine (à archiver après). Tâche roadmap §6.1.
+
+## Objectif
+Deux items :
+1. `HRP()` : remplacer la boucle Python de réordonnancement par du fancy-indexing NumPy.
+2. Évaluer un cache de la matrice de covariance entre steps de `rolling_allocation()`.
+
+## Décisions
+- **HRP fancy-indexing** : la boucle
+  ```python
+  w = np.empty(N)
+  for i, col_idx in enumerate(sortIx):
+      w[col_idx] = w_sorted[i]
+  ```
+  devient `w = np.empty(N); w[np.asarray(sortIx)] = w_sorted`. Équivalent exact
+  (scatter), couvert par les tests HRP existants.
+- **Cache covariance** : *évalué, non retenu*. Dans `rolling_allocation`, les
+  fenêtres avancent de `s` (par défaut 63) → quasi aucun recouvrement utile ; la
+  covariance dépend de toute la fenêtre `[t-n, t]` et changerait à chaque step.
+  Un update incrémental O(1) (rank-1) serait complexe et fragile pour un gain
+  marginal sur des tailles réalistes. Reporté (noté dans la roadmap).
+
+## Vérification
+- `pytest fynance/tests/algorithms/` + suite complète + ruff.

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -150,14 +150,7 @@ tests de propriété (parité + non-lookahead) ; à étendre aux nouvelles featu
 
 ## 6. Optimisations & nettoyage
 
-### 6.1 Optimisations allocation.py
-
-- [ ] `HRP()` : remplacer le loop Python de réordonnancement par du fancy indexing
-  NumPy (`w[np.array(sortIx)] = w_sorted`).
-- [ ] Évaluer un cache de la matrice de covariance entre steps consécutifs dans
-  `rolling_allocation()` (O(N²) par step, coûteux à grande échelle).
-
-### 6.2 Migrer les TODO inline
+### 6.1 Migrer les TODO inline
 
 - [ ] Revue des `# TODO` / `# FIXME` restants dans le code (metrics submodules,
   `_base.py`, `allocation.py`, `_wrappers.py`, `backtest/`) — fermer ou tracer.

--- a/fynance/algorithms/allocation.py
+++ b/fynance/algorithms/allocation.py
@@ -328,9 +328,9 @@ def HRP(
     sortIx = _get_quasi_diag(link)
     w_sorted = _get_rec_bisec(mat_cov, sortIx)
 
+    # Scatter the cluster-ordered weights back to original asset order.
     w = np.empty(N)
-    for i, col_idx in enumerate(sortIx):
-        w[col_idx] = w_sorted[i]
+    w[np.asarray(sortIx)] = w_sorted
 
     return _normalize(w.reshape([N, 1]), up_bound=up_bound, low_bound=low_bound)
 


### PR DESCRIPTION
Roadmap §6.1. `HRP()` scatters the cluster-ordered weights with NumPy fancy-indexing (`w[np.asarray(sortIx)] = w_sorted`) instead of a Python loop — exact equivalent, covered by existing HRP tests. The covariance-cache idea for `rolling_allocation` was evaluated and deferred (rationale in the root `PLAN-6.1`). ruff/mypy/pytest (294) green.