### PR TITLE
feat: market-regime detection (roadmap 5.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `detect_regimes` (`fynance.features.regime`) — k-means market-regime labelling on rolling vol/return features, ordered by volatility
+
 - `fynance.features.engineering`: `multi_resolution` (stack a feature across windows), `granger_causality` (F-test feature filter), `IncrementalMoments` (O(1) online mean/variance)
 
 - Robust-training utilities: `purge` parameter on `_RollingBasis._fold_slices`/`cross_validate` (purged walk-forward CV), and `fynance.models.training` with `exp_sample_weights` and `EarlyStopping`

--- a/PLAN-5.3-regime-detection.md
+++ b/PLAN-5.3-regime-detection.md
@@ -1,0 +1,23 @@
+# Plan — §5.3 Régimes de marché
+
+> Plan jetable à la racine (à archiver). Roadmap §5.3 (bloc 🟢).
+
+## Livré (`fynance/features/regime.py`)
+- `detect_regimes(X, n_regimes, w, period, seed)` — labels de régime par k-means
+  (scipy) sur 2 features (vol réalisée glissante + return moyen glissant),
+  standardisées. Labels **ordonnés par vol croissante** (0=calme … n-1=volatil).
+
+## Note causalité
+k-means **in-sample** (voit toute la série) → outil d'**analyse** / étude de
+conditionnement, pas une feature strictement causale. L'assignation online
+causale (fit sur le passé) est l'extension 🟡.
+
+## Tests (3)
+forme + range des labels ; ordonnancement par vol (calme < volatil) ; déterminisme (seed).
+
+## 🟡 Non fait (besoin de données / expériences)
+- Conditionner l'architecture (mixture-of-experts / embedding de régime).
+- Évaluer si la détection améliore le Sharpe out-of-sample.
+
+## Vérif
+- 3 tests ; suite 380 ; ruff + mypy 0.

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -42,11 +42,11 @@ Fait (PR #88) : `CalmarLoss`, `OmegaLoss`, `HybridLoss` (α fixe ou learnable).
 
 ### 5.3 Régimes de marché
 
-- [ ] Identifier des régimes (bull/bear/sideways/high-vol) via HMM ou k-means
-  sur les features de volatilité réalisée.
-- [ ] Conditionner l'architecture : un modèle par régime (mixture of experts),
-  ou un embedding de régime concaténé aux features d'entrée.
-- [ ] Évaluer si la détection de régime améliore le Sharpe out-of-sample.
+Fait (PR #92) : `detect_regimes` (k-means in-sample sur vol/return, labels
+ordonnés par vol). Reste 🟡 (besoin de données / orchestration) :
+
+- [ ] Conditionner l'architecture (mixture-of-experts / embedding de régime).
+- [ ] Assignation online causale + évaluer l'impact sur le Sharpe out-of-sample.
 
 ### 5.4 Features / indicateurs techniques
 

--- a/fynance/features/__init__.py
+++ b/fynance/features/__init__.py
@@ -35,6 +35,7 @@ from . import (
     momentums,
     momentums_cy,
     money_management,
+    regime,
     roll_functions,
     roll_functions_cy,
     scale,
@@ -47,11 +48,13 @@ from .metrics_cy import *
 from .momentums import *
 from .momentums_cy import *
 from .money_management import *
+from .regime import *
 from .roll_functions import *
 from .roll_functions_cy import *
 from .scale import *
 
 __all__ = engineering.__all__
+__all__ += regime.__all__
 __all__ += filters.__all__
 __all__ += metrics_cy.__all__
 __all__ += metrics.__all__

--- a/fynance/features/regime.py
+++ b/fynance/features/regime.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Market-regime detection.
+
+Unsupervised labelling of market regimes (e.g. calm / volatile, trending /
+mean-reverting) by clustering rolling volatility and return features. Intended
+for *analysis* and architecture conditioning (a model per regime, or a regime
+embedding) — see the notes on causality.
+"""
+
+from __future__ import annotations
+
+# Third-party packages
+import numpy as np
+from numpy.typing import NDArray
+from scipy.cluster.vq import kmeans2
+
+# Local packages
+from fynance.features.indicators import realized_volatility
+
+__all__ = ['detect_regimes']
+
+
+def detect_regimes(
+    X: NDArray, n_regimes: int = 3, w: int = 21, period: int = 252, seed: int = 0,
+) -> NDArray:
+    r""" Label market regimes by k-means on rolling vol / return features.
+
+    Builds two features per date — trailing realized volatility and trailing
+    mean return — standardizes them, and clusters with k-means into
+    ``n_regimes`` groups. Labels are **ordered by mean volatility** (0 = calmest,
+    ``n_regimes - 1`` = most volatile) so they are comparable across runs.
+
+    .. note::
+
+       The clustering is fit **in-sample** (it sees the whole series), so the
+       labels are appropriate for *analysis* and for studying regime
+       conditioning — not as a strictly-causal online feature. A causal online
+       assignment (fit on the past only) is a separate extension.
+
+    Parameters
+    ----------
+    X : np.ndarray
+        One-dimensional price/level series.
+    n_regimes : int, optional
+        Number of regimes (clusters). Default 3.
+    w : int, optional
+        Rolling window for the features. Default 21.
+    period : int, optional
+        Annualization factor for the volatility feature. Default 252.
+    seed : int, optional
+        Seed for the k-means initialization. Default 0.
+
+    Returns
+    -------
+    np.ndarray
+        Integer regime label per observation, shape ``(len(X),)``, in
+        ``[0, n_regimes)`` and ordered by increasing average volatility.
+
+    """
+    X = np.asarray(X, dtype=np.float64).reshape(-1)
+    vol = np.asarray(realized_volatility(X, w=w, period=period))
+    ret = np.zeros_like(X)
+    ret[1:] = np.log(X[1:] / X[:-1])
+    roll_ret = np.zeros_like(X)
+    for t in range(X.shape[0]):
+        roll_ret[t] = ret[max(0, t - w + 1):t + 1].mean()
+
+    feats = np.column_stack([vol, roll_ret])
+    mu = feats.mean(axis=0)
+    sd = feats.std(axis=0)
+    sd[sd == 0] = 1.0
+    feats = (feats - mu) / sd
+
+    _, labels = kmeans2(feats, n_regimes, seed=seed, minit='++', missing='raise')
+
+    # Re-order labels by increasing mean volatility for stable interpretation.
+    order = np.argsort([vol[labels == k].mean() for k in range(n_regimes)])
+    remap = np.empty(n_regimes, dtype=int)
+    remap[order] = np.arange(n_regimes)
+
+    return remap[labels]

--- a/fynance/tests/features/test_regime.py
+++ b/fynance/tests/features/test_regime.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for §5.3 market-regime detection. """
+
+import numpy as np
+
+from fynance.features.regime import detect_regimes
+
+
+def _two_regime_series(seed=0):
+    rng = np.random.RandomState(seed)
+    r = np.r_[rng.standard_normal(120) * 0.004, rng.standard_normal(120) * 0.03]
+    return 100 * np.cumprod(1 + r)
+
+
+def test_labels_shape_and_range():
+    X = _two_regime_series()
+    labels = detect_regimes(X, n_regimes=3, w=15)
+    assert labels.shape == (240,)
+    assert set(np.unique(labels)).issubset({0, 1, 2})
+
+
+def test_labels_ordered_by_volatility():
+    X = _two_regime_series()
+    labels = detect_regimes(X, n_regimes=2, w=15)
+    # calm first half should get a lower (calmer) regime label than the volatile half
+    assert labels[20:120].mean() < labels[140:].mean()
+
+
+def test_deterministic_with_seed():
+    X = _two_regime_series()
+    a = detect_regimes(X, n_regimes=2, w=15, seed=42)
+    b = detect_regimes(X, n_regimes=2, w=15, seed=42)
+    assert np.array_equal(a, b)


### PR DESCRIPTION
Roadmap §5.3 (🟢). New `fynance.features.regime.detect_regimes` — labels market regimes by **k-means** (scipy) on standardized rolling **realized volatility + mean return**, with labels **ordered by volatility** (0 = calm … n-1 = volatile) for stable interpretation.

3 tests (shape/range, vol ordering, seed determinism). ruff/mypy(0)/pytest(380) green.

> Note: clustering is in-sample (an analysis / conditioning-study tool, not a strictly-causal online feature). 🟡 Deferred (need data/orchestration): architecture conditioning (mixture-of-experts / regime embedding), causal online assignment, and out-of-sample evaluation.