### PR TITLE
test: train RollMLP with SharpeLoss end-to-end (roadmap §2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Integration test training `RollMultiLayerPerceptron` with the differentiable `SharpeLoss` (instead of MSE) — demonstrates the custom financial losses end-to-end
+
 ### Changed
 
 - `HRP()` scatters cluster-ordered weights via NumPy fancy-indexing instead of a Python loop

--- a/PLAN-2-rollmlp-sharpe-loss.md
+++ b/PLAN-2-rollmlp-sharpe-loss.md
@@ -1,0 +1,23 @@
+# Plan — §2 RollMLP entraîné avec SharpeLoss
+
+> Plan jetable à la racine (à archiver). Tâche roadmap §2.
+
+## Objectif
+Démontrer (test d'intégration) qu'un `RollMultiLayerPerceptron` s'entraîne avec
+`SharpeLoss` (loss financière différentiable) à la place de MSE.
+
+## Mécanisme
+- `set_optimizer(SharpeLoss, torch.optim.Adam, lr=...)` → `set_optimizer` fait
+  `criterion = SharpeLoss()`.
+- Le loop appelle `criterion(outputs, y)` → `SharpeLoss.forward(y_pred=outputs,
+  y_true=y)` (y_true ignoré ; le Sharpe ne dépend que des returns prédits).
+- Renvoie le Sharpe négatif (scalaire) → `.backward()` met à jour les poids.
+
+## Tests (TestRollMLPWithSharpeLoss)
+1. un pas de `_training` tourne, `loss_train[i]` fini.
+2. après quelques epochs, au moins un tenseur de poids a bougé (les gradients
+   SharpeLoss pilotent bien l'optimiseur).
+3. la prédiction garde la bonne forme.
+
+## Vérif
+- 3 tests verts ; suite complète + ruff + mypy.

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -34,14 +34,6 @@ Compléter `fynance/models/transformer.py`.
 - [ ] Tester multi-head attention avec données réelles
 - [ ] Tests : 6–10 tests
 
-## 2. Loss functions custom pour optimisation
-
-Architecture retenue (Option C) : formules numpy dans `fynance/features/` (métriques
-d'évaluation/backtest), réimplémentées en ops torch pures dans `fynance/models/loss/`
-(entraînement). Les deux paths sont indépendantes — pas de conversion numpy↔torch.
-
-- [ ] `RollMLP` entraîné avec `SharpeLoss` à la place de MSE (test ou notebook)
-
 ## 3. Documentation & notebooks
 
 ### 3.1 URL de la documentation

--- a/fynance/tests/models/test_neural_network.py
+++ b/fynance/tests/models/test_neural_network.py
@@ -8,6 +8,7 @@ import torch.nn as nn
 from fynance.models._base import _type_convert
 from fynance.models.attention import MultiHeadAttention, ScaledDotProductAttention
 from fynance.models.gru import GatedRecurrentUnit, GRUCell
+from fynance.models.loss import SharpeLoss
 from fynance.models.lstm import LongShortTermMemory, LSTMCell
 from fynance.models.mlp import MultiLayerPerceptron
 from fynance.models.rolling import RollMultiLayerPerceptron
@@ -477,3 +478,43 @@ class TestRollMLP:
         next(it)
         model._training()
         assert np.isfinite(model.loss_train[model.i])
+
+
+class TestRollMLPWithSharpeLoss:
+    """ Integration: train a RollMLP with the differentiable SharpeLoss. """
+
+    def _make(self):
+        model = RollMultiLayerPerceptron(X_t, y_t, layers=[16])
+        # SharpeLoss is passed as the criterion class; set_optimizer does
+        # criterion() and the training loop calls criterion(outputs, y).
+        model.set_optimizer(SharpeLoss, torch.optim.Adam, lr=1e-2)
+        model.set_roll_period(
+            train_period=40, test_period=10, roll_period=10, epochs=1
+        )
+        return model
+
+    def test_training_step_runs_and_is_finite(self):
+        model = self._make()
+        it = iter(model)
+        next(it)
+        model._training()
+        assert np.isfinite(model.loss_train[model.i])
+
+    def test_optimizer_updates_weights(self):
+        model = self._make()
+        before = [p.detach().clone() for p in model.parameters()]
+        it = iter(model)
+        next(it)
+        for _ in range(3):  # a few epochs on the first train window
+            model._training()
+        after = list(model.parameters())
+        # at least one parameter tensor must have moved under SharpeLoss grads
+        assert any(not torch.allclose(b, a) for b, a in zip(before, after))
+
+    def test_prediction_shape_after_training(self):
+        model = self._make()
+        it = iter(model)
+        eval_set, _ = next(it)
+        model._training()
+        pred = model.sub_predict(model.X[eval_set])
+        assert pred.shape[1] == N_OUT


### PR DESCRIPTION
Roadmap §2. Integration test showing a `RollMultiLayerPerceptron` trains with the differentiable **`SharpeLoss`** instead of MSE: `set_optimizer(SharpeLoss, Adam, …)` → the loop calls `criterion(outputs, y)` (negative Sharpe) → `backward()`. Asserts the step runs (finite loss), weights move under SharpeLoss gradients, and prediction shape holds. Root `PLAN-2` included. ruff/mypy/pytest (297) green.