### PR TITLE
docs: cover all v1.6 features in Sphinx + README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Sphinx API docs now cover every new feature: pages for TCN, Transformer, the stacking ensemble, all loss functions, training utilities, position sizing, feature engineering and market-regime detection; README updated accordingly
+
 - `StackingEnsemble` (`fynance.models.ensemble`) — direction + magnitude base models combined by a meta-model trained on their out-of-fold predictions (leak-free stacking)
 
 - `detect_regimes` (`fynance.features.regime`) — k-means market-regime labelling on rolling vol/return features, ordered by volatility

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ python setup.py build_ext --inplace
 ## Subpackages
 
 **Algorithms** `fynance.algorithms`  
-Portfolio allocation methods (ERC, HRP, IVP, MDP, MVP) and rolling walk-forward wrappers.
+Portfolio allocation methods (ERC, HRP, IVP, MDP, MVP), walk-forward wrappers, and position sizing (fractional Kelly, volatility targeting, transaction costs).
 
 **Backtest** `fynance.backtest`  
 Profit-and-loss plotting and performance measurement.
@@ -47,13 +47,15 @@ Profit-and-loss plotting and performance measurement.
 Cython ARMA / GARCH parameter estimation.
 
 **Features** `fynance.features`  
-Kalman filter, financial indicators (Bollinger, RSI, MACD, …), statistical momentums (SMA, EMA, WMA, …),
-metrics (Sharpe, Sortino, Calmar, drawdown, …), scaling, and rolling functions.
+Kalman filter, technical indicators (Bollinger, RSI, MACD, ROC, realized volatility, rolling skew/kurtosis/autocorr, …),
+statistical momentums (SMA, EMA, WMA, …), metrics (Sharpe, Sortino, Calmar, drawdown, tail ratio, …), scaling
+(incl. rolling rank), feature-engineering tools (multi-resolution, Granger causality), and market-regime detection.
 
 **Models** `fynance.models`  
 Econometric models (MA, ARMA, ARMA-GARCH), neural networks with PyTorch (MLP, RNN, GRU, LSTM,
-MultiHeadAttention), differentiable loss functions (SharpeLoss, SortinoLoss,
-DirectionalAccuracyLoss), and walk-forward rolling evaluation.
+MultiHeadAttention, **TCN**, **Transformer**), a **direction+magnitude stacking ensemble**,
+differentiable loss functions (Sharpe, Sortino, Calmar, Omega, directional, hybrid),
+robust-training utilities (purged CV, early stopping, sample weighting), and walk-forward rolling evaluation.
 
 ## Quick start
 

--- a/doc/dev/01-overview.md
+++ b/doc/dev/01-overview.md
@@ -12,8 +12,9 @@ that usually live in separate packages:
 - **Algorithms** — portfolio allocation (ERC, HRP, IVP, MDP, MVP) and a generic
   rolling/walk-forward driver.
 - **Models** — econometric (ARMA/GARCH via a Cython estimator) and neural
-  (MLP, RNN/GRU/LSTM, attention) with a walk-forward training base, plus custom
-  financial loss functions (Sharpe/Sortino/directional) in PyTorch.
+  (MLP, RNN/GRU/LSTM, attention, TCN, Transformer, stacking ensemble) with a
+  walk-forward training base, plus custom PyTorch losses (Sharpe/Sortino/Calmar/
+  Omega/directional/hybrid).
 - **Backtest** — evaluation, P&L/perf plotting (static + dynamic), stat printing.
 
 The throughline is **strict temporal causality**: every rolling feature and every

--- a/doc/dev/04-subpackages.md
+++ b/doc/dev/04-subpackages.md
@@ -22,11 +22,14 @@ modernisation).
   `roll_*` rolling variants, `z_score`, `accuracy`, momentums (EMA/SMA…),
   filters, `scale`, `roll_functions`, `money_management`. Re-exported from
   `features/__init__.py` (which pulls both the Python and `_cy` implementations).
