### PR TITLE
feat: Calmar, Omega, Hybrid losses (roadmap 5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- New differentiable losses in `fynance.models.loss`: `CalmarLoss` (Calmar via `torch.cummax` drawdown), `OmegaLoss` (gain/loss ratio over a threshold), and `HybridLoss` (convex combo of two losses, with an optional learnable weight)
+
 - Realistic-backtest primitives: robustness metrics `percent_positive` / `tail_ratio` (`fynance.features`), and `fynance.algorithms.sizing` with `kelly_fraction`, causal `vol_target`, and turnover-based `transaction_cost`
 
 - Technical indicators in `fynance.features.indicators`: `roc`, `realized_volatility`, `rolling_skewness`, `rolling_kurtosis`, `rolling_autocorr` — single-series, strictly causal, with parity + no-lookahead tests

--- a/PLAN-5.1-loss-functions.md
+++ b/PLAN-5.1-loss-functions.md
@@ -1,0 +1,23 @@
+# Plan — §5.1 Nouvelles loss functions
+
+> Plan jetable à la racine (à archiver). Roadmap §5.1 (bloc 🟢).
+
+## Livré (dans `fynance/models/loss/`, calqués sur SharpeLoss)
+- `CalmarLoss` — Calmar négatif ; max drawdown différentiable via `torch.cummax`.
+- `OmegaLoss` — Omega négatif `E[relu(r-L)] / E[relu(L-r)]` (seuil `threshold`).
+- `HybridLoss` — combinaison convexe `α·L_a + (1-α)·L_b` ; `α` fixe **ou
+  learnable** (`nn.Parameter` via sigmoid). Forwarde `y_true` aux composants
+  (ex. DirectionalAccuracyLoss qui en a besoin).
+
+Exportés via `fynance.models.loss` et `fynance.models`.
+
+## Tests (9 + intégration)
+Calmar (scalaire+grad, rejet non-tensor), Omega (valeur connue, seuil+grad),
+Hybrid (somme pondérée, forward y_true, α learnable optimisé), entraînement
+d'un MLP avec CalmarLoss.
+
+## 🟡 Non fait (besoin de données)
+« Benchmark empirique » des loss sur dataset réel (out-of-sample Sharpe/Sortino/…).
+
+## Vérif
+- 26 tests loss (dont 9 neufs) ; suite 354 ; ruff + mypy 0.

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -24,17 +24,10 @@ notebook/rapport.
 
 ### 5.1 Nouvelles loss functions
 
-- [ ] **Calmar loss** — proxy différentiable du max drawdown
-  (`max_drawdown ≈ max(cumsum(-r)) − min(cumsum(-r))` via `torch.cumsum` + `torch.max`).
-  Valeur à annualiser pour comparer avec la métrique d'évaluation.
-- [ ] **Omega loss** — ratio gains/pertes pondérés au-delà d'un seuil `L` :
-  `Ω = E[max(r−L, 0)] / E[max(L−r, 0) + ε]`, entièrement différentiable avec `F.relu`.
-- [ ] **Loss hybride multi-objectif** — combiner deux objectifs avec un poids `α` :
-  `L = α·SharpeLoss + (1−α)·DirectionalAccuracyLoss`. Chercher `α` optimal
-  par grid-search ou en le rendant learnable (paramètre `nn.Parameter`).
-- [ ] **Benchmark empirique** : comparer les loss sur un jeu de données réel
-  (même walk-forward, mêmes features) — métriques out-of-sample : Sharpe, Sortino,
-  Calmar, accuracy directionnelle, drawdown max.
+Fait (PR #88) : `CalmarLoss`, `OmegaLoss`, `HybridLoss` (α fixe ou learnable).
+
+- [ ] 🟡 **Benchmark empirique** : comparer les loss sur un jeu de données réel
+  (out-of-sample Sharpe/Sortino/Calmar/accuracy/drawdown) — nécessite des données.
 
 ### 5.2 Architecture : ensemble direction + magnitude avec meta-modèle
 

--- a/fynance/models/__init__.py
+++ b/fynance/models/__init__.py
@@ -49,7 +49,15 @@ from .econometric_models_cy import (
     get_parameters_cy,
 )
 from .gru import GatedRecurrentUnit, GRUCell
-from .loss import BaseLoss, DirectionalAccuracyLoss, SharpeLoss, SortinoLoss
+from .loss import (
+    BaseLoss,
+    CalmarLoss,
+    DirectionalAccuracyLoss,
+    HybridLoss,
+    OmegaLoss,
+    SharpeLoss,
+    SortinoLoss,
+)
 from .lstm import LongShortTermMemory, LSTMCell
 from .mlp import MultiLayerPerceptron
 from .rnn import RecurrentNeuralNetwork
@@ -98,6 +106,9 @@ __all__ = [
     # loss
     'BaseLoss',
     'DirectionalAccuracyLoss',
+    'CalmarLoss',
+    'HybridLoss',
+    'OmegaLoss',
     'SharpeLoss',
     'SortinoLoss',
 ]

--- a/fynance/models/loss/__init__.py
+++ b/fynance/models/loss/__init__.py
@@ -30,8 +30,12 @@ from __future__ import annotations
 
 # Local packages
 from ._base import BaseLoss
+from .calmar import CalmarLoss
 from .directional import DirectionalAccuracyLoss
+from .hybrid import HybridLoss
+from .omega import OmegaLoss
 from .sharpe import SharpeLoss
 from .sortino import SortinoLoss
 
-__all__ = ['BaseLoss', 'DirectionalAccuracyLoss', 'SharpeLoss', 'SortinoLoss']
+__all__ = ['BaseLoss', 'CalmarLoss', 'DirectionalAccuracyLoss', 'HybridLoss',
+           'OmegaLoss', 'SharpeLoss', 'SortinoLoss']

--- a/fynance/models/loss/calmar.py
+++ b/fynance/models/loss/calmar.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Differentiable Calmar-ratio loss. """
+
+from __future__ import annotations
+
+# Third-party packages
+import torch
+
+# Local packages
+from ._base import BaseLoss
+
+__all__ = ['CalmarLoss']
+
+
+class CalmarLoss(BaseLoss):
+    r""" Negative Calmar ratio as a differentiable loss.
+
+    Calmar = annualized return / maximum drawdown. Minimizing this loss
+    maximizes return per unit of worst peak-to-trough loss. The maximum
+    drawdown is computed differentiably from the cumulative return path
+    via :func:`torch.cummax`.
+
+    Parameters are inherited from :class:`BaseLoss` (``period``, ``eps``).
+
+    """
+
+    def forward(
+        self, y_pred: torch.Tensor, y_true: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """ Compute the negative Calmar ratio (scalar). """
+        self._check_tensor(y_pred)
+        equity = torch.cumsum(y_pred, dim=0)
+        running_max, _ = torch.cummax(equity, dim=0)
+        max_drawdown = (running_max - equity).max()
+        annual_return = y_pred.mean() * self.period
+
+        return -(annual_return / (max_drawdown + self.eps))

--- a/fynance/models/loss/hybrid.py
+++ b/fynance/models/loss/hybrid.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Multi-objective hybrid loss combining two financial losses. """
+
+from __future__ import annotations
+
+# Built-in packages
+import math
+
+# Third-party packages
+import torch
+
+# Local packages
+from ._base import BaseLoss
+
+__all__ = ['HybridLoss']
+
+
+class HybridLoss(BaseLoss):
+    r""" Convex combination of two losses: :math:`\alpha L_a + (1-\alpha) L_b`.
+
+    Combines two differentiable objectives (e.g. :class:`SharpeLoss` and
+    :class:`DirectionalAccuracyLoss`) with a weight ``alpha``. The weight can
+    be fixed or made **learnable** (an ``nn.Parameter`` passed through a sigmoid
+    so it stays in ``(0, 1)`` and is optimized jointly with the model).
+
+    Parameters
+    ----------
+    loss_a, loss_b : BaseLoss
+        The two component losses (any callables ``(y_pred, y_true) -> scalar``).
+    alpha : float, optional
+        Weight of ``loss_a`` in ``[0, 1]``. Default 0.5.
+    learnable : bool, optional
+        If True, ``alpha`` becomes a learnable parameter. Default False.
+    **kwargs
+        Forwarded to :class:`BaseLoss`.
+
+    """
+
+    def __init__(self, loss_a, loss_b, alpha: float = 0.5,
+                 learnable: bool = False, **kwargs):
+        super().__init__(**kwargs)
+        self.loss_a = loss_a
+        self.loss_b = loss_b
+        self.learnable = learnable
+        if learnable:
+            a = min(max(alpha, 1e-4), 1 - 1e-4)
+            self._alpha_raw = torch.nn.Parameter(
+                torch.tensor(math.log(a / (1 - a)))
+            )
+        else:
+            self.alpha = alpha
+
+    def forward(
+        self, y_pred: torch.Tensor, y_true: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """ Compute the weighted sum of the two losses (scalar). """
+        a = torch.sigmoid(self._alpha_raw) if self.learnable else self.alpha
+
+        return a * self.loss_a(y_pred, y_true) + (1 - a) * self.loss_b(y_pred, y_true)

--- a/fynance/models/loss/omega.py
+++ b/fynance/models/loss/omega.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Differentiable Omega-ratio loss. """
+
+from __future__ import annotations
+
+# Third-party packages
+import torch
+
+# Local packages
+from ._base import BaseLoss
+
+__all__ = ['OmegaLoss']
+
+
+class OmegaLoss(BaseLoss):
+    r""" Negative Omega ratio as a differentiable loss.
+
+    :math:`\Omega = \frac{E[\max(r - L, 0)]}{E[\max(L - r, 0)] + \varepsilon}`,
+    the ratio of expected gains to expected losses relative to a threshold
+    ``L``. Fully differentiable through :func:`torch.relu`. Minimizing the
+    loss maximizes the Omega ratio.
+
+    Parameters
+    ----------
+    threshold : float, optional
+        Return threshold ``L`` separating gains from losses. Default 0.
+    **kwargs
+        Forwarded to :class:`BaseLoss` (``rf``, ``period``, ``eps``).
+
+    """
+
+    def __init__(self, threshold: float = 0., **kwargs):
+        super().__init__(**kwargs)
+        self.threshold = threshold
+
+    def forward(
+        self, y_pred: torch.Tensor, y_true: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """ Compute the negative Omega ratio (scalar). """
+        self._check_tensor(y_pred)
+        diff = y_pred - self.threshold
+        gains = torch.relu(diff).mean()
+        losses = torch.relu(-diff).mean()
+
+        return -(gains / (losses + self.eps))

--- a/fynance/tests/models/test_loss.py
+++ b/fynance/tests/models/test_loss.py
@@ -131,3 +131,82 @@ class TestDirectionalAccuracyLoss:
     def test_type_error_y_true(self):
         with pytest.raises(TypeError, match="torch.Tensor"):
             DirectionalAccuracyLoss()(Y_PRED, np.array([1., -1.]))
+
+
+# ---------------------------------------------------------------------------
+# §5.1 new losses: Calmar, Omega, Hybrid
+# ---------------------------------------------------------------------------
+
+class TestCalmarLoss:
+    def test_scalar_and_grad(self):
+        from fynance.models.loss import CalmarLoss
+        r = torch.randn(120, 1, requires_grad=True)
+        loss = CalmarLoss()(r)
+        assert loss.ndim == 0
+        loss.backward()
+        assert r.grad is not None and torch.any(r.grad != 0)
+
+    def test_rejects_non_tensor(self):
+        from fynance.models.loss import CalmarLoss
+        with pytest.raises(TypeError):
+            CalmarLoss()(np.zeros(10))
+
+
+class TestOmegaLoss:
+    def test_known_value(self):
+        from fynance.models.loss import OmegaLoss
+        # gains mean = (1+3)/4 = 1 ; losses mean = (2+0+0+0... ) -> compute
+        r = torch.tensor([1.0, -2.0, 3.0, -1.0])
+        gains = torch.relu(r).mean()
+        losses = torch.relu(-r).mean()
+        expected = -(gains / (losses + 1e-8))
+        assert torch.isclose(OmegaLoss()(r), expected)
+
+    def test_threshold_and_grad(self):
+        from fynance.models.loss import OmegaLoss
+        r = torch.randn(100, 1, requires_grad=True)
+        loss = OmegaLoss(threshold=0.01)(r)
+        loss.backward()
+        assert r.grad is not None
+
+
+class TestHybridLoss:
+    def test_weighted_sum(self):
+        from fynance.models.loss import HybridLoss, SharpeLoss, SortinoLoss
+        r = torch.randn(100, 1)
+        a, b = SharpeLoss(), SortinoLoss()
+        h = HybridLoss(a, b, alpha=0.3)
+        expected = 0.3 * a(r) + 0.7 * b(r)
+        assert torch.isclose(h(r), expected)
+
+    def test_forwards_y_true(self):
+        from fynance.models.loss import DirectionalAccuracyLoss, HybridLoss, SharpeLoss
+        r = torch.randn(100, 1)
+        y = torch.randn(100, 1)
+        h = HybridLoss(SharpeLoss(), DirectionalAccuracyLoss(), alpha=0.5)
+        assert torch.isfinite(h(r, y))
+
+    def test_learnable_alpha_is_parameter(self):
+        from fynance.models.loss import HybridLoss, SharpeLoss, SortinoLoss
+        h = HybridLoss(SharpeLoss(), SortinoLoss(), alpha=0.5, learnable=True)
+        params = list(h.parameters())
+        assert len(params) == 1 and params[0].requires_grad
+        r = torch.randn(80, 1)
+        before = h._alpha_raw.detach().clone()
+        opt = torch.optim.SGD(h.parameters(), lr=1.0)
+        for _ in range(5):
+            opt.zero_grad()
+            h(r).backward()
+            opt.step()
+        assert not torch.allclose(before, h._alpha_raw)
+
+
+def test_train_model_with_calmar_loss():
+    from fynance.models.loss import CalmarLoss
+    from fynance.models.mlp import MultiLayerPerceptron
+    X = torch.randn(60, 3)
+    y = torch.randn(60, 1)
+    model = MultiLayerPerceptron(X, y, layers=[8])
+    model.set_optimizer(CalmarLoss, torch.optim.Adam, lr=1e-2)
+    loss = model.train_on(model.X, model.y)
+    assert torch.isfinite(loss)


### PR DESCRIPTION
Roadmap §5.1 (🟢). Three new differentiable training losses in `fynance.models.loss` (mirroring `SharpeLoss`):

- **`CalmarLoss`** — negative Calmar ratio; max drawdown computed differentiably from the cumulative path via `torch.cummax`.
- **`OmegaLoss`** — negative Omega `E[relu(r−L)] / E[relu(L−r)]` over a threshold `L`.
- **`HybridLoss`** — convex combination `α·L_a + (1−α)·L_b`; `α` fixed **or learnable** (an `nn.Parameter` through a sigmoid); forwards `y_true` to components (e.g. `DirectionalAccuracyLoss`).

Exported from `fynance.models` and `fynance.models.loss`. **9 new tests** + a CalmarLoss training test (26 in the loss suite). ruff/mypy(0)/pytest(354) green.

🟡 Still open (needs real data): the empirical benchmark comparing the losses out-of-sample.