### PR TITLE
feat: technical indicators (roc, realized vol, rolling moments) — roadmap 5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Technical indicators in `fynance.features.indicators`: `roc`, `realized_volatility`, `rolling_skewness`, `rolling_kurtosis`, `rolling_autocorr` — single-series, strictly causal, with parity + no-lookahead tests
+
 ### Changed
 
 ### Fixed

--- a/PLAN-5.4-technical-indicators.md
+++ b/PLAN-5.4-technical-indicators.md
@@ -1,0 +1,22 @@
+# Plan — §5.4 Features / indicateurs techniques
+
+> Plan jetable à la racine (à archiver). Roadmap §5.4 (bloc 🟢).
+
+## Déjà présents (non re-faits)
+Bollinger, MACD (line/hist/signal), RSI, CCI, HMA ; EMA/SMA/WMA + std.
+
+## Ajoutés (single-série, causaux, `@WrapperArray`, dans `indicators.py`)
+- `roc` — Rate of Change (momentum).
+- `realized_volatility` — std glissante des log-returns, annualisée.
+- `rolling_skewness`, `rolling_kurtosis` (via scipy.stats, fenêtre stricte passée).
+- `rolling_autocorr` — autocorrélation glissante lag-k.
+
+15 tests : parité vs référence/scipy + **non-lookahead** + colonne-par-colonne 2D.
+
+## Différé (nécessite une API multi-séries OHLCV)
+ATR, ADX, Williams %R (High/Low), OBV, VWAP (Volume) — demandent High/Low/Volume,
+incompatibles avec la convention single-série actuelle. Décision d'API à part.
+GARCH-as-feature : possible via `fynance.estimator` mais coûteux ; reporté.
+
+## Vérif
+- 15 tests verts ; suite 333 ; ruff + mypy 0.

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -57,14 +57,13 @@ notebook/rapport.
 
 ### 5.4 Features / indicateurs techniques
 
