### PR TITLE
feat: rolling rank-based feature normalization (roadmap 5.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `roll_rank` (`fynance.features.scale`) — rolling percentile-rank feature normalization (causal, outlier-robust)
+
 - New differentiable losses in `fynance.models.loss`: `CalmarLoss` (Calmar via `torch.cummax` drawdown), `OmegaLoss` (gain/loss ratio over a threshold), and `HybridLoss` (convex combo of two losses, with an optional learnable weight)
 
 - Realistic-backtest primitives: robustness metrics `percent_positive` / `tail_ratio` (`fynance.features`), and `fynance.algorithms.sizing` with `kelly_fraction`, causal `vol_target`, and turnover-based `transaction_cost`

--- a/PLAN-5.5-rank-normalization.md
+++ b/PLAN-5.5-rank-normalization.md
@@ -1,0 +1,18 @@
+# Plan — §5.5 Normalisation des features
+
+> Plan jetable à la racine (à archiver). Roadmap §5.5 (bloc 🟢).
+
+## État
+- **Rolling z-score** : déjà couvert par `roll_standardize` (scale) / `roll_z_score` (stats).
+- **Vol-targeting** : déjà couvert par `algorithms.sizing.vol_target` (PR #87).
+- **Rank-based normalization** : **ajouté** — `scale.roll_rank` (rang percentile
+  glissant strictement passé, [0,1], robuste aux outliers).
+
+## Tests (4)
+valeurs (doctest), bornes [0,1], **non-lookahead**, 2D colonne-par-colonne.
+
+## 🟡 Non fait (besoin de données)
+Comparaison empirique des 3 approches sur le Sharpe out-of-sample.
+
+## Vérif
+- 8 tests scale ; suite 359 ; ruff + mypy 0.

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -60,10 +60,11 @@ Bollinger/CCI/HMA. Reste **différé** (nécessite une API multi-séries OHLCV) 
 
 ### 5.5 Normalisation des features
 
-- [ ] **Rolling z-score** : `(x − μ_t) / σ_t` avec fenêtre strictement passée.
-- [ ] **Rank-based normalization** : rangs percentiles sur la fenêtre passée.
-- [ ] **Vol-targeting** : normaliser les returns par la vol réalisée passée.
-- [ ] Comparer empiriquement les trois approches sur le Sharpe out-of-sample.
+Couvert : rolling z-score (`roll_standardize`/`roll_z_score`), vol-targeting
+(`sizing.vol_target`), rank-based (`scale.roll_rank`, PR #89).
+
+- [ ] 🟡 Comparer empiriquement les trois approches sur le Sharpe out-of-sample
+  (nécessite des données).
 
 ### 5.6 Protocole d'entraînement robuste
 

--- a/fynance/features/scale.py
+++ b/fynance/features/scale.py
@@ -37,8 +37,8 @@ from fynance.features.momentums import *
 # Local packages
 from fynance.features.roll_functions import roll_max, roll_min
 
-__all__ = ["normalize", "roll_normalize", "roll_standardize", "Scale",
-           "standardize"]
+__all__ = ["normalize", "roll_normalize", "roll_rank", "roll_standardize",
+           "Scale", "standardize"]
 
 
 _HANDLER_MOMENTUM = {
@@ -480,6 +480,65 @@ def roll_normalize(X, w=None, a=0, b=1, axis=0):
         return _normalize(X.T, m, s, a, b).T
 
     return _normalize(X, m, s, a, b)
+
+
+def _roll_rank(X, w):
+    X = np.asarray(X, dtype=np.float64)
+    is1d = X.ndim == 1
+    if is1d:
+        X = X.reshape(-1, 1)
+    out = np.full(X.shape, 0.5)
+    for t in range(X.shape[0]):
+        win = X[max(0, t - w + 1):t + 1]
+        n = win.shape[0]
+        if n > 1:
+            out[t] = (win < X[t]).sum(axis=0) / (n - 1)
+
+    return out[:, 0] if is1d else out
+
+
+def roll_rank(X, w=None, axis=0):
+    r""" Rolling percentile rank of each observation within its past window.
+
+    For each ``t`` returns the fraction of the strictly-past window
+    ``[t-w+1, t]`` that is below ``X_t``, in ``[0, 1]`` (0 = lowest, 1 =
+    highest). Robust to outliers and strictly causal — useful as a feature
+    normalisation that ignores the scale/distribution of the raw series.
+
+    Parameters
+    ----------
+    X : np.ndarray[dtype, ndim=1 or 2]
+        Data to rank.
+    w : int, optional
+        Size of the lagged window. If ``None`` or ``0``, ``w = X.shape[axis]``.
+        Default None.
+    axis : int, optional
+        Axis along which to compute the rank. Default 0.
+
+    Returns
+    -------
+    np.ndarray[dtype, ndim=1 or 2]
+        Rolling percentile ranks in ``[0, 1]`` (0.5 for a single observation).
+
+    See Also
+    --------
+    roll_normalize, roll_standardize
+
+    Examples
+    --------
+    >>> X = np.array([1., 3., 2., 5., 4.])
+    >>> roll_rank(X, w=3)
+    array([0.5, 1. , 0.5, 1. , 0.5])
+
+    """
+    if w is None or w == 0:
+        w = X.shape[axis]
+
+    if axis == 1:
+
+        return _roll_rank(X.T, w).T
+
+    return _roll_rank(X, w)
 
 
 if __name__ == "__main__":

--- a/fynance/tests/features/test_scale.py
+++ b/fynance/tests/features/test_scale.py
@@ -113,3 +113,47 @@ def test_scale_roll_norm(set_variables):
     assert (s.params["s"] == std).all()
     assert (s(x_2d) == ((2 - 1) * scaled + 1).T).all()
     assert (s.revert(s(x_2d)) == x_2d).all()
+
+
+# §5.5 rank-based normalization
+
+def test_roll_rank_values():
+    import numpy as np
+
+    from fynance.features.scale import roll_rank
+    X = np.array([1., 3., 2., 5., 4.])
+    assert np.allclose(roll_rank(X, w=3), [0.5, 1., 0.5, 1., 0.5])
+
+
+def test_roll_rank_in_unit_interval():
+    import numpy as np
+
+    from fynance.features.scale import roll_rank
+    rng = np.random.RandomState(0)
+    out = np.asarray(roll_rank(rng.standard_normal(200), w=20))
+    assert out.min() >= 0.0 and out.max() <= 1.0
+
+
+def test_roll_rank_no_lookahead():
+    import numpy as np
+
+    from fynance.features.scale import roll_rank
+    rng = np.random.RandomState(1)
+    X = rng.standard_normal(100)
+    t = 60
+    base = np.asarray(roll_rank(X, w=20))
+    X2 = X.copy()
+    X2[t:] += 10.0
+    pert = np.asarray(roll_rank(X2, w=20))
+    assert np.allclose(base[:t], pert[:t])
+
+
+def test_roll_rank_2d_columnwise():
+    import numpy as np
+
+    from fynance.features.scale import roll_rank
+    X = np.array([1., 3., 2., 5., 4.])
+    X2 = np.column_stack([X, X[::-1]])
+    out = np.asarray(roll_rank(X2, w=3))
+    assert out.shape == (5, 2)
+    assert np.allclose(out[:, 0], roll_rank(X, w=3))


### PR DESCRIPTION
Roadmap §5.5 (🟢). Adds `scale.roll_rank` — rolling **percentile-rank** normalization within a strictly-past window (`[0,1]`, outlier-robust, causal).

The other two §5.5 approaches were already covered: rolling z-score (`roll_standardize` / `roll_z_score`) and vol-targeting (`algorithms.sizing.vol_target`, #87).

4 tests (doctest values, [0,1] bounds, **no-lookahead**, 2D column-wise). ruff/mypy(0)/pytest(359) green. 🟡 The empirical comparison of the three approaches stays open (needs data).