### PR TITLE
feat: direction+magnitude stacking ensemble (roadmap 5.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `StackingEnsemble` (`fynance.models.ensemble`) — direction + magnitude base models combined by a meta-model trained on their out-of-fold predictions (leak-free stacking)
+
 - `detect_regimes` (`fynance.features.regime`) — k-means market-regime labelling on rolling vol/return features, ordered by volatility
 
 - `fynance.features.engineering`: `multi_resolution` (stack a feature across windows), `granger_causality` (F-test feature filter), `IncrementalMoments` (O(1) online mean/variance)

--- a/PLAN-5.2-stacking-ensemble.md
+++ b/PLAN-5.2-stacking-ensemble.md
@@ -1,0 +1,21 @@
+# Plan — §5.2 Ensemble direction + magnitude (meta-modèle)
+
+> Plan jetable à la racine (à archiver). Roadmap §5.2 (bloc 🟢).
+
+## Livré (`fynance/models/ensemble.py`)
+`StackingEnsemble(direction_factory, magnitude_factory, meta_factory)` :
+- modèle direction (ex. `DirectionalAccuracyLoss`) + modèle magnitude (MSE/Sortino).
+- `fit_predict(X, y, train/test/roll)` : OOF des 2 bases via `cross_validate`
+  (leak-free), empilés comme méta-features, méta-modèle (ex. `SharpeLoss`)
+  entraîné dessus. Retourne les prédictions méta (NaN avant le 1er fold).
+
+Anti-fuite : les méta-features sont **out-of-fold** (jamais in-sample des bases).
+
+## Tests (3)
+forme (T,M) ; OOF NaN avant 1er fold + fini après ; le méta reçoit 2·M features.
+
+## 🟡 Non fait (besoin de données)
+Comparaison empirique vs modèle unique entraîné directement avec SharpeLoss.
+
+## Vérif
+- 3 tests ; suite 383 ; ruff + mypy 0.

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -31,14 +31,10 @@ Fait (PR #88) : `CalmarLoss`, `OmegaLoss`, `HybridLoss` (α fixe ou learnable).
 
 ### 5.2 Architecture : ensemble direction + magnitude avec meta-modèle
 
-- [ ] **Modèle 1 (direction)** : entraîné avec `DirectionalAccuracyLoss`,
-  sortie = probabilité de signe positif (sigmoid).
-- [ ] **Modèle 2 (magnitude)** : entraîné avec MSE ou `SortinoLoss`,
-  sortie = estimation du return.
-- [ ] **Meta-modèle** : prend `[signal_1, magnitude_2]` en entrée,
-  entraîné avec `SharpeLoss` ou `SortinoLoss`, sur les prédictions out-of-fold
-  (walk-forward OOF) pour éviter la fuite de données.
-- [ ] Comparer vs. modèle unique entraîné directement avec `SharpeLoss`.
+Fait (PR #93) : `StackingEnsemble` — bases direction/magnitude + méta-modèle
+entraîné sur les prédictions **out-of-fold** (leak-free).
+
+- [ ] 🟡 Comparer empiriquement vs modèle unique `SharpeLoss` (besoin de données).
 
 ### 5.3 Régimes de marché
 

--- a/fynance/models/__init__.py
+++ b/fynance/models/__init__.py
@@ -29,6 +29,7 @@ from . import (
     attention,
     econometric_models,
     econometric_models_cy,
+    ensemble,
     gru,
     loss,
     lstm,
@@ -49,6 +50,7 @@ from .econometric_models_cy import (
     MA_cy,
     get_parameters_cy,
 )
+from .ensemble import StackingEnsemble
 from .gru import GatedRecurrentUnit, GRUCell
 from .loss import (
     BaseLoss,
@@ -89,6 +91,7 @@ __all__ = [
     'get_parameters_cy',
     # _base / mlp
     'BaseNeuralNet',
+    'StackingEnsemble',
     'MultiLayerPerceptron',
     # rnn / gru / lstm
     'GRUCell',

--- a/fynance/models/ensemble.py
+++ b/fynance/models/ensemble.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Stacked direction + magnitude ensemble with a meta-model.
+
+Two base models — one specialized in the *direction* of the move, one in its
+*magnitude* — are combined by a meta-model trained on their **out-of-fold**
+predictions (walk-forward OOF), which keeps the meta-features leak-free.
+"""
+
+from __future__ import annotations
+
+# Built-in packages
+from typing import Callable
+
+# Third-party packages
+import numpy as np
+import torch
+from numpy.typing import NDArray
+
+# Local packages
+from fynance.models.rolling import _RollingBasis
+
+__all__ = ['StackingEnsemble']
+
+
+class StackingEnsemble:
+    r""" Direction + magnitude stacking with an out-of-fold meta-model.
+
+    The two base models are evaluated with walk-forward cross-validation; their
+    out-of-fold (OOF) predictions become the meta-features on which the
+    meta-model is trained (e.g. with :class:`fynance.models.loss.SharpeLoss`).
+    Using OOF predictions avoids feeding the meta-model with in-sample base
+    predictions, the classic stacking leakage.
+
+    Parameters
+    ----------
+    direction_factory, magnitude_factory : callable
+        No-arg callables returning base models (the
+        :class:`~fynance.models._base.BaseNeuralNet` interface). Typically the
+        direction model is trained with
+        :class:`~fynance.models.loss.DirectionalAccuracyLoss`, the magnitude
+        model with MSE or :class:`~fynance.models.loss.SortinoLoss`.
+    meta_factory : callable
+        Callable ``meta_factory(n_features) -> model`` returning the meta-model
+        sized for the stacked features.
+
+    """
+
+    def __init__(
+        self,
+        direction_factory: Callable,
+        magnitude_factory: Callable,
+        meta_factory: Callable,
+    ):
+        self.direction_factory = direction_factory
+        self.magnitude_factory = magnitude_factory
+        self.meta_factory = meta_factory
+
+    def fit_predict(
+        self, X, y, train_period: int, test_period: int, roll_period: int,
+        epochs: int = 1,
+    ) -> NDArray:
+        """ Fit the ensemble and return meta out-of-fold predictions.
+
+        Parameters
+        ----------
+        X, y : torch.Tensor
+            Input and target, shapes ``(T, N)`` and ``(T, M)``.
+        train_period, test_period, roll_period : int
+            Walk-forward window parameters.
+        epochs : int, optional
+            Training passes per fold and for the meta-model. Default 1.
+
+        Returns
+        -------
+        np.ndarray
+            Meta predictions of shape ``(T, M)``; rows before the first test
+            fold (no OOF base features) are ``NaN``.
+
+        """
+        n_out = y.shape[1] if y.ndim > 1 else 1
+
+        rb = _RollingBasis(X, y)
+        rb(train_period=train_period, test_period=test_period,
+           roll_period=roll_period)
+        dir_oof = rb.cross_validate(
+            self.direction_factory, X, y, epochs=epochs).oof_predictions
+        mag_oof = rb.cross_validate(
+            self.magnitude_factory, X, y, epochs=epochs).oof_predictions
+
+        meta_x = np.hstack([dir_oof, mag_oof])
+        mask = ~np.isnan(meta_x).any(axis=1)
+
+        y_np = y.numpy() if hasattr(y, 'numpy') else np.asarray(y)
+        x_meta = torch.from_numpy(meta_x[mask].astype(np.float32))
+        y_meta = torch.from_numpy(y_np[mask].astype(np.float32))
+
+        meta = self.meta_factory(meta_x.shape[1])
+        for _ in range(epochs):
+            meta.train_on(x_meta, y_meta)
+
+        pred = meta.predict(x_meta)
+        pred = pred.numpy() if hasattr(pred, 'numpy') else np.asarray(pred)
+
+        out = np.full((X.shape[0], n_out), np.nan)
+        out[mask] = pred.reshape(-1, n_out)
+
+        return out

--- a/fynance/tests/models/test_ensemble.py
+++ b/fynance/tests/models/test_ensemble.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for §5.2 direction+magnitude stacking ensemble. """
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+from fynance.models.ensemble import StackingEnsemble
+from fynance.models.loss import DirectionalAccuracyLoss, SharpeLoss
+from fynance.models.mlp import MultiLayerPerceptron
+
+T, N_IN, N_OUT = 100, 4, 1
+
+
+def _data():
+    rng = np.random.default_rng(0)
+    X = torch.from_numpy(rng.standard_normal((T, N_IN)).astype(np.float32))
+    y = torch.from_numpy(rng.standard_normal((T, N_OUT)).astype(np.float32))
+    return X, y
+
+
+def _ensemble():
+    def direction():
+        m = MultiLayerPerceptron(N_IN, N_OUT, layers=[8])
+        m.set_optimizer(DirectionalAccuracyLoss, torch.optim.Adam, lr=1e-3)
+        return m
+
+    def magnitude():
+        m = MultiLayerPerceptron(N_IN, N_OUT, layers=[8])
+        m.set_optimizer(nn.MSELoss, torch.optim.Adam, lr=1e-3)
+        return m
+
+    def meta(n_features):
+        m = MultiLayerPerceptron(n_features, N_OUT, layers=[4])
+        m.set_optimizer(SharpeLoss, torch.optim.Adam, lr=1e-3)
+        return m
+
+    return StackingEnsemble(direction, magnitude, meta)
+
+
+def test_fit_predict_shape():
+    X, y = _data()
+    out = _ensemble().fit_predict(X, y, train_period=40, test_period=10, roll_period=10)
+    assert out.shape == (T, N_OUT)
+
+
+def test_oof_nan_before_first_fold_and_finite_after():
+    X, y = _data()
+    out = _ensemble().fit_predict(X, y, train_period=40, test_period=10, roll_period=10)
+    assert np.isnan(out[:40]).all()      # no OOF base features yet
+    assert np.isfinite(out[50:]).all()   # predictions once folds exist
+
+
+def test_meta_features_are_two_per_output():
+    # The meta-model receives [direction_oof, magnitude_oof] -> 2 * N_OUT inputs.
+    X, y = _data()
+    captured = {}
+
+    def meta(n_features):
+        captured['n'] = n_features
+        m = MultiLayerPerceptron(n_features, N_OUT, layers=[4])
+        m.set_optimizer(nn.MSELoss, torch.optim.Adam, lr=1e-3)
+        return m
+
+    def base():
+        m = MultiLayerPerceptron(N_IN, N_OUT, layers=[8])
+        m.set_optimizer(nn.MSELoss, torch.optim.Adam, lr=1e-3)
+        return m
+
+    StackingEnsemble(base, base, meta).fit_predict(
+        X, y, train_period=40, test_period=10, roll_period=10)
+    assert captured['n'] == 2 * N_OUT


### PR DESCRIPTION
Roadmap §5.2 (🟢) — the last green block. New `fynance.models.ensemble.StackingEnsemble`:

- A **direction** base model (e.g. `DirectionalAccuracyLoss`) + a **magnitude** base model (MSE / `SortinoLoss`).
- `fit_predict` runs walk-forward `cross_validate` to get each base model's **out-of-fold** predictions, stacks them as meta-features, and trains a **meta-model** (e.g. `SharpeLoss`) on them. Using OOF features avoids the classic stacking leakage.

3 tests (shape, OOF NaN-before-first-fold + finite after, meta receives 2·M features). ruff/mypy(0)/pytest(383) green. 🟡 Empirical comparison vs a single SharpeLoss model stays open (needs data).