### PR TITLE
feat: realistic-backtest primitives (roadmap 5.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Realistic-backtest primitives: robustness metrics `percent_positive` / `tail_ratio` (`fynance.features`), and `fynance.algorithms.sizing` with `kelly_fraction`, causal `vol_target`, and turnover-based `transaction_cost`
+
 - Technical indicators in `fynance.features.indicators`: `roc`, `realized_volatility`, `rolling_skewness`, `rolling_kurtosis`, `rolling_autocorr` — single-series, strictly causal, with parity + no-lookahead tests
 
 ### Changed

--- a/PLAN-5.8-realistic-backtest.md
+++ b/PLAN-5.8-realistic-backtest.md
@@ -1,0 +1,19 @@
+# Plan — §5.8 Backtest réaliste
+
+> Plan jetable à la racine (à archiver). Roadmap §5.8 (bloc 🟢).
+
+## Livré
+- **Métriques de robustesse** (`features/stats.py`, exposées via le shim metrics) :
+  `percent_positive` (hit rate), `tail_ratio` (|q95|/|q05|).
+- **`fynance/algorithms/sizing.py`** (nouveau) :
+  - `kelly_fraction(returns, fraction)` — levier Kelly fractionnel (μ/σ²).
+  - `vol_target(X, target_vol, period, w, max_leverage)` — levier ciblant une vol
+    constante, **causal** (réutilise `realized_volatility`), capé.
+  - `transaction_cost(weights, fee)` — coût par pas basé sur le turnover |Δw|.
+
+## Tests (10)
+robustesse (formule/quantiles/2D) ; kelly (formule + var nulle) ; vol_target
+(forme + cap + **non-lookahead**) ; transaction_cost (turnover 1D/2D).
+
+## Vérif
+- 10 tests + doctests (kelly, transaction_cost) ; suite 346 ; ruff + mypy 0.

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -95,6 +95,8 @@ tests de propriété (parité + non-lookahead) ; à étendre aux nouvelles featu
 
 ### 5.8 Backtest réaliste
 
-- [ ] **Coûts de transaction** : spread bid-ask + slippage dans le P&L (BPS/trade, impact linéaire).
-- [ ] **Position sizing** : Kelly fractionnel + vol-targeting dans `fynance/algorithms/`.
-- [ ] **Métriques de robustesse** : tail ratio, % de mois positifs, etc. — compléter `fynance/features/`.
+Fait (PR #87) : `algorithms/sizing.py` (`kelly_fraction`, causal `vol_target`,
+`transaction_cost` turnover-based) ; métriques `percent_positive`, `tail_ratio`.
+Reste optionnel :
+
+- [ ] Slippage / impact de marché non-linéaire au-delà du coût proportionnel.

--- a/fynance/algorithms/__init__.py
+++ b/fynance/algorithms/__init__.py
@@ -23,7 +23,9 @@
 # Third party packages
 
 # Local packages
-from . import allocation
+from . import allocation, sizing
 from .allocation import *
+from .sizing import *
 
 __all__ = allocation.__all__
+__all__ += sizing.__all__

--- a/fynance/algorithms/sizing.py
+++ b/fynance/algorithms/sizing.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Position sizing and transaction-cost primitives for realistic backtests.
+
+Time-series leverage rules (Kelly, volatility targeting) and a turnover-based
+transaction-cost model — the building blocks for going from a raw signal to a
+net-of-cost P&L.
+
+Main entry points
+-----------------
+- :func:`kelly_fraction` — (fractional) Kelly leverage from return moments.
+- :func:`vol_target` — causal leverage that targets a constant volatility.
+- :func:`transaction_cost` — per-step cost from weight turnover.
+
+"""
+
+from __future__ import annotations
+
+# Third-party packages
+import numpy as np
+from numpy.typing import NDArray
+
+# Local packages
+from fynance.features.indicators import realized_volatility
+
+__all__ = ['kelly_fraction', 'transaction_cost', 'vol_target']
+
+
+def kelly_fraction(returns: NDArray, fraction: float = 1.0) -> float:
+    r""" Fractional Kelly leverage from a return series.
+
+    Under a Gaussian approximation the growth-optimal leverage is
+    :math:`f^\star = \mu / \sigma^2`; ``fraction`` scales it down
+    (fractional Kelly, e.g. 0.5 for half-Kelly).
+
+    Parameters
+    ----------
+    returns : array_like
+        Series of (arithmetic) returns.
+    fraction : float, optional
+        Multiplier on the full Kelly leverage. Default 1.0.
+
+    Returns
+    -------
+    float
+        Kelly leverage (0 if the variance is null).
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> r = np.array([0.01, -0.02, 0.03, 0.00, 0.02])
+    >>> round(kelly_fraction(r, fraction=0.5), 4)
+    13.5135
+
+    """
+    returns = np.asarray(returns, dtype=np.float64).ravel()
+    var = returns.var(ddof=0)
+    if var <= 0:
+        return 0.0
+
+    return float(fraction * returns.mean() / var)
+
+
+def vol_target(
+    X: NDArray,
+    target_vol: float = 0.15,
+    period: int = 252,
+    w: int = 21,
+    max_leverage: float = 5.0,
+) -> NDArray:
+    r""" Causal volatility-targeting leverage series.
+
+    Leverage that scales inversely with the *past* realized volatility so the
+    strategy targets a constant annualized volatility ``target_vol``:
+    :math:`\\ell_t = target\\_vol / \\hat\\sigma_t`, capped at ``max_leverage``.
+    Strictly causal — uses :func:`fynance.features.indicators.realized_volatility`.
+
+    Parameters
+    ----------
+    X : array_like
+        Price/level series.
+    target_vol : float, optional
+        Target annualized volatility. Default 0.15.
+    period : int, optional
+        Annualization factor. Default 252.
+    w : int, optional
+        Rolling window for the realized volatility. Default 21.
+    max_leverage : float, optional
+        Cap on the leverage. Default 5.0.
+
+    Returns
+    -------
+    np.ndarray
+        Leverage series aligned to ``X`` (0 where volatility is not yet defined).
+
+    """
+    X = np.asarray(X, dtype=np.float64)
+    vol = np.asarray(realized_volatility(X, w=w, period=period))
+    with np.errstate(divide='ignore', invalid='ignore'):
+        lev = np.where(vol > 0, target_vol / vol, 0.0)
+
+    return np.clip(lev, 0.0, max_leverage)
+
+
+def transaction_cost(
+    weights: NDArray, fee: float = 0.001, axis: int = 0,
+) -> NDArray:
+    r""" Per-step transaction cost from weight turnover.
+
+    Cost at each step is ``fee`` times the traded amount (turnover):
+    :math:`c_t = fee \\cdot \\sum_i |w_{t,i} - w_{t-1,i}|`, with the first step
+    charging the initial position.
+
+    Parameters
+    ----------
+    weights : array_like
+        Portfolio weights over time, shape ``(T,)`` or ``(T, n_assets)``.
+    fee : float, optional
+        Proportional cost per unit traded (e.g. 0.001 = 10 bps). Default 0.001.
+    axis : {0, 1}, optional
+        Time axis. Default 0.
+
+    Returns
+    -------
+    np.ndarray
+        Cost per step, shape ``(T,)``.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> w = np.array([[1.0, 0.0], [0.5, 0.5], [0.5, 0.5]])
+    >>> transaction_cost(w, fee=0.01)
+    array([0.01, 0.01, 0.  ])
+
+    """
+    w = np.asarray(weights, dtype=np.float64)
+    if axis == 1:
+        w = w.T
+    if w.ndim == 1:
+        w = w.reshape(-1, 1)
+
+    turnover = np.empty(w.shape[0])
+    turnover[0] = np.abs(w[0]).sum()
+    turnover[1:] = np.abs(np.diff(w, axis=0)).sum(axis=1)
+
+    return fee * turnover

--- a/fynance/features/metrics.py
+++ b/fynance/features/metrics.py
@@ -26,5 +26,7 @@ from fynance.features.returns import *
 # non-__all__ public helpers still imported directly by some callers/tests
 from fynance.features.returns import perf_strat, returns_strat  # noqa: F401
 from fynance.features.stats import *
+from fynance.features.stats import percent_positive, tail_ratio  # noqa: F401
 
-__all__ = ['accuracy', 'annual_return', 'annual_volatility', 'calmar', 'directional_accuracy', 'diversified_ratio', 'drawdown', 'mad', 'mdd', 'roll_annual_return', 'roll_annual_volatility', 'roll_calmar', 'roll_drawdown', 'roll_mad', 'roll_mdd', 'roll_sharpe', 'roll_z_score', 'sharpe', 'sortino', 'perf_index', 'perf_returns', 'z_score']
+__all__ = ['accuracy', 'annual_return', 'annual_volatility', 'calmar', 'directional_accuracy', 'diversified_ratio', 'drawdown', 'mad', 'mdd', 'roll_annual_return', 'roll_annual_volatility', 'roll_calmar', 'roll_drawdown', 'roll_mad', 'roll_mdd', 'roll_sharpe', 'roll_z_score', 'sharpe', 'sortino', 'perf_index', 'perf_returns', 'z_score',
+           'percent_positive', 'tail_ratio']

--- a/fynance/features/stats.py
+++ b/fynance/features/stats.py
@@ -15,7 +15,8 @@ from fynance._wrappers import WrapperArray
 from fynance.features._metrics_helpers import *  # noqa: F401,F403
 from fynance.features.metrics_cy import *
 
-__all__ = ['accuracy', 'directional_accuracy', 'z_score', 'roll_z_score']
+__all__ = ['accuracy', 'directional_accuracy', 'percent_positive',
+           'tail_ratio', 'z_score', 'roll_z_score']
 
 
 @WrapperArray('axis')
@@ -245,3 +246,60 @@ def roll_z_score(X: NDArray, w: int | None = None, kind: str = 's', axis: int = 
 
     return z
 
+
+@WrapperArray('axis')
+def percent_positive(X: NDArray, axis: int = 0) -> NDArray:
+    r""" Fraction of strictly positive observations.
+
+    A simple robustness statistic: the share of periods with a positive
+    return (the "hit rate" / percentage of winning periods).
+
+    Parameters
+    ----------
+    X : np.ndarray[dtype, ndim=1 or 2]
+        Series of returns.
+    axis : {0, 1}, optional
+        Axis of computation. Default 0.
+
+    Returns
+    -------
+    float or np.ndarray
+        Fraction in ``[0, 1]`` of strictly positive values.
+
+    Examples
+    --------
+    >>> X = np.array([0.1, -0.2, 0.3, 0.0, 0.4])
+    >>> float(percent_positive(X))
+    0.6
+
+    """
+    return np.mean(X > 0, axis=0)
+
+
+@WrapperArray('axis')
+def tail_ratio(X: NDArray, alpha: float = 0.05, axis: int = 0) -> NDArray:
+    r""" Tail ratio of a return series.
+
+    Ratio of the magnitude of the right tail to the left tail:
+    :math:`|q_{1-\alpha}| / |q_{\alpha}|`. A value above 1 means the
+    upside tail is larger than the downside tail.
+
+    Parameters
+    ----------
+    X : np.ndarray[dtype, ndim=1 or 2]
+        Series of returns.
+    alpha : float, optional
+        Tail quantile level. Default 0.05 (95th vs 5th percentile).
+    axis : {0, 1}, optional
+        Axis of computation. Default 0.
+
+    Returns
+    -------
+    float or np.ndarray
+        Tail ratio (0 when the left tail is exactly 0).
+
+    """
+    hi = np.abs(np.quantile(X, 1.0 - alpha, axis=0))
+    lo = np.abs(np.quantile(X, alpha, axis=0))
+
+    return np.where(lo > 0, hi / np.where(lo > 0, lo, 1.0), 0.0)

--- a/fynance/tests/algorithms/test_sizing.py
+++ b/fynance/tests/algorithms/test_sizing.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for §5.8 position sizing + transaction costs. """
+
+import numpy as np
+
+from fynance.algorithms.sizing import kelly_fraction, transaction_cost, vol_target
+
+
+def test_kelly_fraction_formula():
+    r = np.array([0.01, -0.02, 0.03, 0.0, 0.02])
+    assert np.isclose(kelly_fraction(r, fraction=0.5), 0.5 * r.mean() / r.var(ddof=0))
+
+
+def test_kelly_zero_variance():
+    assert kelly_fraction(np.zeros(10)) == 0.0
+
+
+def test_vol_target_shape_and_cap():
+    rng = np.random.RandomState(0)
+    X = 100 * np.cumprod(1 + rng.standard_normal(120) * 0.01)
+    lev = np.asarray(vol_target(X, target_vol=0.15, w=21, max_leverage=3.0))
+    assert lev.shape == (120,)
+    assert lev.min() >= 0.0 and lev.max() <= 3.0
+
+
+def test_vol_target_no_lookahead():
+    rng = np.random.RandomState(1)
+    X = 100 * np.cumprod(1 + rng.standard_normal(100) * 0.01)
+    t = 60
+    base = np.asarray(vol_target(X, w=21))
+    X2 = X.copy()
+    X2[t:] *= 1.5
+    pert = np.asarray(vol_target(X2, w=21))
+    assert np.allclose(base[:t], pert[:t])
+
+
+def test_transaction_cost_turnover():
+    w = np.array([[1.0, 0.0], [0.5, 0.5], [0.5, 0.5]])
+    cost = transaction_cost(w, fee=0.01)
+    # step0: |1|+|0| = 1 -> 0.01 ; step1: |0.5|+|0.5| = 1 -> 0.01 ; step2: 0
+    assert np.allclose(cost, [0.01, 0.01, 0.0])
+
+
+def test_transaction_cost_1d():
+    w = np.array([0.0, 1.0, 1.0, -1.0])
+    cost = transaction_cost(w, fee=0.001)
+    assert np.allclose(cost, [0.0, 0.001, 0.0, 0.002])

--- a/fynance/tests/features/test_robustness.py
+++ b/fynance/tests/features/test_robustness.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for §5.8 robustness metrics (tail_ratio, percent_positive). """
+
+import numpy as np
+
+from fynance.features.stats import percent_positive, tail_ratio
+
+
+def test_percent_positive():
+    X = np.array([0.1, -0.2, 0.3, 0.0, 0.4])
+    assert np.isclose(percent_positive(X), 0.6)
+
+
+def test_percent_positive_2d():
+    X = np.array([[0.1, -0.1], [-0.2, 0.2], [0.3, 0.3]])
+    assert np.allclose(percent_positive(X), [2 / 3, 2 / 3])
+
+
+def test_tail_ratio_symmetric_is_one():
+    rng = np.random.RandomState(0)
+    X = rng.standard_normal(10000)  # symmetric -> tail ratio ~ 1
+    assert abs(float(tail_ratio(X)) - 1.0) < 0.1
+
+
+def test_tail_ratio_matches_quantiles():
+    X = np.array([-3., -1., 0., 0., 1., 2., 5.])
+    expected = abs(np.quantile(X, 0.95)) / abs(np.quantile(X, 0.05))
+    assert np.isclose(tail_ratio(X), expected)


### PR DESCRIPTION
Roadmap §5.8 (🟢). Building blocks for net-of-cost, volatility-aware backtests.

## features (robustness metrics, exposed at `fynance.*`)
- `percent_positive` — hit rate (share of positive periods)
- `tail_ratio` — |q95| / |q05|

## `fynance.algorithms.sizing` (new)
- `kelly_fraction(returns, fraction)` — fractional Kelly (μ/σ²)
- `vol_target(X, target_vol, period, w, max_leverage)` — **causal** volatility-targeting leverage (reuses `realized_volatility`), capped
- `transaction_cost(weights, fee)` — per-step turnover cost (`fee · Σ|Δw|`)

**10 tests** (incl. `vol_target` no-lookahead) + doctests. ruff/mypy(0)/pytest(346) green.

Deferred: non-linear slippage / market-impact beyond the proportional cost.