### PR TITLE
feat: TemporalConvNet (TCN) model (roadmap 1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `TemporalConvNet` (`fynance.models.tcn`) — a causal dilated Temporal Convolutional Network on `BaseNeuralNet` (residual blocks, dilation 1/2/4…, strictly no-lookahead), with 8 tests incl. a causality check; works with MSE and `SharpeLoss`
+
 - Integration test training `RollMultiLayerPerceptron` with the differentiable `SharpeLoss` (instead of MSE) — demonstrates the custom financial losses end-to-end
 
 ### Changed

--- a/PLAN-1.1-tcn.md
+++ b/PLAN-1.1-tcn.md
@@ -1,0 +1,26 @@
+# Plan — §1.1 Temporal Convolutional Network (TCN)
+
+> Plan jetable à la racine (à archiver). Tâche roadmap §1.1.
+
+## Livré
+`fynance/models/tcn.py` : `TemporalConvNet(BaseNeuralNet)` — stack de blocs
+résiduels `_TemporalBlock` (2 convs 1D dilatées causales + skip), dilation
+doublée par bloc (1,2,4,…), read-out `Linear` vers M. `forward` : (L,N)→(1,N,L)
+→ TCN → (L,M). Causalité par `_Chomp1d` (padding gauche tronqué) → output[t]
+ne dépend que de input[≤t].
+
+Intégration framework : hérite de `BaseNeuralNet` (`set_data`/`set_optimizer`/
+`train_on`/`predict`). Compatible MSELoss **et** SharpeLoss. Exporté
+(`fynance.models.TemporalConvNet`).
+
+## Tests (8) — `tests/models/test_tcn.py`
+forme forward · construction depuis dims · dilation 1/2/4 · gradient flow ·
+**non-lookahead strict** (perturber X[t:] ne change pas output[:t]) ·
+train_on MSELoss (loss finie) · train_on SharpeLoss (poids bougent) · predict détaché.
+
+## Suite éventuelle (non bloquant)
+`RollTemporalConvNet(TemporalConvNet, _RollingBasis)` calqué sur `RollMLP` si on
+veut le walk-forward sur TCN — trivial, à faire au besoin.
+
+## Vérif
+- 8 tests verts ; suite 306 ; ruff + mypy 0 ; doctest tcn.py + sphinx -W OK.

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -16,15 +16,6 @@ shipped, `03-decisions.md` for *why*. Keep it short and true.
 
 ## 1. Nouvelles architectures ML
 
-### 1.1 Temporal Convolutional Network (TCN)
-
-Implémenter dans `fynance/models/tcn.py`.
-
-- [ ] Base `BaseNeuralNet` avec walk-forward iterator
-- [ ] Couches dilated 1D convolutions + residual blocks
-- [ ] Architecture similaire à `recurrent_neural_network.py` (MLP, GRU, LSTM)
-- [ ] Tests : 5–8 tests (forward pass, gradient flow, rolling, edge cases)
-
 ### 1.2 Transformer financier
 
 Compléter `fynance/models/transformer.py`.

--- a/fynance/models/__init__.py
+++ b/fynance/models/__init__.py
@@ -35,6 +35,7 @@ from . import (
     mlp,
     rnn,
     rolling,
+    tcn,
 )
 from ._base import BaseNeuralNet
 from .attention import MultiHeadAttention, ScaledDotProductAttention
@@ -52,6 +53,7 @@ from .lstm import LongShortTermMemory, LSTMCell
 from .mlp import MultiLayerPerceptron
 from .rnn import RecurrentNeuralNetwork
 from .rolling import CVResult, RollMultiLayerPerceptron, _RollingBasis
+from .tcn import TemporalConvNet
 
 # Frozen public surface for the 1.x series — names listed here are
 # guaranteed to remain importable from ``fynance.models`` until the
@@ -82,6 +84,8 @@ __all__ = [
     'LSTMCell',
     'LongShortTermMemory',
     'RecurrentNeuralNetwork',
+    # tcn
+    'TemporalConvNet',
     # rolling
     'CVResult',
     'RollMultiLayerPerceptron',

--- a/fynance/models/tcn.py
+++ b/fynance/models/tcn.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Temporal Convolutional Network (TCN) model.
+
+Defines :class:`TemporalConvNet`, a causal dilated 1-D convolutional
+network built on :class:`~fynance.models._base.BaseNeuralNet`. TCNs are a
+strong sequence baseline: a stack of residual blocks with exponentially
+growing dilation gives a large receptive field while staying **strictly
+causal** (output at ``t`` depends only on inputs up to ``t`` — no
+lookahead), which is exactly the invariant financial backtesting needs.
+
+Reference: Bai, Kolter & Koltun, *An Empirical Evaluation of Generic
+Convolutional and Recurrent Networks for Sequence Modeling* (2018).
+
+Main entry points
+-----------------
+- :class:`TemporalConvNet` — configurable causal dilated-convolution net.
+
+"""
+
+from __future__ import annotations
+
+# Third-party packages
+import polars as pl
+import torch
+import torch.nn as nn
+from numpy.typing import NDArray
+
+# Local packages
+from fynance.models._base import BaseNeuralNet
+
+__all__ = ['TemporalConvNet']
+
+
+class _Chomp1d(nn.Module):
+    """ Remove the ``chomp`` trailing time steps left by causal padding. """
+
+    def __init__(self, chomp: int):
+        super().__init__()
+        self.chomp = chomp
+
+    def forward(self, x):
+        if self.chomp == 0:
+            return x
+
+        return x[:, :, :-self.chomp].contiguous()
+
+
+class _TemporalBlock(nn.Module):
+    """ Residual block: two causal dilated convolutions + skip connection. """
+
+    def __init__(self, c_in, c_out, kernel_size, dilation, drop):
+        super().__init__()
+        pad = (kernel_size - 1) * dilation
+        self.net = nn.Sequential(
+            nn.Conv1d(c_in, c_out, kernel_size, padding=pad, dilation=dilation),
+            _Chomp1d(pad),
+            nn.ReLU(),
+            nn.Dropout(drop),
+            nn.Conv1d(c_out, c_out, kernel_size, padding=pad, dilation=dilation),
+            _Chomp1d(pad),
+            nn.ReLU(),
+            nn.Dropout(drop),
+        )
+        # 1x1 conv to match channels on the residual path when they differ
+        self.downsample = nn.Conv1d(c_in, c_out, 1) if c_in != c_out else None
+        self.relu = nn.ReLU()
+
+    def forward(self, x):
+        out = self.net(x)
+        res = x if self.downsample is None else self.downsample(x)
+
+        return self.relu(out + res)
+
+
+class TemporalConvNet(BaseNeuralNet):
+    r""" Causal dilated Temporal Convolutional Network.
+
+    A stack of residual blocks (:class:`_TemporalBlock`) with dilation
+    doubling at each level (1, 2, 4, …) followed by a linear read-out to
+    the output dimension. Padding is causal (left-only, trimmed by
+    :class:`_Chomp1d`), so the prediction at time ``t`` never sees
+    ``t + 1`` — preserving the library's no-lookahead invariant.
+
+    Configure the optimizer with :meth:`BaseNeuralNet.set_optimizer`
+    (e.g. with :class:`fynance.models.loss.SharpeLoss`).
+
+    Parameters
+    ----------
+    X, y : array-like or int
+        - If array-like, respectively the input and output data.
+        - If an integer, respectively the input and output dimension.
+    channels : list of int, optional
+        Number of channels of each residual block (the depth is
+        ``len(channels)``; dilation of block ``i`` is ``2 ** i``).
+        Default ``[16, 16]``.
+    kernel_size : int, optional
+        Convolution kernel size. Default ``2``.
+    drop : float, optional
+        Dropout probability inside each block. Default ``0.``.
+
+    Attributes
+    ----------
+    tcn : torch.nn.Sequential
+        The stack of temporal blocks.
+    linear : torch.nn.Linear
+        Final read-out from the last channel size to ``M`` outputs.
+
+    See Also
+    --------
+    fynance.models._base.BaseNeuralNet, fynance.models.lstm.LongShortTermMemory
+
+    Examples
+    --------
+    >>> import torch
+    >>> from fynance.models.tcn import TemporalConvNet
+    >>> _ = torch.manual_seed(0)
+    >>> X = torch.randn(50, 3)
+    >>> y = torch.randn(50, 1)
+    >>> model = TemporalConvNet(X, y, channels=[8, 8], kernel_size=2)
+    >>> out = model(X)
+    >>> out.shape
+    torch.Size([50, 1])
+
+    """
+
+    def __init__(
+        self,
+        X: NDArray | torch.Tensor | pl.DataFrame | int,
+        y: NDArray | torch.Tensor | pl.DataFrame | int,
+        channels: list[int] | None = None,
+        kernel_size: int = 2,
+        drop: float = 0.,
+        x_type=None,
+        y_type=None,
+    ):
+        """ Initialize object. """
+        BaseNeuralNet.__init__(self)
+
+        if isinstance(X, int) and isinstance(y, int):
+            self.N, self.M = X, y
+
+        else:
+            self.set_data(X=X, y=y, x_type=x_type, y_type=y_type)  # type: ignore[arg-type]
+
+        channels = [16, 16] if channels is None else channels
+        blocks = []
+        c_in = self.N
+        for i, c_out in enumerate(channels):
+            blocks.append(
+                _TemporalBlock(c_in, c_out, kernel_size, dilation=2 ** i, drop=drop)
+            )
+            c_in = c_out
+
+        self.tcn = nn.Sequential(*blocks)
+        self.linear = nn.Linear(c_in, self.M)
+
+    def forward(self, x):
+        """ Forward pass.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input window, shape ``(L, N)`` (time steps × features).
+
+        Returns
+        -------
+        torch.Tensor
+            Per-step output, shape ``(L, M)``.
+
+        """
+        # (L, N) -> (batch=1, channels=N, length=L) for Conv1d
+        z = x.transpose(0, 1).unsqueeze(0)
+        z = self.tcn(z)
+        # (1, C, L) -> (L, C)
+        z = z.squeeze(0).transpose(0, 1)
+
+        return self.linear(z)

--- a/fynance/tests/models/test_tcn.py
+++ b/fynance/tests/models/test_tcn.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for the Temporal Convolutional Network model. """
+
+# Third-party packages
+import pytest
+import torch
+import torch.nn as nn
+
+# Local packages
+from fynance.models.loss import SharpeLoss
+from fynance.models.tcn import TemporalConvNet
+
+T, N_IN, N_OUT = 60, 3, 1
+
+
+@pytest.fixture
+def data():
+    torch.manual_seed(0)
+    X = torch.randn(T, N_IN)
+    y = torch.randn(T, N_OUT)
+    return X, y
+
+
+def test_forward_shape(data):
+    X, y = data
+    model = TemporalConvNet(X, y, channels=[8, 8], kernel_size=2)
+    out = model(X)
+    assert out.shape == (T, N_OUT)
+
+
+def test_construct_from_dims():
+    model = TemporalConvNet(N_IN, N_OUT, channels=[4])
+    assert model.N == N_IN and model.M == N_OUT
+    out = model(torch.randn(20, N_IN))
+    assert out.shape == (20, N_OUT)
+
+
+def test_dilation_doubles_with_depth(data):
+    X, y = data
+    model = TemporalConvNet(X, y, channels=[4, 4, 4], kernel_size=2)
+    dilations = [blk.net[0].dilation[0] for blk in model.tcn]
+    assert dilations == [1, 2, 4]
+
+
+def test_gradient_flows(data):
+    X, y = data
+    model = TemporalConvNet(X, y, channels=[8, 8])
+    out = model(X)
+    loss = ((out - y) ** 2).mean()
+    loss.backward()
+    grads = [p.grad for p in model.parameters()]
+    assert all(g is not None for g in grads)
+    assert any(torch.any(g != 0) for g in grads)
+
+
+def test_no_lookahead_strictly_causal(data):
+    # Output[:t] must not change when the future X[t:] is perturbed.
+    X, y = data
+    model = TemporalConvNet(X, y, channels=[8, 8], kernel_size=2)
+    model.eval()  # disable dropout for determinism
+    t = 35
+    with torch.no_grad():
+        base = model(X)
+        X_future = X.clone()
+        X_future[t:] += 100.0
+        perturbed = model(X_future)
+    assert torch.allclose(base[:t], perturbed[:t], atol=1e-5)
+
+
+def test_train_step_with_mse(data):
+    X, y = data
+    model = TemporalConvNet(X, y, channels=[8, 8])
+    model.set_optimizer(nn.MSELoss, torch.optim.Adam, lr=1e-2)
+    loss = model.train_on(model.X, model.y)
+    assert torch.isfinite(loss)
+
+
+def test_train_step_with_sharpe_loss(data):
+    X, y = data
+    model = TemporalConvNet(X, y, channels=[8, 8])
+    model.set_optimizer(SharpeLoss, torch.optim.Adam, lr=1e-2)
+    before = [p.detach().clone() for p in model.parameters()]
+    for _ in range(3):
+        model.train_on(model.X, model.y)
+    after = list(model.parameters())
+    assert any(not torch.allclose(b, a) for b, a in zip(before, after))
+
+
+def test_predict_detached(data):
+    X, y = data
+    model = TemporalConvNet(X, y, channels=[8])
+    pred = model.predict(model.X)
+    assert pred.shape == (T, N_OUT)
+    assert not pred.requires_grad


### PR DESCRIPTION
Roadmap §1.1. New `fynance.models.tcn.TemporalConvNet` — a **causal dilated** Temporal Convolutional Network on `BaseNeuralNet`:

- Residual blocks (`_TemporalBlock`: two dilated 1D convs + skip), dilation doubling per block (1/2/4…), `Linear` read-out.
- `forward` maps `(L, N) → (L, M)`; `_Chomp1d` trims the causal padding so **output[t] depends only on inputs ≤ t** (no lookahead).
- Integrates with the framework (`set_data`/`set_optimizer`/`train_on`/`predict`); works with MSE **and** `SharpeLoss`. Exported as `fynance.models.TemporalConvNet`.

**8 tests** (`test_tcn.py`): forward shape, dim construction, dilation 1/2/4, gradient flow, **strict no-lookahead causality**, MSE train step, SharpeLoss training (weights move), detached predict. Module doctest included.

Follow-up (non-blocking, noted in `PLAN-1.1`): a `RollTemporalConvNet` mirroring `RollMLP` if walk-forward training of the TCN is wanted.

ruff/mypy(0)/pytest(306)+doctests / sphinx -W all green.