### PR TITLE
feat: causal Transformer model (roadmap 1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Transformer` (`fynance.models.transformer`) — a causal Transformer encoder on `BaseNeuralNet` (sinusoidal `PositionalEncoding`, reuses `MultiHeadAttention`, lower-triangular causal mask = no lookahead), with 10 tests incl. a causality check; works with MSE and `SharpeLoss`
+
 - `TemporalConvNet` (`fynance.models.tcn`) — a causal dilated Temporal Convolutional Network on `BaseNeuralNet` (residual blocks, dilation 1/2/4…, strictly no-lookahead), with 8 tests incl. a causality check; works with MSE and `SharpeLoss`
 
 - Integration test training `RollMultiLayerPerceptron` with the differentiable `SharpeLoss` (instead of MSE) — demonstrates the custom financial losses end-to-end

--- a/PLAN-1.2-transformer.md
+++ b/PLAN-1.2-transformer.md
@@ -1,0 +1,28 @@
+# Plan — §1.2 Transformer financier
+
+> Plan jetable à la racine (à archiver). Tâche roadmap §1.2.
+
+## Livré
+`fynance/models/transformer.py` :
+- `PositionalEncoding` : encodage sinusoïdal **absolu** (Vaswani 2017).
+- `_TransformerBlock` : self-attention causale (réutilise `MultiHeadAttention`
+  de `attention.py`, qui fait déjà résiduel+LayerNorm) + FFN position-wise.
+- `Transformer(BaseNeuralNet)` : proj. entrée N→d_model, +PE, `num_layers` blocs,
+  read-out d_model→M. `forward` (L,N)→(L,M).
+- **Masking causal** : `torch.tril` (L,L) passé à la MHA → position t n'attend que ≤t.
+
+Intègre set_optimizer/train_on/predict ; compatible MSE et SharpeLoss. Exporté
+(`fynance.models.Transformer`, `PositionalEncoding`).
+
+## Tests (10) — `tests/models/test_transformer.py`
+forme · dims · num_layers · d_model%heads≠0 lève · PE ajoute du signal ·
+**non-lookahead strict** (masking causal vérifié) · gradient flow ·
+train MSE · train SharpeLoss (poids bougent) · predict détaché.
+
+## Choix / suite
+- Positional encoding **absolu** retenu (standard, bien défini). Le **relatif**
+  (roadmap « relatif vs absolu ») est laissé en option future — non bloquant.
+- `RollTransformer` (walk-forward) calquable sur RollMLP au besoin.
+
+## Vérif
+- 10 tests verts ; suite 317 ; ruff + mypy 0 ; doctest + sphinx -W OK.

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -14,16 +14,6 @@ shipped, `03-decisions.md` for *why*. Keep it short and true.
 
 ---
 
-## 1. Nouvelles architectures ML
-
-### 1.2 Transformer financier
-
-Compléter `fynance/models/transformer.py`.
-
-- [ ] Positional encoding pour séries temporelles (relatif vs absolu)
-- [ ] Masking causal (pas de lookahead)
-- [ ] Tester multi-head attention avec données réelles
-- [ ] Tests : 6–10 tests
 
 ## 3. Documentation & notebooks
 

--- a/fynance/models/__init__.py
+++ b/fynance/models/__init__.py
@@ -36,6 +36,7 @@ from . import (
     rnn,
     rolling,
     tcn,
+    transformer,
 )
 from ._base import BaseNeuralNet
 from .attention import MultiHeadAttention, ScaledDotProductAttention
@@ -54,6 +55,7 @@ from .mlp import MultiLayerPerceptron
 from .rnn import RecurrentNeuralNetwork
 from .rolling import CVResult, RollMultiLayerPerceptron, _RollingBasis
 from .tcn import TemporalConvNet
+from .transformer import PositionalEncoding, Transformer
 
 # Frozen public surface for the 1.x series — names listed here are
 # guaranteed to remain importable from ``fynance.models`` until the
@@ -86,6 +88,9 @@ __all__ = [
     'RecurrentNeuralNetwork',
     # tcn
     'TemporalConvNet',
+    # transformer
+    'PositionalEncoding',
+    'Transformer',
     # rolling
     'CVResult',
     'RollMultiLayerPerceptron',

--- a/fynance/models/transformer.py
+++ b/fynance/models/transformer.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Transformer model for financial sequences.
+
+Defines :class:`Transformer`, a causal Transformer encoder on
+:class:`~fynance.models._base.BaseNeuralNet`. It reuses the attention
+building blocks from :mod:`fynance.models.attention` and applies a
+**causal mask** so position ``t`` attends only to ``≤ t`` — preserving
+the library's no-lookahead invariant for time-series prediction.
+
+Main entry points
+-----------------
+- :class:`PositionalEncoding` — sinusoidal absolute positional encoding.
+- :class:`Transformer` — stacked causal Transformer encoder blocks.
+
+References
+----------
+.. [1] Vaswani, A. et al. (2017). Attention Is All You Need.
+
+"""
+
+from __future__ import annotations
+
+# Built-in packages
+import math
+
+# Third-party packages
+import polars as pl
+import torch
+import torch.nn as nn
+from numpy.typing import NDArray
+
+# Local packages
+from fynance.models._base import BaseNeuralNet
+from fynance.models.attention import MultiHeadAttention
+
+__all__ = ['PositionalEncoding', 'Transformer']
+
+
+class PositionalEncoding(nn.Module):
+    r""" Sinusoidal absolute positional encoding (Vaswani et al., 2017).
+
+    Adds a fixed position-dependent signal to the input embeddings so the
+    attention layers can use the order of the sequence.
+
+    Parameters
+    ----------
+    d_model : int
+        Embedding dimension.
+    max_len : int, optional
+        Maximum supported sequence length. Default ``5000``.
+
+    """
+
+    def __init__(self, d_model: int, max_len: int = 5000):
+        super().__init__()
+        pe = torch.zeros(max_len, d_model)
+        position = torch.arange(max_len).unsqueeze(1).float()
+        div = torch.exp(
+            torch.arange(0, d_model, 2).float() * (-math.log(10000.0) / d_model)
+        )
+        pe[:, 0::2] = torch.sin(position * div)
+        pe[:, 1::2] = torch.cos(position * div[: pe[:, 1::2].size(1)])
+        self.register_buffer('pe', pe)
+
+    def forward(self, x):
+        """ Add positional encoding to ``x`` of shape ``(B, T, d_model)``. """
+        return x + self.pe[: x.size(1)]
+
+
+class _TransformerBlock(nn.Module):
+    """ Causal Transformer encoder block: self-attention + feed-forward. """
+
+    def __init__(self, d_model, num_heads, dim_ff, drop):
+        super().__init__()
+        # MultiHeadAttention already applies the residual + layer-norm.
+        self.attn = MultiHeadAttention(d_model, num_heads, dropout=drop)
+        self.ff = nn.Sequential(
+            nn.Linear(d_model, dim_ff),
+            nn.ReLU(),
+            nn.Dropout(drop),
+            nn.Linear(dim_ff, d_model),
+        )
+        self.norm = nn.LayerNorm(d_model)
+        self.drop = nn.Dropout(drop)
+
+    def forward(self, x, mask):
+        x, _ = self.attn(x, mask=mask)
+
+        return self.norm(x + self.drop(self.ff(x)))
+
+
+class Transformer(BaseNeuralNet):
+    r""" Causal Transformer encoder for sequential financial data.
+
+    Projects the ``N`` input features to ``d_model``, adds sinusoidal
+    positional encoding, applies ``num_layers`` causal self-attention
+    blocks, and reads out to ``M`` outputs. A lower-triangular mask makes
+    every block **strictly causal** (no lookahead): the output at ``t``
+    depends only on inputs up to ``t``.
+
+    Configure the optimizer with :meth:`BaseNeuralNet.set_optimizer`
+    (e.g. with :class:`fynance.models.loss.SharpeLoss`).
+
+    Parameters
+    ----------
+    X, y : array-like or int
+        - If array-like, respectively the input and output data.
+        - If an integer, respectively the input and output dimension.
+    d_model : int, optional
+        Embedding / model dimension (divisible by ``num_heads``). Default 32.
+    num_heads : int, optional
+        Number of attention heads. Default 4.
+    num_layers : int, optional
+        Number of stacked encoder blocks. Default 2.
+    dim_ff : int, optional
+        Hidden size of the position-wise feed-forward sublayer. Default 64.
+    drop : float, optional
+        Dropout probability. Default 0.
+
+    See Also
+    --------
+    fynance.models.attention.MultiHeadAttention, fynance.models.tcn.TemporalConvNet
+
+    Examples
+    --------
+    >>> import torch
+    >>> from fynance.models.transformer import Transformer
+    >>> _ = torch.manual_seed(0)
+    >>> X = torch.randn(40, 3)
+    >>> y = torch.randn(40, 1)
+    >>> model = Transformer(X, y, d_model=16, num_heads=2, num_layers=2)
+    >>> model(X).shape
+    torch.Size([40, 1])
+
+    """
+
+    def __init__(
+        self,
+        X: NDArray | torch.Tensor | pl.DataFrame | int,
+        y: NDArray | torch.Tensor | pl.DataFrame | int,
+        d_model: int = 32,
+        num_heads: int = 4,
+        num_layers: int = 2,
+        dim_ff: int = 64,
+        drop: float = 0.,
+        x_type=None,
+        y_type=None,
+    ):
+        """ Initialize object. """
+        BaseNeuralNet.__init__(self)
+
+        if isinstance(X, int) and isinstance(y, int):
+            self.N, self.M = X, y
+
+        else:
+            self.set_data(X=X, y=y, x_type=x_type, y_type=y_type)  # type: ignore[arg-type]
+
+        self.input_proj = nn.Linear(self.N, d_model)
+        self.pos_encoder = PositionalEncoding(d_model)
+        self.blocks = nn.ModuleList([
+            _TransformerBlock(d_model, num_heads, dim_ff, drop)
+            for _ in range(num_layers)
+        ])
+        self.output_proj = nn.Linear(d_model, self.M)
+
+    def forward(self, x):
+        """ Forward pass.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input window, shape ``(L, N)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Per-step output, shape ``(L, M)``.
+
+        """
+        length = x.size(0)
+        z = self.input_proj(x).unsqueeze(0)  # (1, L, d_model)
+        z = self.pos_encoder(z)
+        # Lower-triangular causal mask: position t may attend to <= t only.
+        mask = torch.tril(torch.ones(length, length, device=x.device))
+        for block in self.blocks:
+            z = block(z, mask)
+
+        return self.output_proj(z.squeeze(0))  # (L, M)

--- a/fynance/tests/models/test_transformer.py
+++ b/fynance/tests/models/test_transformer.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for the causal Transformer model. """
+
+# Third-party packages
+import pytest
+import torch
+import torch.nn as nn
+
+# Local packages
+from fynance.models.loss import SharpeLoss
+from fynance.models.transformer import PositionalEncoding, Transformer
+
+T, N_IN, N_OUT = 40, 3, 1
+
+
+@pytest.fixture
+def data():
+    torch.manual_seed(0)
+    return torch.randn(T, N_IN), torch.randn(T, N_OUT)
+
+
+def _make(X, y, **kw):
+    kw.setdefault("d_model", 16)
+    kw.setdefault("num_heads", 2)
+    kw.setdefault("num_layers", 2)
+    return Transformer(X, y, **kw)
+
+
+def test_forward_shape(data):
+    X, y = data
+    assert _make(X, y)(X).shape == (T, N_OUT)
+
+
+def test_construct_from_dims():
+    model = _make(N_IN, N_OUT)
+    assert model.N == N_IN and model.M == N_OUT
+    assert model(torch.randn(15, N_IN)).shape == (15, N_OUT)
+
+
+def test_num_layers(data):
+    X, y = data
+    model = _make(X, y, num_layers=3)
+    assert len(model.blocks) == 3
+
+
+def test_d_model_not_divisible_raises(data):
+    X, y = data
+    with pytest.raises(ValueError, match="divisible"):
+        _make(X, y, d_model=15, num_heads=2)
+
+
+def test_positional_encoding_adds_signal():
+    pe = PositionalEncoding(8)
+    x = torch.zeros(1, 5, 8)
+    out = pe(x)
+    assert out.shape == (1, 5, 8)
+    assert torch.any(out != 0)  # encoding added to zeros
+
+
+def test_no_lookahead_strictly_causal(data):
+    # The causal mask must prevent any position from seeing the future.
+    X, y = data
+    model = _make(X, y)
+    model.eval()
+    t = 25
+    with torch.no_grad():
+        base = model(X)
+        X_future = X.clone()
+        X_future[t:] += 100.0
+        perturbed = model(X_future)
+    assert torch.allclose(base[:t], perturbed[:t], atol=1e-5)
+
+
+def test_gradient_flows(data):
+    X, y = data
+    model = _make(X, y)
+    loss = ((model(X) - y) ** 2).mean()
+    loss.backward()
+    assert all(p.grad is not None for p in model.parameters())
+
+
+def test_train_step_with_mse(data):
+    X, y = data
+    model = _make(X, y)
+    model.set_optimizer(nn.MSELoss, torch.optim.Adam, lr=1e-3)
+    assert torch.isfinite(model.train_on(model.X, model.y))
+
+
+def test_train_step_with_sharpe_loss(data):
+    X, y = data
+    model = _make(X, y)
+    model.set_optimizer(SharpeLoss, torch.optim.Adam, lr=1e-2)
+    before = [p.detach().clone() for p in model.parameters()]
+    for _ in range(3):
+        model.train_on(model.X, model.y)
+    after = list(model.parameters())
+    assert any(not torch.allclose(b, a) for b, a in zip(before, after))
+
+
+def test_predict_detached(data):
+    X, y = data
+    model = _make(X, y)
+    pred = model.predict(model.X)
+    assert pred.shape == (T, N_OUT) and not pred.requires_grad


### PR DESCRIPTION
Roadmap §1.2 (completes §1). New `fynance.models.transformer`:

- **`Transformer(BaseNeuralNet)`** — input projection N→d_model, sinusoidal **`PositionalEncoding`**, `num_layers` causal encoder blocks (reusing `MultiHeadAttention` + a position-wise FFN), read-out to M. `forward` maps `(L,N)→(L,M)`.
- **Causal mask** (lower-triangular) → position t attends only to ≤ t (**no lookahead**).
- Integrates with `set_optimizer`/`train_on`/`predict`; works with MSE **and** `SharpeLoss`. Exported (`Transformer`, `PositionalEncoding`).

**10 tests**: shape, dims, num_layers, `d_model % num_heads` guard, positional-encoding signal, **strict no-lookahead causality**, gradient flow, MSE train, SharpeLoss training (weights move), detached predict. Module doctest included.

Absolute positional encoding chosen (standard); relative left as a future option (`PLAN-1.2`).

ruff/mypy(0)/pytest(317)+doctests / sphinx -W green.