### PR TITLE
feat: feature-engineering tools (roadmap 5.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `fynance.features.engineering`: `multi_resolution` (stack a feature across windows), `granger_causality` (F-test feature filter), `IncrementalMoments` (O(1) online mean/variance)
+
 - Robust-training utilities: `purge` parameter on `_RollingBasis._fold_slices`/`cross_validate` (purged walk-forward CV), and `fynance.models.training` with `exp_sample_weights` and `EarlyStopping`
 
 - `roll_rank` (`fynance.features.scale`) — rolling percentile-rank feature normalization (causal, outlier-robust)

--- a/PLAN-5.7-feature-engineering.md
+++ b/PLAN-5.7-feature-engineering.md
@@ -1,0 +1,22 @@
+# Plan — §5.7 R&D rolling : multi-résolution & efficacité
+
+> Plan jetable à la racine (à archiver). Roadmap §5.7 (bloc 🟢).
+
+## Livré (`fynance/features/engineering.py`)
+- `multi_resolution(func, X, windows)` — empile une feature window-based à
+  plusieurs résolutions (colonne par fenêtre).
+- `granger_causality(x, y, lag)` — test F de causalité de Granger (filtrage de
+  features) → (F, p-value) via OLS numpy + scipy.f.
+- `IncrementalMoments` — moyenne/variance en ligne O(1) (Welford), prototype
+  pour mises à jour incrémentales.
+
+## Tests (6)
+multi_res (forme + colonnes) ; granger (cause détectée p<0.01, indépendant
+p>0.05, série trop courte lève) ; IncrementalMoments (== numpy batch, chaînage).
+
+## Différé
+**Fenêtres adaptatives** (window selon régime de vol) — flou, dépend de §5.3
+(détection de régime). À traiter après 5.3.
+
+## Vérif
+- 6 tests ; suite 377 ; ruff + mypy 0 ; doctests (multi_resolution, IncrementalMoments).

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -77,11 +77,11 @@ La construction causale des features reste garantie par les property tests
 
 ### 5.7 R&D rolling — features multi-résolution et efficacité
 
-- [ ] **Multi-résolution** : mêmes features sur plusieurs fenêtres (5/10/21/63) concaténées.
-- [ ] **Streaming / mises à jour incrémentales** : prototype `IncrementalFeature`
-  (formule récursive O(1) par pas pour GARCH, corrélations).
-- [ ] **Fenêtres adaptatives** : `window` variable selon le régime de vol.
-- [ ] **Test de causalité de Granger** : filtrer les features sans signal prédictif.
+Fait (PR #91) : `multi_resolution`, `granger_causality`, `IncrementalMoments`
+(Welford O(1)) dans `features/engineering.py`.
+
+- [ ] **Fenêtres adaptatives** : `window` variable selon le régime de vol
+  (dépend de §5.3 détection de régime).
 
 ### 5.8 Backtest réaliste
 

--- a/fynance/features/__init__.py
+++ b/fynance/features/__init__.py
@@ -27,6 +27,7 @@ features.
 # Cython imports
 # Python imports
 from . import (
+    engineering,
     filters,
     indicators,
     metrics,
@@ -38,6 +39,7 @@ from . import (
     roll_functions_cy,
     scale,
 )
+from .engineering import *
 from .filters import *
 from .indicators import *
 from .metrics import *
@@ -49,7 +51,8 @@ from .roll_functions import *
 from .roll_functions_cy import *
 from .scale import *
 
-__all__ = filters.__all__
+__all__ = engineering.__all__
+__all__ += filters.__all__
 __all__ += metrics_cy.__all__
 __all__ += metrics.__all__
 __all__ += momentums_cy.__all__

--- a/fynance/features/engineering.py
+++ b/fynance/features/engineering.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Feature-engineering & selection research tools.
+
+Multi-resolution feature stacking, incremental (O(1)) moment updates, and a
+Granger-causality test for filtering candidate features.
+"""
+
+from __future__ import annotations
+
+# Built-in packages
+from typing import Callable
+
+# Third-party packages
+import numpy as np
+from numpy.typing import NDArray
+from scipy import stats as _sp_stats
+
+__all__ = ['IncrementalMoments', 'granger_causality', 'multi_resolution']
+
+
+def multi_resolution(
+    func: Callable[..., NDArray], X: NDArray, windows, **kwargs,
+) -> NDArray:
+    r""" Stack a window-based feature computed at several resolutions.
+
+    Applies ``func(X, w, **kwargs)`` for every window ``w`` in ``windows`` and
+    column-stacks the results, letting a model learn the relevant horizon
+    instead of fixing one.
+
+    Parameters
+    ----------
+    func : callable
+        A feature function taking ``(X, w, **kwargs)`` (e.g.
+        :func:`~fynance.features.momentums.sma`,
+        :func:`~fynance.features.indicators.realized_volatility`).
+    X : np.ndarray
+        One-dimensional input series.
+    windows : iterable of int
+        Window sizes / resolutions.
+    **kwargs
+        Extra keyword arguments forwarded to ``func``.
+
+    Returns
+    -------
+    np.ndarray
+        Array of shape ``(len(X), len(windows))``, one column per resolution.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from fynance.features.momentums import sma
+    >>> X = np.arange(1., 6.)
+    >>> multi_resolution(sma, X, [2, 3]).shape
+    (5, 2)
+
+    """
+    cols = [np.asarray(func(X, w, **kwargs)).reshape(-1) for w in windows]
+
+    return np.column_stack(cols)
+
+
+def granger_causality(x: NDArray, y: NDArray, lag: int = 1) -> tuple[float, float]:
+    r""" Granger-causality F-test: does ``x`` help predict ``y``?
+
+    Compares a restricted autoregression of ``y`` on its own lags with an
+    unrestricted one that also includes lags of ``x``. A small p-value means
+    ``x`` Granger-causes ``y`` (adds predictive power beyond ``y``'s past).
+
+    Parameters
+    ----------
+    x, y : np.ndarray
+        One-dimensional series of equal length.
+    lag : int, optional
+        Number of lags. Default 1.
+
+    Returns
+    -------
+    f_stat : float
+        F statistic of the restricted-vs-unrestricted comparison.
+    p_value : float
+        Associated p-value (low → ``x`` Granger-causes ``y``).
+
+    """
+    x = np.asarray(x, dtype=np.float64).reshape(-1)
+    y = np.asarray(y, dtype=np.float64).reshape(-1)
+    n = y.shape[0] - lag
+    if n <= 2 * lag + 1:
+        raise ValueError("series too short for the requested lag")
+
+    target = y[lag:]
+    y_lags = np.column_stack([y[lag - k - 1:-k - 1] for k in range(lag)])
+    x_lags = np.column_stack([x[lag - k - 1:-k - 1] for k in range(lag)])
+    ones = np.ones((n, 1))
+
+    def _rss(design):
+        beta, _, _, _ = np.linalg.lstsq(design, target, rcond=None)
+        resid = target - design @ beta
+        return float(resid @ resid)
+
+    rss_r = _rss(np.hstack([ones, y_lags]))
+    rss_u = _rss(np.hstack([ones, y_lags, x_lags]))
+
+    df_u = n - (2 * lag + 1)
+    f_stat = ((rss_r - rss_u) / lag) / (rss_u / df_u + 1e-12)
+    p_value = float(_sp_stats.f.sf(f_stat, lag, df_u))
+
+    return float(f_stat), p_value
+
+
+class IncrementalMoments:
+    """ Online mean / variance via Welford's algorithm (O(1) per update).
+
+    Streaming alternative to recomputing a rolling mean/variance from scratch.
+
+    Attributes
+    ----------
+    n : int
+        Number of observations seen.
+    mean : float
+        Running mean.
+
+    Examples
+    --------
+    >>> im = IncrementalMoments()
+    >>> for v in [1.0, 2.0, 3.0]:
+    ...     _ = im.update(v)
+    >>> im.mean, round(im.var, 4)
+    (2.0, 0.6667)
+
+    """
+
+    def __init__(self):
+        self.n = 0
+        self.mean = 0.0
+        self._m2 = 0.0
+
+    def update(self, x: float) -> "IncrementalMoments":
+        """ Incorporate one observation; return self for chaining. """
+        self.n += 1
+        delta = x - self.mean
+        self.mean += delta / self.n
+        self._m2 += delta * (x - self.mean)
+
+        return self
+
+    @property
+    def var(self) -> float:
+        """ Population variance (0 before the second observation). """
+        return self._m2 / self.n if self.n > 0 else 0.0
+
+    @property
+    def std(self) -> float:
+        """ Population standard deviation. """
+        return self.var ** 0.5

--- a/fynance/tests/features/test_engineering.py
+++ b/fynance/tests/features/test_engineering.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for §5.7 feature-engineering tools. """
+
+import numpy as np
+import pytest
+
+from fynance.features.engineering import (
+    IncrementalMoments,
+    granger_causality,
+    multi_resolution,
+)
+from fynance.features.momentums import sma
+
+
+def test_multi_resolution_shape_and_columns():
+    X = np.arange(1.0, 11.0)
+    out = multi_resolution(sma, X, [2, 3])
+    assert out.shape == (10, 2)
+    assert np.allclose(out[:, 0], np.asarray(sma(X, 2)).reshape(-1))
+    assert np.allclose(out[:, 1], np.asarray(sma(X, 3)).reshape(-1))
+
+
+def test_granger_detects_causality():
+    rng = np.random.RandomState(0)
+    x = rng.standard_normal(300)
+    y = np.r_[0.0, 0.8 * x[:-1]] + 0.1 * rng.standard_normal(300)
+    _, p = granger_causality(x, y, lag=1)
+    assert p < 0.01
+
+
+def test_granger_independent_not_significant():
+    rng = np.random.RandomState(1)
+    _, p = granger_causality(rng.standard_normal(300), rng.standard_normal(300), lag=1)
+    assert p > 0.05
+
+
+def test_granger_too_short_raises():
+    with pytest.raises(ValueError):
+        granger_causality(np.arange(3.0), np.arange(3.0), lag=1)
+
+
+def test_incremental_moments_matches_numpy():
+    rng = np.random.RandomState(2)
+    data = rng.standard_normal(100)
+    im = IncrementalMoments()
+    for v in data:
+        im.update(v)
+    assert im.n == 100
+    assert np.isclose(im.mean, data.mean())
+    assert np.isclose(im.var, data.var())
+    assert np.isclose(im.std, data.std())
+
+
+def test_incremental_update_returns_self():
+    im = IncrementalMoments()
+    assert im.update(1.0) is im


### PR DESCRIPTION
Roadmap §5.7 (🟢). New `fynance.features.engineering`:

- **`multi_resolution(func, X, windows)`** — stack a window-based feature (sma, realized_volatility, …) across several resolutions (one column per window).
- **`granger_causality(x, y, lag)`** — OLS-based Granger F-test (restricted vs unrestricted AR); returns `(F, p_value)` to filter features without predictive signal.
- **`IncrementalMoments`** — Welford online mean/variance, O(1) per update (the `IncrementalFeature` prototype).

**6 tests** (incl. Granger detecting a causal link p<0.01 vs independent p>0.05) + doctests. ruff/mypy(0)/pytest(377) green. Adaptive windows deferred (depend on §5.3 regimes).