### PR TITLE
chore: drop unused xgboost dependency (roadmap §4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- `xgboost` dependency — it was declared in `pyproject.toml` but never imported anywhere in the package (lighter install; non-breaking)
+
 - Legacy notebooks: the Keras `Exemple_Rolling_NeuralNetwork.ipynb` and the stale dev notebooks `test_roll_NN_test.ipynb` / `Test_various_NN_models_with_simulated_data.ipynb`
 
 ## [1.4.0] - 2026-06-14

--- a/PLAN-4-deps-audit.md
+++ b/PLAN-4-deps-audit.md
@@ -1,0 +1,24 @@
+# Plan — §4 Audit des dépendances
+
+> Plan jetable à la racine (à archiver). Tâche roadmap §4.
+
+## Audit (usage réel dans fynance/, hors tests)
+| dep | fichiers | verdict |
+|-----|---------:|---------|
+| numpy | 33 | cœur — garder |
+| torch | 14 | backend ML — garder |
+| matplotlib | 9 | plotting backtest — garder |
+| polars | 5 | entrées (remplace pandas) — garder |
+| scipy | 4 | optim/clustering (alloc) — garder |
+| seaborn | 3 | palettes plotting — garder |
+| numba | 1 | `@njit` (filters) — garder |
+| **xgboost** | **0** | **inutilisé → retiré** |
+
+## Action
+- `xgboost>=2.0` retiré de `pyproject.toml` + `requirements.txt` (jamais importé ;
+  dépendance lourde). Non-breaking (fynance ne l'importe nulle part). Mention
+  obsolète retirée de `01-overview.md`.
+- Versions plancher (`>=`) des autres deps cohérentes ; rien d'autre à changer.
+
+## Vérif
+- `import fynance` OK ; suite + ruff + mypy verts.

--- a/doc/dev/01-overview.md
+++ b/doc/dev/01-overview.md
@@ -31,7 +31,7 @@ library's core invariant, enforced in tests.
   the suite and must stay runnable. `ruff` + `mypy` configured; Sphinx docs build
   (furo).
 - **Core stack**: NumPy 2, pandas 2, SciPy, Numba (`@njit`), **PyTorch** (the ML
-  backend — Keras/TensorFlow is being retired), XGBoost, matplotlib/seaborn.
+  backend — Keras/TensorFlow is being retired), matplotlib/seaborn.
 
 ## Repo map
 

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -15,12 +15,6 @@ shipped, `03-decisions.md` for *why*. Keep it short and true.
 ---
 
 
-## 4. Performance & dépendances
-
-- [ ] Audit versions et alternatives modernes des dépendances restantes.
-  (pandas a été remplacé par polars en entrée + numpy en sortie ; le cœur
-  algébrique reste NumPy natif.)
-
 ## 5. R&D — Loss, architecture, données
 
 Objectif : identifier empiriquement la meilleure combinaison loss / architecture / features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dependencies = [
     "scipy>=1.11",
     "seaborn>=0.12",
     "torch>=2.0",
-    "xgboost>=2.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ polars>=1.0
 scipy>=1.11
 seaborn>=0.12
 torch>=2.0
-xgboost>=2.0


### PR DESCRIPTION
Roadmap §4 (dependency audit). Audited real usage of every runtime dep in `fynance/`:

| dep | files | verdict |
|---|--:|---|
| numpy 33 · torch 14 · matplotlib 9 · polars 5 · scipy 4 · seaborn 3 · numba 1 | — | used, keep |
| **xgboost** | **0** | **never imported → removed** |

`xgboost` was a declared runtime dependency used **nowhere** in the package — removed from `pyproject.toml` + `requirements.txt` (lighter install, **non-breaking** since fynance never imported it) and the stale mention dropped from `01-overview`. All other deps are used with sensible `>=` floors.

Closes §4 — only the §5 R&D backlog remains. ruff/mypy(0)/pytest(317) green.