-- **`algorithms`** — portfolio allocation: `ERC`, `HRP`, `IVP`, `MDP`, `MVP`, and
-  `rolling_allocation()` for walk-forward application.
+- **`algorithms`** — portfolio allocation (`ERC`, `HRP`, `IVP`, `MDP`, `MVP`,
+  `rolling_allocation()`) and position sizing (`sizing.py`: `kelly_fraction`,
+  `vol_target`, `transaction_cost`).
 - **`models`** — econometric (`ARMA`/`GARCH` family via `get_parameters`) and
   neural (`MultiLayerPerceptron`, `RollMultiLayerPerceptron`, RNN/`GRU`/`LSTM`,
-  attention); custom losses under `models/loss/`.
+  attention, `TemporalConvNet`, `Transformer`), `StackingEnsemble`; custom losses
+  under `models/loss/` (Sharpe/Sortino/Calmar/Omega/directional/hybrid); training
+  utils in `models/training.py`.
 - **`backtest`** — `BackTest`/plotting objects (`PlotBackTest`,
   `DynaPlotBackTest`, …), `print_stats`.
 

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -13,8 +13,11 @@ so an agent doesn't re-investigate settled ground or assume a known stub is a bu
   re-export aggregator (public API + import paths unchanged).
 - **Walk-forward base**: `_RollingBasis` iterator + `RollMultiLayerPerceptron` and
   `rolling_allocation()` — the causal windowing used everywhere.