-- [ ] **Tendance** : EMA, MACD, ADX.
-- [ ] **Momentum** : RSI, ROC, Williams %R.
-- [ ] **Volatilité** : ATR, Bollinger Band width, vol réalisée glissante.
-- [ ] **Volume** : OBV, VWAP (si données intraday disponibles).
-- [ ] **Statistiques glissantes** : autocorrélation, skewness, kurtosis
-  des returns sur fenêtres multiples (5, 10, 21, 63 jours).
-- [ ] **Vol conditionnelle** : GARCH(1,1) comme feature (via `fynance.estimator`).
-- [ ] Implémenter dans `fynance/features/` avec décorateurs `@WrapperArray` existants.
+Fait (single-série, causaux) : `roc`, `realized_volatility`, `rolling_skewness`,
+`rolling_kurtosis`, `rolling_autocorr` (PR #86) ; déjà présents : EMA/MACD/RSI/
+Bollinger/CCI/HMA. Reste **différé** (nécessite une API multi-séries OHLCV) :
+
+- [ ] **ATR / ADX / Williams %R** (High/Low) et **OBV / VWAP** (Volume) — exigent
+  des entrées OHLCV ; concevoir une API multi-séries d'abord.
+- [ ] **GARCH(1,1) comme feature** (via `fynance.estimator`).
 
 ### 5.5 Normalisation des features
 

--- a/fynance/features/indicators.py
+++ b/fynance/features/indicators.py
@@ -33,6 +33,7 @@ from warnings import warn
 # External packages
 import numpy as np
 from numpy.typing import NDArray
+from scipy import stats as _sp_stats
 
 # Local packages
 from fynance._wrappers import WrapperArray
@@ -41,7 +42,8 @@ from fynance.features.momentums import _ema, _emstd, _sma, _smstd, _wma, _wmstd
 
 __all__ = [
     'bollinger_band', 'cci', 'hma', 'macd_hist', 'macd_line',
-    'rsi', 'signal_line',
+    'realized_volatility', 'roc', 'rolling_autocorr', 'rolling_kurtosis',
+    'rolling_skewness', 'rsi', 'signal_line',
 ]
 
 _handler_ma = {'s': _sma, 'w': _wma, 'e': _ema}
@@ -654,3 +656,175 @@ if __name__ == '__main__':
     import doctest
 
     doctest.testmod()
+
+
+@WrapperArray('dtype', 'axis', 'window')
+def roc(X: NDArray, w: int = 14, axis: int = 0, dtype=None) -> NDArray:
+    r""" Rate of Change momentum indicator.
+
+    Percentage change of the series over a lagged window ``w``:
+    :math:`ROC^w_t = 100 \cdot (X_t / X_{t-w} - 1)`. Strictly causal —
+    the first ``w`` points use the first observation as the base (expanding).
+
+    Parameters
+    ----------
+    X : np.ndarray[dtype, ndim=1 or 2]
+        Price/level series.
+    w : int, optional
+        Lag window. Default 14.
+    axis : {0, 1}, optional
+        Axis of computation. Default 0.
+    dtype : np.dtype, optional
+        Output dtype.
+
+    Returns
+    -------
+    np.ndarray[dtype, ndim=1 or 2]
+        Rate of change in percent.
+
+    Examples
+    --------
+    >>> X = np.array([10., 11., 12., 13., 14.])
+    >>> roc(X, w=2)
+    array([ 0.        , 10.        , 20.        , 18.18181818, 16.66666667])
+
+    """
+    out = np.zeros(X.shape)
+    out[1:w] = (X[1:w] / X[0] - 1.) * 100.
+    out[w:] = (X[w:] / X[:-w] - 1.) * 100.
+
+    return out
+
+
+@WrapperArray('dtype', 'axis', 'window')
+def realized_volatility(X: NDArray, w: int = 21, period: int = 252, axis: int = 0, dtype=None) -> NDArray:
+    r""" Annualized realized volatility from a price series.
+
+    Rolling standard deviation of log-returns, annualized by
+    :math:`\sqrt{period}`. Causal: returns are strictly past, the window
+    expands over the first observations.
+
+    Parameters
+    ----------
+    X : np.ndarray[dtype, ndim=1 or 2]
+        Price/level series.
+    w : int, optional
+        Rolling window over returns. Default 21.
+    period : int, optional
+        Annualization factor (e.g. 252 daily). Default 252.
+    axis : {0, 1}, optional
+        Axis of computation. Default 0.
+    dtype : np.dtype, optional
+        Output dtype.
+
+    Returns
+    -------
+    np.ndarray[dtype, ndim=1 or 2]
+        Annualized realized volatility, aligned to ``X`` (first entry 0).
+
+    """
+    r = np.log(X[1:] / X[:-1])
+    std = np.asarray(_smstd(r, w))
+    out = np.zeros(X.shape)
+    out[1:] = np.sqrt(period) * std
+
+    return out
+
+
+def _rolling_apply(X, w, fn, min_obs):
+    # Causal rolling reduction: window [max(0, t-w+1), t], expanding at start.
+    out = np.zeros(X.shape)
+    n = X.shape[0]
+    for t in range(n):
+        lo = max(0, t - w + 1)
+        win = X[lo:t + 1]
+        if win.shape[0] >= min_obs:
+            out[t] = fn(win)
+
+    return out
+
+
+@WrapperArray('dtype', 'axis', 'window')
+def rolling_skewness(X: NDArray, w: int = 21, axis: int = 0, dtype=None) -> NDArray:
+    """ Rolling sample skewness over a strictly-past window ``w``.
+
+    Parameters
+    ----------
+    X : np.ndarray[dtype, ndim=1 or 2]
+        Input series.
+    w : int, optional
+        Rolling window. Default 21.
+    axis : {0, 1}, optional
+        Axis of computation. Default 0.
+    dtype : np.dtype, optional
+        Output dtype.
+
+    Returns
+    -------
+    np.ndarray[dtype, ndim=1 or 2]
+        Rolling skewness (0 where fewer than 3 observations are available).
+
+    """
+    return np.nan_to_num(
+        _rolling_apply(X, w, lambda win: _sp_stats.skew(win, axis=0), min_obs=3)
+    )
+
+
+@WrapperArray('dtype', 'axis', 'window')
+def rolling_kurtosis(X: NDArray, w: int = 21, axis: int = 0, dtype=None) -> NDArray:
+    """ Rolling excess kurtosis over a strictly-past window ``w``.
+
+    Parameters
+    ----------
+    X : np.ndarray[dtype, ndim=1 or 2]
+        Input series.
+    w : int, optional
+        Rolling window. Default 21.
+    axis : {0, 1}, optional
+        Axis of computation. Default 0.
+    dtype : np.dtype, optional
+        Output dtype.
+
+    Returns
+    -------
+    np.ndarray[dtype, ndim=1 or 2]
+        Rolling excess kurtosis (0 where fewer than 4 observations).
+
+    """
+    return np.nan_to_num(
+        _rolling_apply(X, w, lambda win: _sp_stats.kurtosis(win, axis=0), min_obs=4)
+    )
+
+
+@WrapperArray('dtype', 'axis', 'window')
+def rolling_autocorr(X: NDArray, w: int = 21, lag: int = 1, axis: int = 0, dtype=None) -> NDArray:
+    """ Rolling lag-``lag`` autocorrelation over a strictly-past window ``w``.
+
+    Parameters
+    ----------
+    X : np.ndarray[dtype, ndim=1 or 2]
+        Input series.
+    w : int, optional
+        Rolling window. Default 21.
+    lag : int, optional
+        Autocorrelation lag. Default 1.
+    axis : {0, 1}, optional
+        Axis of computation. Default 0.
+    dtype : np.dtype, optional
+        Output dtype.
+
+    Returns
+    -------
+    np.ndarray[dtype, ndim=1 or 2]
+        Rolling autocorrelation (0 where the window is too short).
+
+    """
+    def _ac(win):
+        a, b = win[:-lag], win[lag:]
+        a = a - a.mean(axis=0)
+        b = b - b.mean(axis=0)
+        denom = np.sqrt((a ** 2).sum(axis=0) * (b ** 2).sum(axis=0))
+        with np.errstate(invalid='ignore', divide='ignore'):
+            return np.where(denom > 0, (a * b).sum(axis=0) / denom, 0.)
+
+    return np.nan_to_num(_rolling_apply(X, w, _ac, min_obs=lag + 2))

--- a/fynance/tests/features/test_technical_indicators.py
+++ b/fynance/tests/features/test_technical_indicators.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for the §5.4 technical indicators (ROC, realized vol, rolling moments). """
+
+# Third-party packages
+import numpy as np
+import pytest
+from scipy import stats as sp_stats
+
+# Local packages
+from fynance.features.indicators import (
+    realized_volatility,
+    roc,
+    rolling_autocorr,
+    rolling_kurtosis,
+    rolling_skewness,
+)
+
+
+@pytest.fixture
+def x():
+    rng = np.random.RandomState(7)
+    return np.cumsum(rng.standard_normal(80)) + 100.0
+
+
+def test_roc_matches_formula(x):
+    w = 5
+    out = np.asarray(roc(x, w=w))
+    expected = np.zeros_like(x)
+    expected[1:w] = (x[1:w] / x[0] - 1) * 100
+    expected[w:] = (x[w:] / x[:-w] - 1) * 100
+    assert np.allclose(out, expected)
+
+
+def test_realized_volatility_matches_reference(x):
+    w, period = 10, 252
+    out = np.asarray(realized_volatility(x, w=w, period=period))
+    r = np.log(x[1:] / x[:-1])
+    ref = np.zeros_like(x)
+    for i in range(len(r)):
+        lo = max(0, i - w + 1)
+        ref[i + 1] = np.sqrt(period) * np.std(r[lo:i + 1], ddof=0)
+    assert np.allclose(out, ref)
+
+
+def test_rolling_skewness_matches_scipy(x):
+    w = 12
+    out = np.asarray(rolling_skewness(x, w=w))
+    t = 40
+    assert np.isclose(out[t], sp_stats.skew(x[t - w + 1:t + 1]))
+
+
+def test_rolling_kurtosis_matches_scipy(x):
+    w = 12
+    out = np.asarray(rolling_kurtosis(x, w=w))
+    t = 40
+    assert np.isclose(out[t], sp_stats.kurtosis(x[t - w + 1:t + 1]))
+
+
+def test_rolling_autocorr_matches_reference(x):
+    w = 15
+    out = np.asarray(rolling_autocorr(x, w=w, lag=1))
+    t = 50
+    win = x[t - w + 1:t + 1]
+    a, b = win[:-1], win[1:]
+    ref = np.corrcoef(a, b)[0, 1]
+    assert np.isclose(out[t], ref)
+
+
+INDICATORS = [
+    ("roc", lambda a: roc(a, w=5)),
+    ("realized_volatility", lambda a: realized_volatility(a, w=10)),
+    ("rolling_skewness", lambda a: rolling_skewness(a, w=12)),
+    ("rolling_kurtosis", lambda a: rolling_kurtosis(a, w=12)),
+    ("rolling_autocorr", lambda a: rolling_autocorr(a, w=12)),
+]
+
+
+@pytest.mark.parametrize("name,fn", INDICATORS, ids=[n for n, _ in INDICATORS])
+def test_no_lookahead(x, name, fn):
+    t = 55
+    base = np.asarray(fn(x))
+    x2 = x.copy()
+    x2[t:] += 50.0
+    pert = np.asarray(fn(x2))
+    assert np.allclose(base[:t], pert[:t]), f"{name} leaks the future"
+
+
+@pytest.mark.parametrize("name,fn", INDICATORS, ids=[n for n, _ in INDICATORS])
+def test_2d_columnwise(x, name, fn):
+    X2 = np.column_stack([x, x[::-1] + 1.0])
+    out = np.asarray(fn(X2))
+    assert out.shape == X2.shape
+    assert np.allclose(out[:, 0], np.asarray(fn(x)))


### PR DESCRIPTION
Roadmap §5.4 (🟢). Adds single-series, **strictly causal** indicators to `fynance.features.indicators`:

- `roc` — rate of change (momentum)
- `realized_volatility` — annualized rolling std of log-returns
- `rolling_skewness`, `rolling_kurtosis` (scipy.stats), `rolling_autocorr`

**15 tests**: reference/scipy parity, **no-lookahead causality**, 2D column-wise. Already-present indicators (EMA/MACD/RSI/Bollinger/CCI/HMA) untouched.

**Deferred** (need a multi-series OHLCV input API — a separate design decision): ATR, ADX, Williams %R (High/Low), OBV, VWAP (Volume), and GARCH-as-feature.

ruff/mypy(0)/pytest(333)+doctests green.