### PR TITLE
chore: release v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [1.5.0] - 2026-06-14
+
+### Added
+
 - `Notebooks/pytorch_examples.ipynb` — a runnable PyTorch tour (metrics, allocation, MLP/TCN/Transformer with `SharpeLoss`, walk-forward CV, custom losses), replacing the old Keras/dev notebooks
 
 - `Transformer` (`fynance.models.transformer`) — a causal Transformer encoder on `BaseNeuralNet` (sinusoidal `PositionalEncoding`, reuses `MultiHeadAttention`, lower-triangular causal mask = no lookahead), with 10 tests incl. a causality check; works with MSE and `SharpeLoss`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fynance"
-version = "1.4.0"
+version = "1.5.0"
 description = "Python and Cython scripts of machine learning, econometrics and statistical features for financial analysis"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## [1.5.0] - 2026-06-14

### Added

- `Notebooks/pytorch_examples.ipynb` — a runnable PyTorch tour (metrics, allocation, MLP/TCN/Transformer with `SharpeLoss`, walk-forward CV, custom losses), replacing the old Keras/dev notebooks

- `Transformer` (`fynance.models.transformer`) — a causal Transformer encoder on `BaseNeuralNet` (sinusoidal `PositionalEncoding`, reuses `MultiHeadAttention`, lower-triangular causal mask = no lookahead), with 10 tests incl. a causality check; works with MSE and `SharpeLoss`

- `TemporalConvNet` (`fynance.models.tcn`) — a causal dilated Temporal Convolutional Network on `BaseNeuralNet` (residual blocks, dilation 1/2/4…, strictly no-lookahead), with 8 tests incl. a causality check; works with MSE and `SharpeLoss`

- Integration test training `RollMultiLayerPerceptron` with the differentiable `SharpeLoss` (instead of MSE) — demonstrates the custom financial losses end-to-end

### Changed

- `HRP()` scatters cluster-ordered weights via NumPy fancy-indexing instead of a Python loop

### Fixed

- README quickstart: `fy.ERC(cov)()` → `fy.ERC(cov)` (ERC returns an array, not a callable) and the rolling example now uses the real `model(train_period=…, test_period=…, roll_period=…)` signature

- Swept stale/decided inline `# TODO`/`# FIXME` markers; in particular the `momentums_cy` "window is w+1" FIXME was verified stale (window size is correct, proven by the property tests) and removed

### Deprecated

### Removed

- `xgboost` dependency — it was declared in `pyproject.toml` but never imported anywhere in the package (lighter install; non-breaking)

- Legacy notebooks: the Keras `Exemple_Rolling_NeuralNetwork.ipynb` and the stale dev notebooks `test_roll_NN_test.ipynb` / `Test_various_NN_models_with_simulated_data.ipynb`

## Test plan

- ruff, mypy (0), pytest (317 + doctests), sphinx-build -W — all green on develop.
- CI runs the four gates (test 3.10-3.13 / lint+interrogate / docs / typecheck) on this PR.