-- **Models**: econometric (ARMA/GARCH) + neural (MLP, RNN/GRU/LSTM, attention) on
-  PyTorch; custom financial losses (Sharpe/Sortino/directional) in `models/loss/`.
+- **Models**: econometric (ARMA/GARCH) + neural (MLP, RNN/GRU/LSTM, attention,
+  **TCN**, **Transformer**) on PyTorch; a **StackingEnsemble** (direction+magnitude
+  OOF meta-model); custom losses (Sharpe/Sortino/Calmar/Omega/directional/hybrid)
+  in `models/loss/`; robust-training utils (purged CV, early stopping, sample
+  weighting) in `models/training.py`.
 - **Data frames**: **polars** at the input edges (`set_data`, `MA`), **numpy** at
   the output edges (`rolling_allocation`, `get_stats`); pandas removed.
 - **Backtest**: static + dynamic plotting (orchestrator `BacktestNeuralNet` split

--- a/doc/source/algorithms.rst
+++ b/doc/source/algorithms.rst
@@ -18,8 +18,15 @@ Portfolio allocation algorithms and rolling walk-forward wrappers.
       (MDP), Minimum Variance Portfolio (MVP, MVP_uc) and a rolling
       walk-forward wrapper.
 
+   .. grid-item-card:: :octicon:`pin;1.2em;sd-mr-1` Position sizing
+      :link: algorithms.sizing
+      :link-type: doc
+
+      Fractional Kelly, volatility targeting and transaction costs.
+
 .. toctree::
    :maxdepth: 1
    :hidden:
 
    algorithms.allocation
+   algorithms.sizing

--- a/doc/source/algorithms.sizing.rst
+++ b/doc/source/algorithms.sizing.rst
@@ -1,0 +1,14 @@
+***************
+Position sizing
+***************
+
+Position sizing and transaction-cost primitives for realistic backtests: fractional Kelly (:func:`~fynance.algorithms.sizing.kelly_fraction`), volatility targeting (:func:`~fynance.algorithms.sizing.vol_target`) and turnover-based transaction costs (:func:`~fynance.algorithms.sizing.transaction_cost`).
+
+.. currentmodule:: fynance.algorithms.sizing
+
+.. autosummary::
+   :toctree: generated/
+
+   kelly_fraction
+   vol_target
+   transaction_cost

--- a/doc/source/features.engineering.rst
+++ b/doc/source/features.engineering.rst
@@ -1,0 +1,14 @@
+*******************
+Feature engineering
+*******************
+
+Feature-engineering and selection research tools: multi-resolution feature stacking (:func:`~fynance.features.engineering.multi_resolution`), a Granger-causality test (:func:`~fynance.features.engineering.granger_causality`) and incremental moments (:func:`~fynance.features.engineering.IncrementalMoments`).
+
+.. currentmodule:: fynance.features.engineering
+
+.. autosummary::
+   :toctree: generated/
+
+   multi_resolution
+   granger_causality
+   IncrementalMoments

--- a/doc/source/features.indicators.rst
+++ b/doc/source/features.indicators.rst
@@ -17,5 +17,10 @@ Financial indicators
    hma
    macd_hist
    macd_line
+   realized_volatility
+   roc
+   rolling_autocorr
+   rolling_kurtosis
+   rolling_skewness
    rsi
    signal_line

--- a/doc/source/features.metrics.rst
+++ b/doc/source/features.metrics.rst
@@ -22,10 +22,12 @@ Classical version of metrics
    drawdown
    mad
    mdd
+   percent_positive
    perf_index
    perf_returns
    perf_strat
    sharpe
+   tail_ratio
    z_score
 
 Rolling version of metrics

--- a/doc/source/features.regime.rst
+++ b/doc/source/features.regime.rst
@@ -1,0 +1,12 @@
+*************
+Market regime
+*************
+
+Unsupervised market-regime labelling by clustering rolling volatility / return features (:func:`~fynance.features.regime.detect_regimes`).
+
+.. currentmodule:: fynance.features.regime
+
+.. autosummary::
+   :toctree: generated/
+
+   detect_regimes

--- a/doc/source/features.rst
+++ b/doc/source/features.rst
@@ -43,6 +43,18 @@ moving standard deviations and rolling functions.
 
       Rolling minimum and rolling maximum.
 
+   .. grid-item-card:: :octicon:`beaker;1.2em;sd-mr-1` Feature engineering
+      :link: features.engineering
+      :link-type: doc
+
+      Multi-resolution stacking, Granger-causality filter, incremental moments.
+
+   .. grid-item-card:: :octicon:`broadcast;1.2em;sd-mr-1` Market regime
+      :link: features.regime
+      :link-type: doc
+
+      Unsupervised regime labelling by clustering volatility/return features.
+
    .. grid-item-card:: :octicon:`arrow-switch;1.2em;sd-mr-1` Scale
       :link: features.scale
       :link-type: doc
@@ -76,9 +88,11 @@ Common parameters across modules:
    :maxdepth: 1
    :hidden:
 
+   features.engineering
    features.filters
    features.indicators
    features.metrics
    features.momentums
+   features.regime
    features.roll_functions
    features.scale

--- a/doc/source/features.scale.rst
+++ b/doc/source/features.scale.rst
@@ -17,6 +17,7 @@ Scale functions
    normalize
    standardize
    roll_normalize
+   roll_rank
    roll_standardize
 
 Scale object

--- a/doc/source/generated/fynance.algorithms.sizing.kelly_fraction.rst
+++ b/doc/source/generated/fynance.algorithms.sizing.kelly_fraction.rst
@@ -1,0 +1,9 @@
+﻿kelly_fraction
+========================================
+
+*Defined in* :mod:`fynance.algorithms.sizing`
+
+.. currentmodule:: fynance.algorithms.sizing
+
+.. autofunction:: kelly_fraction
+   :no-index:

--- a/doc/source/generated/fynance.algorithms.sizing.transaction_cost.rst
+++ b/doc/source/generated/fynance.algorithms.sizing.transaction_cost.rst
@@ -1,0 +1,9 @@
+﻿transaction_cost
+==========================================
+
+*Defined in* :mod:`fynance.algorithms.sizing`
+
+.. currentmodule:: fynance.algorithms.sizing
+
+.. autofunction:: transaction_cost
+   :no-index:

--- a/doc/source/generated/fynance.algorithms.sizing.vol_target.rst
+++ b/doc/source/generated/fynance.algorithms.sizing.vol_target.rst
@@ -1,0 +1,9 @@
+﻿vol_target
+====================================
+
+*Defined in* :mod:`fynance.algorithms.sizing`
+
+.. currentmodule:: fynance.algorithms.sizing
+
+.. autofunction:: vol_target
+   :no-index:

--- a/doc/source/generated/fynance.features.engineering.IncrementalMoments.rst
+++ b/doc/source/generated/fynance.features.engineering.IncrementalMoments.rst
@@ -1,0 +1,13 @@
+﻿IncrementalMoments
+===============================================
+
+*Defined in* :mod:`fynance.features.engineering`
+
+.. currentmodule:: fynance.features.engineering
+
+.. autoclass:: IncrementalMoments
+   :members:
+   :inherited-members:
+   :special-members: __call__, __iter__, __next__
+   :show-inheritance:
+   :no-index:

--- a/doc/source/generated/fynance.features.engineering.granger_causality.rst
+++ b/doc/source/generated/fynance.features.engineering.granger_causality.rst
@@ -1,0 +1,9 @@
+﻿granger_causality
+==============================================
+
+*Defined in* :mod:`fynance.features.engineering`
+
+.. currentmodule:: fynance.features.engineering
+
+.. autofunction:: granger_causality
+   :no-index:

--- a/doc/source/generated/fynance.features.engineering.multi_resolution.rst
+++ b/doc/source/generated/fynance.features.engineering.multi_resolution.rst
@@ -1,0 +1,9 @@
+﻿multi_resolution
+=============================================
+
+*Defined in* :mod:`fynance.features.engineering`
+
+.. currentmodule:: fynance.features.engineering
+
+.. autofunction:: multi_resolution
+   :no-index:

--- a/doc/source/generated/fynance.features.indicators.realized_volatility.rst
+++ b/doc/source/generated/fynance.features.indicators.realized_volatility.rst
@@ -1,0 +1,9 @@
+﻿realized_volatility
+===============================================
+
+*Defined in* :mod:`fynance.features.indicators`
+
+.. currentmodule:: fynance.features.indicators
+
+.. autofunction:: realized_volatility
+   :no-index:

--- a/doc/source/generated/fynance.features.indicators.roc.rst
+++ b/doc/source/generated/fynance.features.indicators.roc.rst
@@ -1,0 +1,9 @@
+﻿roc
+===============================
+
+*Defined in* :mod:`fynance.features.indicators`
+
+.. currentmodule:: fynance.features.indicators
+
+.. autofunction:: roc
+   :no-index:

--- a/doc/source/generated/fynance.features.indicators.rolling_autocorr.rst
+++ b/doc/source/generated/fynance.features.indicators.rolling_autocorr.rst
@@ -1,0 +1,9 @@
+﻿rolling_autocorr
+============================================
+
+*Defined in* :mod:`fynance.features.indicators`
+
+.. currentmodule:: fynance.features.indicators
+
+.. autofunction:: rolling_autocorr
+   :no-index:

--- a/doc/source/generated/fynance.features.indicators.rolling_kurtosis.rst
+++ b/doc/source/generated/fynance.features.indicators.rolling_kurtosis.rst
@@ -1,0 +1,9 @@
+﻿rolling_kurtosis
+============================================
+
+*Defined in* :mod:`fynance.features.indicators`
+
+.. currentmodule:: fynance.features.indicators
+
+.. autofunction:: rolling_kurtosis
+   :no-index:

--- a/doc/source/generated/fynance.features.indicators.rolling_skewness.rst
+++ b/doc/source/generated/fynance.features.indicators.rolling_skewness.rst
@@ -1,0 +1,9 @@
+﻿rolling_skewness
+============================================
+
+*Defined in* :mod:`fynance.features.indicators`
+
+.. currentmodule:: fynance.features.indicators
+
+.. autofunction:: rolling_skewness
+   :no-index:

--- a/doc/source/generated/fynance.features.metrics.percent_positive.rst
+++ b/doc/source/generated/fynance.features.metrics.percent_positive.rst
@@ -1,0 +1,9 @@
+﻿percent_positive
+=========================================
+
+*Defined in* :mod:`fynance.features.metrics`
+
+.. currentmodule:: fynance.features.metrics
+
+.. autofunction:: percent_positive
+   :no-index:

--- a/doc/source/generated/fynance.features.metrics.tail_ratio.rst
+++ b/doc/source/generated/fynance.features.metrics.tail_ratio.rst
@@ -1,0 +1,9 @@
+﻿tail_ratio
+===================================
+
+*Defined in* :mod:`fynance.features.metrics`
+
+.. currentmodule:: fynance.features.metrics
+
+.. autofunction:: tail_ratio
+   :no-index:

--- a/doc/source/generated/fynance.features.regime.detect_regimes.rst
+++ b/doc/source/generated/fynance.features.regime.detect_regimes.rst
@@ -1,0 +1,9 @@
+﻿detect_regimes
+======================================
+
+*Defined in* :mod:`fynance.features.regime`
+
+.. currentmodule:: fynance.features.regime
+
+.. autofunction:: detect_regimes
+   :no-index:

--- a/doc/source/generated/fynance.features.scale.roll_rank.rst
+++ b/doc/source/generated/fynance.features.scale.roll_rank.rst
@@ -1,0 +1,9 @@
+﻿roll_rank
+================================
+
+*Defined in* :mod:`fynance.features.scale`
+
+.. currentmodule:: fynance.features.scale
+
+.. autofunction:: roll_rank
+   :no-index:

--- a/doc/source/generated/fynance.models.ensemble.StackingEnsemble.rst
+++ b/doc/source/generated/fynance.models.ensemble.StackingEnsemble.rst
@@ -1,0 +1,13 @@
+﻿StackingEnsemble
+========================================
+
+*Defined in* :mod:`fynance.models.ensemble`
+
+.. currentmodule:: fynance.models.ensemble
+
+.. autoclass:: StackingEnsemble
+   :members:
+   :inherited-members:
+   :special-members: __call__, __iter__, __next__
+   :show-inheritance:
+   :no-index:

--- a/doc/source/generated/fynance.models.loss.BaseLoss.rst
+++ b/doc/source/generated/fynance.models.loss.BaseLoss.rst
@@ -1,0 +1,13 @@
+﻿BaseLoss
+============================
+
+*Defined in* :mod:`fynance.models.loss`
+
+.. currentmodule:: fynance.models.loss
+
+.. autoclass:: BaseLoss
+   :members:
+   :inherited-members:
+   :special-members: __call__, __iter__, __next__
+   :show-inheritance:
+   :no-index:

--- a/doc/source/generated/fynance.models.loss.CalmarLoss.rst
+++ b/doc/source/generated/fynance.models.loss.CalmarLoss.rst
@@ -1,0 +1,13 @@
+﻿CalmarLoss
+==============================
+
+*Defined in* :mod:`fynance.models.loss`
+
+.. currentmodule:: fynance.models.loss
+
+.. autoclass:: CalmarLoss
+   :members:
+   :inherited-members:
+   :special-members: __call__, __iter__, __next__
+   :show-inheritance:
+   :no-index:

--- a/doc/source/generated/fynance.models.loss.DirectionalAccuracyLoss.rst
+++ b/doc/source/generated/fynance.models.loss.DirectionalAccuracyLoss.rst
@@ -1,0 +1,13 @@
+﻿DirectionalAccuracyLoss
+===========================================
+
+*Defined in* :mod:`fynance.models.loss`
+
+.. currentmodule:: fynance.models.loss
+
+.. autoclass:: DirectionalAccuracyLoss
+   :members:
+   :inherited-members:
+   :special-members: __call__, __iter__, __next__
+   :show-inheritance:
+   :no-index:

--- a/doc/source/generated/fynance.models.loss.HybridLoss.rst
+++ b/doc/source/generated/fynance.models.loss.HybridLoss.rst
@@ -1,0 +1,13 @@
+﻿HybridLoss
+==============================
+
+*Defined in* :mod:`fynance.models.loss`
+
+.. currentmodule:: fynance.models.loss
+
+.. autoclass:: HybridLoss
+   :members:
+   :inherited-members:
+   :special-members: __call__, __iter__, __next__
+   :show-inheritance:
+   :no-index:

--- a/doc/source/generated/fynance.models.loss.OmegaLoss.rst
+++ b/doc/source/generated/fynance.models.loss.OmegaLoss.rst
@@ -1,0 +1,13 @@
+﻿OmegaLoss
+=============================
+
+*Defined in* :mod:`fynance.models.loss`
+
+.. currentmodule:: fynance.models.loss
+
+.. autoclass:: OmegaLoss
+   :members:
+   :inherited-members:
+   :special-members: __call__, __iter__, __next__
+   :show-inheritance:
+   :no-index:

--- a/doc/source/generated/fynance.models.loss.SharpeLoss.rst
+++ b/doc/source/generated/fynance.models.loss.SharpeLoss.rst
@@ -1,0 +1,13 @@
+﻿SharpeLoss
+==============================
+
+*Defined in* :mod:`fynance.models.loss`
+
+.. currentmodule:: fynance.models.loss
+
+.. autoclass:: SharpeLoss
+   :members:
+   :inherited-members:
+   :special-members: __call__, __iter__, __next__
+   :show-inheritance:
+   :no-index:

--- a/doc/source/generated/fynance.models.loss.SortinoLoss.rst
+++ b/doc/source/generated/fynance.models.loss.SortinoLoss.rst
@@ -1,0 +1,13 @@
+﻿SortinoLoss
+===============================
+
+*Defined in* :mod:`fynance.models.loss`
+
+.. currentmodule:: fynance.models.loss
+
+.. autoclass:: SortinoLoss
+   :members:
+   :inherited-members:
+   :special-members: __call__, __iter__, __next__
+   :show-inheritance:
+   :no-index:

--- a/doc/source/generated/fynance.models.tcn.TemporalConvNet.rst
+++ b/doc/source/generated/fynance.models.tcn.TemporalConvNet.rst
@@ -1,0 +1,13 @@
+﻿TemporalConvNet
+==================================
+
+*Defined in* :mod:`fynance.models.tcn`
+
+.. currentmodule:: fynance.models.tcn
+
+.. autoclass:: TemporalConvNet
+   :members:
+   :inherited-members:
+   :special-members: __call__, __iter__, __next__
+   :show-inheritance:
+   :no-index:

--- a/doc/source/generated/fynance.models.training.EarlyStopping.rst
+++ b/doc/source/generated/fynance.models.training.EarlyStopping.rst
@@ -1,0 +1,13 @@
+﻿EarlyStopping
+=====================================
+
+*Defined in* :mod:`fynance.models.training`
+
+.. currentmodule:: fynance.models.training
+
+.. autoclass:: EarlyStopping
+   :members:
+   :inherited-members:
+   :special-members: __call__, __iter__, __next__
+   :show-inheritance:
+   :no-index:

--- a/doc/source/generated/fynance.models.training.exp_sample_weights.rst
+++ b/doc/source/generated/fynance.models.training.exp_sample_weights.rst
@@ -1,0 +1,9 @@
+﻿exp_sample_weights
+==========================================
+
+*Defined in* :mod:`fynance.models.training`
+
+.. currentmodule:: fynance.models.training
+
+.. autofunction:: exp_sample_weights
+   :no-index:

--- a/doc/source/generated/fynance.models.transformer.PositionalEncoding.rst
+++ b/doc/source/generated/fynance.models.transformer.PositionalEncoding.rst
@@ -1,0 +1,13 @@
+﻿PositionalEncoding
+=============================================
+
+*Defined in* :mod:`fynance.models.transformer`
+
+.. currentmodule:: fynance.models.transformer
+
+.. autoclass:: PositionalEncoding
+   :members:
+   :inherited-members:
+   :special-members: __call__, __iter__, __next__
+   :show-inheritance:
+   :no-index:

--- a/doc/source/generated/fynance.models.transformer.Transformer.rst
+++ b/doc/source/generated/fynance.models.transformer.Transformer.rst
@@ -1,0 +1,13 @@
+﻿Transformer
+======================================
+
+*Defined in* :mod:`fynance.models.transformer`
+
+.. currentmodule:: fynance.models.transformer
+
+.. autoclass:: Transformer
+   :members:
+   :inherited-members:
+   :special-members: __call__, __iter__, __next__
+   :show-inheritance:
+   :no-index:

--- a/doc/source/models.ensemble.rst
+++ b/doc/source/models.ensemble.rst
@@ -1,0 +1,12 @@
+********
+Ensemble
+********
+
+Direction + magnitude stacking with an out-of-fold meta-model (:func:`~fynance.models.ensemble.StackingEnsemble`).
+
+.. currentmodule:: fynance.models.ensemble
+
+.. autosummary::
+   :toctree: generated/
+
+   StackingEnsemble

--- a/doc/source/models.loss.rst
+++ b/doc/source/models.loss.rst
@@ -1,0 +1,18 @@
+**************
+Loss functions
+**************
+
+Differentiable financial loss functions for PyTorch training. They are drop-in PyTorch criterions usable with :meth:`~fynance.models._base.BaseNeuralNet.set_optimizer`.
+
+.. currentmodule:: fynance.models.loss
+
+.. autosummary::
+   :toctree: generated/
+
+   BaseLoss
+   SharpeLoss
+   SortinoLoss
+   DirectionalAccuracyLoss
+   CalmarLoss
+   OmegaLoss
+   HybridLoss

--- a/doc/source/models.rst
+++ b/doc/source/models.rst
@@ -36,6 +36,36 @@ architectures.
 
       RNN, GRU and LSTM models with walk-forward training support.
 
+   .. grid-item-card:: :octicon:`stack;1.2em;sd-mr-1` Temporal Convolutional Network
+      :link: models.tcn
+      :link-type: doc
+
+      Causal dilated convolutional network for sequences.
+
+   .. grid-item-card:: :octicon:`eye;1.2em;sd-mr-1` Transformer
+      :link: models.transformer
+      :link-type: doc
+
+      Causal Transformer encoder with positional encoding.
+
+   .. grid-item-card:: :octicon:`git-merge;1.2em;sd-mr-1` Ensemble
+      :link: models.ensemble
+      :link-type: doc
+
+      Direction + magnitude stacking with an out-of-fold meta-model.
+
+   .. grid-item-card:: :octicon:`flame;1.2em;sd-mr-1` Loss functions
+      :link: models.loss
+      :link-type: doc
+
+      Differentiable Sharpe/Sortino/Calmar/Omega/directional losses.
+
+   .. grid-item-card:: :octicon:`gear;1.2em;sd-mr-1` Training utilities
+      :link: models.training
+      :link-type: doc
+
+      Sample weighting and early stopping.
+
    .. grid-item-card:: :octicon:`history;1.2em;sd-mr-1` Rolling models
       :link: models.rolling
       :link-type: doc
@@ -48,6 +78,11 @@ architectures.
 
    models.attention
    models.econometric_models
+   models.ensemble
+   models.loss
    models.neural_network
    models.recurrent_neural_network
    models.rolling
+   models.tcn
+   models.training
+   models.transformer

--- a/doc/source/models.tcn.rst
+++ b/doc/source/models.tcn.rst
@@ -1,0 +1,12 @@
+*****************************
+Temporal Convolutional Network
+*****************************
+
+Causal dilated Temporal Convolutional Network (:func:`~fynance.models.tcn.TemporalConvNet`) for sequential financial data — strictly no-lookahead.
+
+.. currentmodule:: fynance.models.tcn
+
+.. autosummary::
+   :toctree: generated/
+
+   TemporalConvNet

--- a/doc/source/models.training.rst
+++ b/doc/source/models.training.rst
@@ -1,0 +1,13 @@
+*****************
+Training utilities
+*****************
+
+Robust-training helpers: exponential sample weighting (:func:`~fynance.models.training.exp_sample_weights`) and early stopping on a monitored metric (:func:`~fynance.models.training.EarlyStopping`).
+
+.. currentmodule:: fynance.models.training
+
+.. autosummary::
+   :toctree: generated/
+
+   EarlyStopping
+   exp_sample_weights

--- a/doc/source/models.transformer.rst
+++ b/doc/source/models.transformer.rst
@@ -1,0 +1,13 @@
+***********
+Transformer
+***********
+
+Causal Transformer encoder (:func:`~fynance.models.transformer.Transformer`) with sinusoidal positional encoding (:func:`~fynance.models.transformer.PositionalEncoding`) and a lower-triangular causal mask (no lookahead).
+
+.. currentmodule:: fynance.models.transformer
+
+.. autosummary::
+   :toctree: generated/
+
+   Transformer
+   PositionalEncoding


### PR DESCRIPTION
Pre-release doc audit (requested before cutting v1.6.0). The features shipped since v1.5.0 had docstrings + tests but were **not referenced anywhere in the Sphinx site**, so they didn't render.

## New Sphinx pages (+ autosummary stubs)
- **models**: `models.tcn` (TCN), `models.transformer` (Transformer + PositionalEncoding), `models.ensemble` (StackingEnsemble), `models.training` (EarlyStopping, exp_sample_weights), **`models.loss`** (all losses — Sharpe/Sortino/Directional + Calmar/Omega/Hybrid; previously undocumented).
- **features**: `features.engineering` (multi_resolution, granger_causality, IncrementalMoments), `features.regime` (detect_regimes).
- **algorithms**: `algorithms.sizing` (kelly_fraction, vol_target, transaction_cost).

## Extended existing pages
- `features.indicators`: roc, realized_volatility, rolling_skewness/kurtosis/autocorr.
- `features.scale`: roll_rank. `features.metrics`: tail_ratio, percent_positive.
- Wired into the features/models/algorithms toctrees + card grids.

## Also
- README subpackage descriptions updated (TCN/Transformer/ensemble, new losses, sizing, indicators, regime).
- doc/dev 01/04/06 inventories refreshed.

## Verification
- `sphinx-build -W` clean (every new symbol resolves; stubs generated).
- ruff / mypy(0) / pytest **383** green.