### PR TITLE
docs: confirm RTD as canonical host + fail_on_warning (roadmap 3.1)

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,4 +17,4 @@ python:
 
 sphinx:
   configuration: doc/source/conf.py
-  fail_on_warning: false
+  fail_on_warning: true

--- a/PLAN-3.1-docs-hosting.md
+++ b/PLAN-3.1-docs-hosting.md
@@ -1,0 +1,17 @@
+# Plan — §3.1 Décision hébergement doc
+
+> Plan jetable à la racine (à archiver). Tâche roadmap §3.1.
+
+## Évaluation
+État réel constaté : `.readthedocs.yaml` complet (build ext + `.[doc]` + sphinx),
+badge + liens README → `fynance.readthedocs.io`, **aucun** workflow GitHub Pages.
+→ **RTD est déjà l'hôte canonique** ; la note « GitHub Pages today » était périmée.
+
+## Décision (= roadmap §3.1)
+- **RTD retenu** (rien à migrer). ADR ajouté dans `03-decisions.md`.
+- `.readthedocs.yaml` : `fail_on_warning: false` → **true** (cohérent avec le gate
+  CI `sphinx-build -W`, déjà vert). Risque faible (mêmes deps `.[doc]`).
+- Note d'hébergement périmée retirée de `06-status.md`.
+
+## Vérif
+- `sphinx-build -W` local vert (RTD `fail_on_warning: true` passera).

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -71,6 +71,18 @@ Template:
 
 <!-- new entries below, newest first -->
 
+### 2026-06-14 — Read the Docs is the canonical docs host (roadmap §3.1)  [accepted]
+- **Choice**: keep **Read the Docs** as the single documentation host. `.readthedocs.yaml`
+  already builds the site (compiles the Cython ext, installs `.[doc]`, runs the
+  Sphinx config), the README badge + links point to `fynance.readthedocs.io`, and
+  there is **no** GitHub Pages deploy workflow. RTD now also builds with
+  `fail_on_warning: true`, matching the CI `sphinx-build -W` gate.
+- **Why**: RTD was already the de-facto host; the earlier "GitHub Pages today /
+  RTD migration open" note was stale. No migration needed — just confirm RTD and
+  align the warning policy.
+- **Rejected alternatives**: GitHub Pages (never actually wired up); a custom
+  domain (not needed).
+
 ### 2026-06-14 — Track doc/dev + CLAUDE.md publicly, mirroring dccd (PR #62)  [accepted]
 - **Choice**: stop gitignoring `doc/dev`. The descriptive pack `01–07` (including
   the roadmap), `README.md`, `plans/README.md` **and `CLAUDE.md`** are now tracked,

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -40,7 +40,6 @@ so an agent doesn't re-investigate settled ground or assume a known stub is a bu
   (the Cython-backed authoritative path).
 - **Notebooks** (`Notebooks/`) still carry Keras examples — to be rewritten in
   PyTorch (roadmap §3.2).
-- **Docs hosting**: GitHub Pages today; RTD migration is an open question (§3.1).
 - **`# type: ignore`** markers exist for genuinely-unmodellable cases (torch
   multiple-inheritance mixins, decorator-filled `w`, star-imported Cython names);
   `warn_return_any` is off (numpy/Cython return `Any` pervasively).

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -15,14 +15,6 @@ shipped, `03-decisions.md` for *why*. Keep it short and true.
 ---
 
 
-## 3. Documentation & notebooks
-
-### 3.1 URL de la documentation
-
-- [ ] Évaluer remplacement de GitHub Pages par RTD (URL `fynance.readthedocs.io`)
-  via trigger manuel de build RTD depuis le workflow GitHub Actions à chaque merge
-  sur `master` (API RTD webhook), ou custom domain sur GitHub Pages.
-
 ## 4. Performance & dépendances
 
 - [ ] Audit versions et alternatives modernes des dépendances restantes.


### PR DESCRIPTION
Roadmap §3.1 (evaluate GitHub Pages vs RTD).

**Finding**: there's nothing to migrate — `.readthedocs.yaml` already builds the docs (Cython ext + `.[doc]` + Sphinx), the README badge & links point to `fynance.readthedocs.io`, and **no GitHub Pages workflow exists**. RTD is already the de-facto host; the "GitHub Pages today" status note was stale.

**Decision**: keep **Read the Docs**; set `fail_on_warning: true` to match the CI `sphinx-build -W` gate (the build is warning-clean locally, so RTD will pass). ADR recorded in `03-decisions.md`; stale status note removed.

Closes the last concrete roadmap item (§3). Docs-only; `sphinx-build -W` green.