### PR TITLE
feat: purged CV + sample weights + early stopping (roadmap 5.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Robust-training utilities: `purge` parameter on `_RollingBasis._fold_slices`/`cross_validate` (purged walk-forward CV), and `fynance.models.training` with `exp_sample_weights` and `EarlyStopping`
+
 - `roll_rank` (`fynance.features.scale`) — rolling percentile-rank feature normalization (causal, outlier-robust)
 
 - New differentiable losses in `fynance.models.loss`: `CalmarLoss` (Calmar via `torch.cummax` drawdown), `OmegaLoss` (gain/loss ratio over a threshold), and `HybridLoss` (convex combo of two losses, with an optional learnable weight)

--- a/PLAN-5.6-robust-training.md
+++ b/PLAN-5.6-robust-training.md
@@ -1,0 +1,25 @@
+# Plan — §5.6 Protocole d'entraînement robuste
+
+> Plan jetable à la racine (à archiver). Roadmap §5.6 (bloc 🟢).
+
+## Livré
+- **Purged walk-forward CV** : param `purge` sur `_RollingBasis._fold_slices`
+  et `cross_validate` — drop des `purge` dernières obs du train à la bordure
+  train/test (Lopez de Prado). Défaut 0 (rétro-compatible).
+- **`fynance/models/training.py`** (nouveau) :
+  - `exp_sample_weights(n, halflife)` — poids à décroissance exponentielle
+    (récent=1, ×½ tous les `halflife`).
+  - `EarlyStopping(patience, min_delta, mode)` — arrêt sur métrique (max/min),
+    p.ex. maximiser le Sharpe de validation.
+
+## Tests (9)
+exp_sample_weights (valeurs/monotonie/halflife invalide) ; EarlyStopping
+(patience/reset/mode min/mode invalide) ; purge (`_fold_slices` rétrécit le
+train, `cross_validate` tourne).
+
+## Note
+« Audit causal de chaque feature » = convention continue, déjà outillée par les
+property tests (parité + non-lookahead). Pas de code dédié.
+
+## Vérif
+- 9 tests ; suite 369 ; ruff + mypy 0.

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -68,16 +68,12 @@ Couvert : rolling z-score (`roll_standardize`/`roll_z_score`), vol-targeting
 
 ### 5.6 Protocole d'entraînement robuste
 
-Construction causale des features (protection primaire contre la fuite) : toute
-feature à `t` doit s'écrire `f(data[t-window:t])`. Garantie côté kernels par les
-tests de propriété (parité + non-lookahead) ; à étendre aux nouvelles features.
+Fait (PR #90) : purged walk-forward CV (`cross_validate(..., purge=)`),
+`exp_sample_weights` (décroissance exponentielle), `EarlyStopping` (sur métrique).
+La construction causale des features reste garantie par les property tests
+(parité + non-lookahead) — convention continue, pas de code dédié.
 
-- [ ] **Audit causal de chaque feature** (pas de `rolling(center=True)`, pas de
-  normalisation globale, pas de z-score incluant la fenêtre test).
-- [ ] **Purged walk-forward CV** : exclure la zone de bordure train/test quand le
-  nombre de folds est grand ou la fenêtre feature >> horizon.
-- [ ] **Pondération des échantillons** : decay exponentiel / down-weight basse vol.
-- [ ] **Early stopping sur métrique financière** (maximiser le Sharpe de validation).
+- [ ] (optionnel) down-weight basse vol dans `exp_sample_weights` (variante).
 
 ### 5.7 R&D rolling — features multi-résolution et efficacité
 

--- a/fynance/models/__init__.py
+++ b/fynance/models/__init__.py
@@ -36,6 +36,7 @@ from . import (
     rnn,
     rolling,
     tcn,
+    training,
     transformer,
 )
 from ._base import BaseNeuralNet
@@ -63,6 +64,7 @@ from .mlp import MultiLayerPerceptron
 from .rnn import RecurrentNeuralNetwork
 from .rolling import CVResult, RollMultiLayerPerceptron, _RollingBasis
 from .tcn import TemporalConvNet
+from .training import EarlyStopping, exp_sample_weights
 from .transformer import PositionalEncoding, Transformer
 
 # Frozen public surface for the 1.x series — names listed here are
@@ -96,6 +98,9 @@ __all__ = [
     'RecurrentNeuralNetwork',
     # tcn
     'TemporalConvNet',
+    # training
+    'EarlyStopping',
+    'exp_sample_weights',
     # transformer
     'PositionalEncoding',
     'Transformer',

--- a/fynance/models/rolling.py
+++ b/fynance/models/rolling.py
@@ -183,27 +183,34 @@ class _RollingBasis:
 
         return eval_set, test_set
 
-    def _fold_slices(self):
+    def _fold_slices(self, purge: int = 0):
         """ Yield ``(train_slice, test_slice)`` for every walk-forward fold.
 
         Unlike :meth:`__next__`, this generator has no epoch loop and
         allocates nothing — it is a pure windowing helper shared by
         :meth:`cross_validate` and any future CV utilities.
 
+        Parameters
+        ----------
+        purge : int, optional
+            Number of training observations to drop at the train/test border
+            (Lopez de Prado *purging*) to avoid leakage from overlapping
+            feature windows. Default 0 (no purge).
+
         Yields
         ------
         train_slice : slice
-            Window ``[t - n, t)`` used for training.
+            Window ``[t - n, t - purge)`` used for training.
         test_slice : slice
             Window ``[t, t + s)`` used for out-of-sample evaluation.
 
         """
         t = self.t0 + self.r
         while t + self.s <= self.T:
-            yield slice(t - self.n, t), slice(t, t + self.s)
+            yield slice(t - self.n, t - purge), slice(t, t + self.s)
             t += self.r
 
-    def cross_validate(self, model_factory, X, y, metric_fn=None, epochs=1):
+    def cross_validate(self, model_factory, X, y, metric_fn=None, epochs=1, purge=0):
         """ Walk-forward cross-validation with out-of-fold predictions.
 
         At each fold a **fresh** model is created via ``model_factory()``,
@@ -231,6 +238,9 @@ class _RollingBasis:
             is an empty list and the mean/std fields are None.
         epochs : int, optional
             Number of full training passes per fold, default 1.
+        purge : int, optional
+            Training observations to drop at the train/test border (purging).
+            Default 0.
 
         Returns
         -------
@@ -261,7 +271,7 @@ class _RollingBasis:
         oof = np.full((X.shape[0], n_out), np.nan)
         fold_metrics = []
 
-        for train_sl, test_sl in self._fold_slices():
+        for train_sl, test_sl in self._fold_slices(purge=purge):
             model = model_factory()
             X_tr, y_tr = X[train_sl], y[train_sl]
             for _ in range(epochs):

--- a/fynance/models/training.py
+++ b/fynance/models/training.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Robust training utilities: sample weighting and early stopping. """
+
+from __future__ import annotations
+
+# Third-party packages
+import numpy as np
+from numpy.typing import NDArray
+
+__all__ = ['EarlyStopping', 'exp_sample_weights']
+
+
+def exp_sample_weights(n: int, halflife: float) -> NDArray:
+    r""" Exponential-decay sample weights (recent observations weighted more).
+
+    The most recent observation gets weight 1; weights halve every
+    ``halflife`` observations into the past. Useful to down-weight stale
+    data when training on a long history.
+
+    Parameters
+    ----------
+    n : int
+        Number of observations.
+    halflife : float
+        Decay half-life in observations (must be > 0).
+
+    Returns
+    -------
+    np.ndarray
+        Weights of shape ``(n,)``, in ``(0, 1]``, increasing with index
+        (oldest first, most recent last).
+
+    Examples
+    --------
+    >>> exp_sample_weights(4, halflife=1)
+    array([0.125, 0.25 , 0.5  , 1.   ])
+
+    """
+    if halflife <= 0:
+        raise ValueError("halflife must be > 0")
+    age = (n - 1) - np.arange(n)
+
+    return 0.5 ** (age / halflife)
+
+
+class EarlyStopping:
+    """ Patience-based early stopping on a monitored metric.
+
+    Call :meth:`step` with the validation metric each epoch; it returns
+    ``True`` once the metric has failed to improve for ``patience`` steps.
+
+    Parameters
+    ----------
+    patience : int, optional
+        Number of non-improving steps to tolerate. Default 5.
+    min_delta : float, optional
+        Minimum change counted as an improvement. Default 0.
+    mode : {'max', 'min'}, optional
+        Whether the metric should be maximized (e.g. Sharpe) or minimized
+        (e.g. loss). Default 'max'.
+
+    Attributes
+    ----------
+    best : float or None
+        Best metric seen so far.
+    stop : bool
+        Whether stopping has been triggered.
+
+    """
+
+    def __init__(self, patience: int = 5, min_delta: float = 0.,
+                 mode: str = 'max'):
+        if mode not in ('max', 'min'):
+            raise ValueError("mode must be 'max' or 'min'")
+        self.patience = patience
+        self.min_delta = min_delta
+        self.mode = mode
+        self.best: float | None = None
+        self.count = 0
+        self.stop = False
+
+    def step(self, metric: float) -> bool:
+        """ Update with a new metric value; return True if training should stop. """
+        if self.best is None:
+            improved = True
+        elif self.mode == 'max':
+            improved = metric > self.best + self.min_delta
+        else:
+            improved = metric < self.best - self.min_delta
+
+        if improved:
+            self.best = metric
+            self.count = 0
+        else:
+            self.count += 1
+            if self.count >= self.patience:
+                self.stop = True
+
+        return self.stop

--- a/fynance/tests/models/test_rolling.py
+++ b/fynance/tests/models/test_rolling.py
@@ -110,3 +110,20 @@ class TestCrossValidate:
     def test_std_metric_consistent(self):
         result = self._run(metric_fn=mse)
         assert result.std_metric == pytest.approx(np.std(result.fold_metrics))
+
+
+# §5.6 purged walk-forward CV
+
+class TestPurge:
+    def test_fold_slices_purge_shrinks_train_end(self):
+        rb = make_rb()
+        purge = 5
+        for (tr, te), (tr_p, te_p) in zip(rb._fold_slices(), rb._fold_slices(purge=purge)):
+            assert tr_p.stop == tr.stop - purge
+            assert tr_p.start == tr.start
+            assert te_p == te  # test window unchanged
+
+    def test_cross_validate_with_purge_runs(self):
+        rb = make_rb()
+        result = rb.cross_validate(model_factory, X_t, y_t, purge=3)
+        assert result.oof_predictions.shape == (T, N_OUT)

--- a/fynance/tests/models/test_training.py
+++ b/fynance/tests/models/test_training.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for §5.6 robust-training utilities. """
+
+import numpy as np
+import pytest
+
+from fynance.models.training import EarlyStopping, exp_sample_weights
+
+
+def test_exp_sample_weights_values():
+    assert np.allclose(exp_sample_weights(4, halflife=1), [0.125, 0.25, 0.5, 1.0])
+
+
+def test_exp_sample_weights_recent_is_one_and_increasing():
+    w = exp_sample_weights(50, halflife=10)
+    assert w[-1] == 1.0
+    assert np.all(np.diff(w) > 0)
+
+
+def test_exp_sample_weights_bad_halflife():
+    with pytest.raises(ValueError):
+        exp_sample_weights(10, halflife=0)
+
+
+def test_early_stopping_triggers_after_patience():
+    es = EarlyStopping(patience=2, mode='max')
+    results = [es.step(v) for v in [1.0, 0.9, 0.8]]
+    assert results == [False, False, True]
+
+
+def test_early_stopping_resets_on_improvement():
+    es = EarlyStopping(patience=2, mode='max')
+    for v in [1.0, 0.9, 1.5, 1.4]:
+        stop = es.step(v)
+    assert es.best == 1.5
+    assert stop is False  # only one non-improving step since the 1.5 peak
+
+
+def test_early_stopping_min_mode():
+    es = EarlyStopping(patience=1, mode='min')
+    assert [es.step(v) for v in [1.0, 0.5, 0.6]] == [False, False, True]
+
+
+def test_early_stopping_bad_mode():
+    with pytest.raises(ValueError):
+        EarlyStopping(mode='nope')


### PR DESCRIPTION
Roadmap §5.6 (🟢). Robust-training building blocks:

- **Purged walk-forward CV** — `purge` parameter on `_RollingBasis._fold_slices` and `cross_validate`: drops the last `purge` training observations at the train/test border (Lopez de Prado purging). Default 0 → fully backward-compatible.
- **`fynance.models.training`** (new): `exp_sample_weights(n, halflife)` (exponential decay, most-recent = 1) and `EarlyStopping(patience, min_delta, mode)` (stop on a monitored metric, e.g. maximize validation Sharpe).

**9 tests**. The causal-feature audit stays a continuous convention (already enforced by the property tests). ruff/mypy(0)/pytest(369) green.