### PR TITLE
feat: core PriceSeries + protocol seams (2.0 E1)

### DIFF
--- a/fynance/core/__init__.py
+++ b/fynance/core/__init__.py
@@ -1,21 +1,32 @@
 #!/usr/bin/env python3
 # coding: utf-8
-# @Author: ArthurBernard
-# @Email: arthur.bernard.92@gmail.com
-# @Date: 2021-04-05 20:35:18
-# @Last modified by: ArthurBernard
-# @Last modified time: 2021-04-05 20:35:21
 
-""" Description. """
+""" Core value objects and composition contracts.
 
-# Built-in packages
+.. currentmodule:: fynance.core
 
-# Third party packages
+Exposes :class:`PriceSeries` (the central numpy-backed financial time-series)
+and the :mod:`typing.Protocol` seams the pipeline composes through.
+
+"""
 
 # Local packages
+from .price_series import PriceSeries
+from .protocols import (
+    Allocator,
+    CostModel,
+    DataSource,
+    FeatureTransform,
+    Metric,
+    SignalModel,
+)
 
-__all__ = []
-
-
-if __name__ == "__main__":
-    pass
+__all__ = [
+    'PriceSeries',
+    'DataSource',
+    'FeatureTransform',
+    'SignalModel',
+    'Allocator',
+    'CostModel',
+    'Metric',
+]

--- a/fynance/core/price_series.py
+++ b/fynance/core/price_series.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Central financial time-series value object.
+
+Defines :class:`PriceSeries`, a thin, numpy-backed container for a 1-D
+financial series with its temporal index and metadata. It is the spine of
+the :mod:`fynance` 2.x pipeline (data -> features -> signal -> portfolio ->
+backtest -> metrics).
+
+Design invariants
+-----------------
+- **Composition, never subclassing** of :class:`numpy.ndarray`: the values
+  are stored as a contiguous, read-only ``float64`` array; transformations
+  return *new* :class:`PriceSeries` objects.
+- **numpy is the lingua franca**: pytorch is never stored, only produced on
+  demand through :meth:`PriceSeries.to_torch`.
+- **Thin object**: only the fundamental price/return identities live here;
+  the rich transform library stays as free functions reachable through
+  :meth:`PriceSeries.pipe`.
+
+"""
+
+from __future__ import annotations
+
+# Built-in packages
+from typing import Any, Callable
+
+# Third-party packages
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+
+__all__ = ['PriceSeries']
+
+
+class PriceSeries:
+    """ Thin, numpy-backed financial time-series.
+
+    Wraps a 1-D array of values together with a temporal ``index`` and light
+    metadata (``name``, ``freq``). It composes a numpy array rather than
+    subclassing it, which keeps numpy interop (``np.asarray(ps)`` works)
+    without the fragility of ndarray subclassing.
+
+    Parameters
+    ----------
+    values : array-like
+        1-D sequence of values (coerced to ``float64``).
+    index : array-like, optional
+        Temporal index of the same length. Defaults to ``0..n-1`` (int64).
+    name : str, optional
+        Series name.
+    freq : str, optional
+        Sampling frequency tag (e.g. ``"1d"``), purely informational.
+
+    Attributes
+    ----------
+    values : numpy.ndarray
+        Read-only ``float64`` 1-D array of values.
+    index : numpy.ndarray
+        1-D array aligned with ``values``.
+    name : str or None
+        Series name.
+    freq : str or None
+        Frequency tag.
+
+    Examples
+    --------
+    >>> ps = PriceSeries([100., 101., 99.], name="px")
+    >>> len(ps)
+    3
+    >>> ps[1]
+    101.0
+
+    """
+
+    def __init__(
+        self,
+        values: ArrayLike,
+        index: ArrayLike | None = None,
+        name: str | None = None,
+        freq: str | None = None,
+    ):
+        """ Initialize the series. """
+        v = np.asarray(values, dtype=np.float64).reshape(-1).copy()
+        v.flags.writeable = False
+        self.values: NDArray[np.float64] = v
+
+        if index is None:
+            idx = np.arange(v.size, dtype=np.int64)
+
+        else:
+            idx = np.asarray(index).reshape(-1)
+
+            if idx.size != v.size:
+
+                raise ValueError(
+                    f"index length {idx.size} != values length {v.size}"
+                )
+
+        idx.flags.writeable = False
+        self.index: NDArray[Any] = idx
+        self.name = name
+        self.freq = freq
+
+    # -- Constructors -----------------------------------------------------
+
+    @classmethod
+    def from_numpy(
+        cls,
+        values: NDArray,
+        index: NDArray | None = None,
+        name: str | None = None,
+        freq: str | None = None,
+    ) -> PriceSeries:
+        """ Build a :class:`PriceSeries` from numpy arrays. """
+        return cls(values, index=index, name=name, freq=freq)
+
+    @classmethod
+    def from_polars(
+        cls,
+        data: Any,
+        value_col: str | None = None,
+        index_col: str | None = None,
+        freq: str | None = None,
+    ) -> PriceSeries:
+        """ Build a :class:`PriceSeries` from a polars Series or DataFrame.
+
+        A :class:`polars.Series` maps directly to the values. For a
+        :class:`polars.DataFrame`, ``value_col`` selects the value column
+        (defaults to the single non-index numeric column) and ``index_col``
+        (or the first temporal column) becomes the index.
+        """
+        import polars as pl
+
+        if isinstance(data, pl.Series):
+
+            return cls(
+                data.to_numpy(),
+                name=value_col or data.name,
+                freq=freq,
+            )
+
+        if not isinstance(data, pl.DataFrame):
+
+            raise TypeError(f"unsupported polars input: {type(data)!r}")
+
+        # Resolve the index column: explicit, else first temporal column.
+        if index_col is None:
+            temporal = [
+                c for c, dt in zip(data.columns, data.dtypes)
+                if dt in (pl.Date, pl.Datetime)
+            ]
+            index_col = temporal[0] if temporal else None
+
+        index = data[index_col].to_numpy() if index_col is not None else None
+
+        if value_col is None:
+            candidates = [c for c in data.columns if c != index_col]
+
+            if len(candidates) != 1:
+
+                raise ValueError(
+                    "value_col is ambiguous; pass it explicitly "
+                    f"(candidates={candidates})"
+                )
+
+            value_col = candidates[0]
+
+        return cls(
+            data[value_col].to_numpy(),
+            index=index,
+            name=value_col,
+            freq=freq,
+        )
+
+    # -- Dunders ----------------------------------------------------------
+
+    def __len__(self) -> int:
+        """ Number of observations. """
+        return int(self.values.size)
+
+    def __getitem__(self, key: int | slice) -> float | PriceSeries:
+        """ Index by position (int -> scalar, slice -> sub-series). """
+        if isinstance(key, slice):
+
+            return PriceSeries(
+                self.values[key],
+                index=self.index[key],
+                name=self.name,
+                freq=self.freq,
+            )
+
+        return float(self.values[key])
+
+    def __array__(self, dtype: Any = None) -> NDArray:
+        """ numpy interop: ``np.asarray(ps)`` returns the values. """
+        if dtype is None:
+
+            return self.values
+
+        return self.values.astype(dtype)
+
+    def __eq__(self, other: object) -> bool:
+        """ Equality by values and index. """
+        if not isinstance(other, PriceSeries):
+
+            return NotImplemented
+
+        return (
+            np.array_equal(self.values, other.values, equal_nan=True)
+            and np.array_equal(self.index, other.index)
+        )
+
+    def __repr__(self) -> str:
+        """ Short representation with head/tail. """
+        n = len(self)
+        name = f" name={self.name!r}" if self.name else ""
+        freq = f" freq={self.freq!r}" if self.freq else ""
+
+        if n <= 6:
+            body = ", ".join(f"{v:g}" for v in self.values)
+
+        else:
+            head = ", ".join(f"{v:g}" for v in self.values[:3])
+            tail = ", ".join(f"{v:g}" for v in self.values[-3:])
+            body = f"{head}, ..., {tail}"
+
+        return f"PriceSeries([{body}], len={n}{name}{freq})"
+
+    __hash__ = None  # type: ignore[assignment]
+
+    # -- Helpers ----------------------------------------------------------
+
+    def _new(self, values: NDArray, index: NDArray | None = None) -> PriceSeries:
+        """ Build a derived series carrying name/freq. """
+        return PriceSeries(
+            values,
+            index=self.index if index is None else index,
+            name=self.name,
+            freq=self.freq,
+        )
+
+    def copy(self) -> PriceSeries:
+        """ Return a copy of this series. """
+        return self._new(self.values.copy())
+
+    # -- Finance core methods (price <-> return identities) ----------------
+
+    def to_returns(
+        self,
+        kind: str = "pct",
+        dropna: bool = True,
+    ) -> PriceSeries:
+        """ Convert a price path to a return series.
+
+        Parameters
+        ----------
+        kind : {"pct", "log", "raw"}
+            ``pct`` -> ``p_t / p_{t-1} - 1``; ``log`` -> ``ln(p_t / p_{t-1})``;
+            ``raw`` -> ``p_t - p_{t-1}``.
+        dropna : bool
+            Drop the (undefined) first observation. If ``False``, a leading
+            ``NaN`` is kept so the length is preserved.
+
+        Returns
+        -------
+        PriceSeries
+            The return series (strictly causal: ``r_t`` uses only ``p_t`` and
+            ``p_{t-1}``).
+
+        Examples
+        --------
+        >>> PriceSeries([100., 110., 99.]).to_returns("pct").values
+        array([ 0.1, -0.1])
+
+        """
+        p = self.values
+
+        if kind == "pct":
+            r = p[1:] / p[:-1] - 1.0
+
+        elif kind == "log":
+            r = np.log(p[1:] / p[:-1])
+
+        elif kind == "raw":
+            r = p[1:] - p[:-1]
+
+        else:
+
+            raise ValueError(f"unknown kind: {kind!r}")
+
+        if dropna:
+
+            return self._new(r, index=self.index[1:])
+
+        full = np.empty(p.size, dtype=np.float64)
+        full[0] = np.nan
+        full[1:] = r
+
+        return self._new(full)
+
+    def to_prices(self, base: float = 1.0, kind: str = "pct") -> PriceSeries:
+        """ Reconstruct a price path from this return series (inverse of
+        :meth:`to_returns`).
+
+        Parameters
+        ----------
+        base : float
+            Initial price prepended to the path.
+        kind : {"pct", "log", "raw"}
+            Must match the convention the returns were computed with.
+
+        Returns
+        -------
+        PriceSeries
+            Price path of length ``len(self) + 1``.
+
+        """
+        r = self.values
+
+        if kind == "pct":
+            path = base * np.cumprod(1.0 + r)
+
+        elif kind == "log":
+            path = base * np.exp(np.cumsum(r))
+
+        elif kind == "raw":
+            path = base + np.cumsum(r)
+
+        else:
+
+            raise ValueError(f"unknown kind: {kind!r}")
+
+        prices = np.empty(r.size + 1, dtype=np.float64)
+        prices[0] = base
+        prices[1:] = path
+
+        return PriceSeries(prices, name=self.name, freq=self.freq)
+
+    def cumulative(self) -> PriceSeries:
+        """ Equity curve of this return series: ``cumprod(1 + r)``. """
+        return self._new(np.cumprod(1.0 + self.values))
+
+    def pnl(self, positions: ArrayLike) -> PriceSeries:
+        """ Strategy returns of a position book on this return series.
+
+        Causal: the position is shifted forward one step, so the position
+        decided at ``t-1`` earns the return at ``t``
+        (``pnl_t = position_{t-1} * r_t``). The first observation is ``NaN``
+        (no prior position).
+
+        Parameters
+        ----------
+        positions : array-like
+            Position series aligned with this return series.
+
+        Returns
+        -------
+        PriceSeries
+            Strategy return series.
+
+        """
+        pos = np.asarray(positions, dtype=np.float64).reshape(-1)
+
+        if pos.size != self.values.size:
+
+            raise ValueError(
+                f"positions length {pos.size} != returns length "
+                f"{self.values.size}"
+            )
+
+        shifted = np.empty_like(pos)
+        shifted[0] = np.nan
+        shifted[1:] = pos[:-1]
+
+        return self._new(shifted * self.values)
+
+    def drop_na(self) -> PriceSeries:
+        """ Drop ``NaN`` observations (and their index entries). """
+        mask = ~np.isnan(self.values)
+
+        return self._new(self.values[mask], index=self.index[mask])
+
+    def fillna(self, value: float = 0.0) -> PriceSeries:
+        """ Replace ``NaN`` observations by a constant value. """
+        return self._new(np.nan_to_num(self.values, nan=value))
+
+    # -- Bridges & composition --------------------------------------------
+
+    def to_numpy(self, copy: bool = True) -> NDArray[np.float64]:
+        """ Return the values as a numpy array (copied by default). """
+        return self.values.copy() if copy else self.values
+
+    def to_torch(self, dtype: Any = None, device: Any = None) -> Any:
+        """ Return the values as a ``torch.Tensor`` (lazy torch import). """
+        import torch
+
+        if dtype is None:
+            dtype = torch.float32
+
+        # Copy: the stored array is read-only, which torch warns about.
+        return torch.as_tensor(self.values.copy(), dtype=dtype, device=device)
+
+    def pipe(
+        self,
+        func: Callable[..., Any],
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        """ Apply a free function to the values, re-wrapping when possible.
+
+        Delegates to the rich transform library without bloating this class:
+        ``ps.pipe(rsi, window=14)`` calls ``rsi(ps.values, window=14)``. If
+        the result is a 1-D array of the same length it is wrapped back into a
+        :class:`PriceSeries` (same index); otherwise the raw result is
+        returned.
+        """
+        out = func(self.values, *args, **kwargs)
+        arr = np.asarray(out)
+
+        if arr.ndim == 1 and arr.size == self.values.size:
+
+            return self._new(arr)
+
+        return out
+
+    def apply(self, func: Callable[[float], float]) -> PriceSeries:
+        """ Apply an element-wise function to the values. """
+        return self._new(np.vectorize(func)(self.values))

--- a/fynance/core/protocols.py
+++ b/fynance/core/protocols.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Composition contracts for the fynance pipeline.
+
+Structural :class:`typing.Protocol` seams the library composes through. They
+are duck-typed (no forced inheritance): any object with the right shape
+conforms. Only :class:`DataSource` is a *port* in the ports-&-adapters sense
+(it touches the outside world); the others are internal composition seams.
+
+Every protocol is numpy-typed and documents its causality contract: an output
+at index ``t`` must depend only on inputs up to ``t`` (no lookahead).
+
+"""
+
+from __future__ import annotations
+
+# Built-in packages
+from typing import Any, Protocol, runtime_checkable
+
+# Third-party packages
+from numpy.typing import NDArray
+
+__all__ = [
+    'DataSource',
+    'FeatureTransform',
+    'SignalModel',
+    'Allocator',
+    'CostModel',
+    'Metric',
+]
+
+
+@runtime_checkable
+class DataSource(Protocol):
+    """ Port: load external data into a :class:`PriceSeries`.
+
+    The only I/O boundary protocol. Concrete adapters (CSV, Parquet, ...)
+    live in :mod:`fynance.data`.
+    """
+
+    def load(self, *args: Any, **kwargs: Any) -> Any:
+        """ Load and return a ``PriceSeries`` (or a mapping of them). """
+        ...
+
+
+@runtime_checkable
+class FeatureTransform(Protocol):
+    """ A stateful or stateless feature transformation.
+
+    ``fit`` records only past-derivable parameters (e.g. train-slice mean and
+    std); ``transform`` must be causal (output at ``t`` uses inputs up to
+    ``t`` only).
+    """
+
+    def fit(self, X: NDArray) -> FeatureTransform:
+        """ Fit any parameters and return ``self``. """
+        ...
+
+    def transform(self, X: NDArray) -> NDArray:
+        """ Return the transformed array. """
+        ...
+
+
+@runtime_checkable
+class SignalModel(Protocol):
+    """ A predictive model mapping features to a target/signal.
+
+    The numpy boundary of the model layer: ``predict`` returns numpy even when
+    the implementation is pytorch internally.
+    """
+
+    def fit(self, X: NDArray, y: NDArray) -> SignalModel:
+        """ Fit the model and return ``self``. """
+        ...
+
+    def predict(self, X: NDArray) -> NDArray:
+        """ Return predictions as a numpy array. """
+        ...
+
+
+@runtime_checkable
+class Allocator(Protocol):
+    """ Map a covariance/return matrix to portfolio weights. """
+
+    def __call__(self, data: NDArray) -> NDArray:
+        """ Return an array of portfolio weights. """
+        ...
+
+
+@runtime_checkable
+class CostModel(Protocol):
+    """ Map a weight book to per-step transaction costs.
+
+    Concrete models live in :mod:`fynance.backtest.cost`.
+    """
+
+    def __call__(self, weights: NDArray) -> NDArray:
+        """ Return per-step costs aligned with the weight series. """
+        ...
+
+
+@runtime_checkable
+class Metric(Protocol):
+    """ Reduce a return series to a scalar performance number. """
+
+    def __call__(self, returns: NDArray, *args: Any, **kwargs: Any) -> float:
+        """ Return the scalar metric value. """
+        ...

--- a/fynance/tests/core/test_price_series.py
+++ b/fynance/tests/core/test_price_series.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for :class:`fynance.core.PriceSeries`. """
+
+# Third-party packages
+import numpy as np
+import pytest
+
+# Local packages
+from fynance.core import PriceSeries
+
+
+def test_construction_and_len():
+    ps = PriceSeries([100.0, 101.0, 99.0], name="px", freq="1d")
+    assert len(ps) == 3
+    assert ps.name == "px"
+    assert ps.freq == "1d"
+    assert ps.values.dtype == np.float64
+    # default index is 0..n-1
+    assert np.array_equal(ps.index, np.arange(3))
+
+
+def test_immutability():
+    ps = PriceSeries([1.0, 2.0, 3.0])
+    assert ps.values.flags.writeable is False
+    with pytest.raises(ValueError):
+        ps.values[0] = 9.0
+    # derived ops return new objects
+    assert ps.to_returns() is not ps
+
+
+def test_numpy_interop():
+    ps = PriceSeries([1.0, 2.0, 3.0])
+    arr = np.asarray(ps)
+    assert np.array_equal(arr, [1.0, 2.0, 3.0])
+    assert float(np.sum(ps)) == 6.0
+
+
+def test_getitem_scalar_and_slice():
+    ps = PriceSeries([10.0, 20.0, 30.0, 40.0], index=[5, 6, 7, 8])
+    assert ps[1] == 20.0
+    sub = ps[1:3]
+    assert isinstance(sub, PriceSeries)
+    assert np.array_equal(sub.values, [20.0, 30.0])
+    assert np.array_equal(sub.index, [6, 7])
+
+
+def test_index_length_mismatch():
+    with pytest.raises(ValueError):
+        PriceSeries([1.0, 2.0], index=[1, 2, 3])
+
+
+def test_equality_and_repr():
+    a = PriceSeries([1.0, 2.0, 3.0])
+    b = PriceSeries([1.0, 2.0, 3.0])
+    c = PriceSeries([1.0, 2.0, 4.0])
+    assert a == b
+    assert a != c
+    assert "PriceSeries(" in repr(a)
+
+
+def test_to_returns_pct_log_raw():
+    ps = PriceSeries([100.0, 110.0, 99.0])
+    assert np.allclose(ps.to_returns("pct").values, [0.1, -0.1])
+    assert np.allclose(ps.to_returns("raw").values, [10.0, -11.0])
+    log_r = ps.to_returns("log").values
+    assert np.allclose(log_r, np.log([110.0 / 100.0, 99.0 / 110.0]))
+
+
+def test_to_returns_dropna_false_keeps_length():
+    ps = PriceSeries([100.0, 110.0, 99.0])
+    r = ps.to_returns("pct", dropna=False)
+    assert len(r) == 3
+    assert np.isnan(r.values[0])
+
+
+def test_returns_prices_roundtrip():
+    rng = np.random.default_rng(0)
+    prices = 100.0 * np.cumprod(1.0 + rng.normal(0, 0.01, 50))
+    ps = PriceSeries(prices)
+    for kind in ("pct", "log", "raw"):
+        r = ps.to_returns(kind, dropna=True)
+        rebuilt = r.to_prices(base=prices[0], kind=kind)
+        assert np.allclose(rebuilt.values, prices, atol=1e-9)
+
+
+def test_cumulative():
+    r = PriceSeries([0.1, -0.1, 0.05])
+    eq = r.cumulative()
+    assert np.allclose(eq.values, np.cumprod([1.1, 0.9, 1.05]))
+
+
+def test_pnl_is_causal():
+    # returns and a position book
+    returns = PriceSeries([0.01, 0.02, -0.03, 0.04])
+    positions = [1.0, 1.0, -1.0, -1.0]
+    pnl = returns.pnl(positions)
+    # first is NaN (no prior position)
+    assert np.isnan(pnl.values[0])
+    # pnl_t = position_{t-1} * r_t
+    assert np.isclose(pnl.values[1], 1.0 * 0.02)
+    assert np.isclose(pnl.values[2], 1.0 * -0.03)
+    assert np.isclose(pnl.values[3], -1.0 * 0.04)
+
+
+def test_pnl_no_lookahead():
+    # changing a future position must not change earlier pnl
+    returns = PriceSeries([0.01, 0.02, -0.03, 0.04])
+    base = returns.pnl([1.0, 1.0, 1.0, 1.0]).values
+    perturbed = returns.pnl([1.0, 1.0, 1.0, -5.0]).values
+    assert np.allclose(base[:3], perturbed[:3], equal_nan=True)
+
+
+def test_dropna_fillna():
+    ps = PriceSeries([np.nan, 1.0, np.nan, 2.0])
+    assert np.array_equal(ps.drop_na().values, [1.0, 2.0])
+    assert np.array_equal(ps.fillna(0.0).values, [0.0, 1.0, 0.0, 2.0])
+
+
+def test_to_numpy_and_pipe():
+    ps = PriceSeries([1.0, 2.0, 3.0])
+    assert np.array_equal(ps.to_numpy(), [1.0, 2.0, 3.0])
+
+    # length-preserving -> wrapped back
+    doubled = ps.pipe(lambda a: a * 2)
+    assert isinstance(doubled, PriceSeries)
+    assert np.array_equal(doubled.values, [2.0, 4.0, 6.0])
+
+    # reducing -> raw result
+    total = ps.pipe(np.sum)
+    assert float(total) == 6.0
+
+
+def test_to_torch_lazy():
+    torch = pytest.importorskip("torch")
+    ps = PriceSeries([1.0, 2.0, 3.0])
+    t = ps.to_torch()
+    assert t.dtype == torch.float32
+    assert t.shape == (3,)
+
+
+def test_from_polars_series_and_frame():
+    pl = pytest.importorskip("polars")
+    s = pl.Series("px", [1.0, 2.0, 3.0])
+    ps = PriceSeries.from_polars(s)
+    assert np.array_equal(ps.values, [1.0, 2.0, 3.0])
+    assert ps.name == "px"
+
+    df = pl.DataFrame({"px": [10.0, 11.0, 12.0]})
+    ps2 = PriceSeries.from_polars(df, value_col="px")
+    assert np.array_equal(ps2.values, [10.0, 11.0, 12.0])

--- a/fynance/tests/core/test_protocols.py
+++ b/fynance/tests/core/test_protocols.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for the :mod:`fynance.core.protocols` seams. """
+
+# Third-party packages
+import numpy as np
+
+# Local packages
+from fynance.core import (
+    Allocator,
+    CostModel,
+    DataSource,
+    FeatureTransform,
+    Metric,
+    SignalModel,
+)
+
+
+def test_feature_transform_runtime_checkable():
+    class Dummy:
+        def fit(self, X):
+            return self
+
+        def transform(self, X):
+            return X
+
+    assert isinstance(Dummy(), FeatureTransform)
+    assert not isinstance(object(), FeatureTransform)
+
+
+def test_signal_model_runtime_checkable():
+    class Dummy:
+        def fit(self, X, y):
+            return self
+
+        def predict(self, X):
+            return np.zeros(len(X))
+
+    assert isinstance(Dummy(), SignalModel)
+    assert not isinstance(object(), SignalModel)
+
+
+def test_callable_protocols():
+    class Alloc:
+        def __call__(self, data):
+            return np.ones(data.shape[-1])
+
+    class Cost:
+        def __call__(self, weights):
+            return np.zeros(len(weights))
+
+    class Sharpe:
+        def __call__(self, returns, *a, **k):
+            return float(np.mean(returns))
+
+    assert isinstance(Alloc(), Allocator)
+    assert isinstance(Cost(), CostModel)
+    assert isinstance(Sharpe(), Metric)
+
+
+def test_datasource_runtime_checkable():
+    class Src:
+        def load(self, *a, **k):
+            return None
+
+    assert isinstance(Src(), DataSource)
+    assert not isinstance(object(), DataSource)


### PR DESCRIPTION
First epic of the **fynance 2.0** refactor (plan: `doc/dev/plans/v2-refactor/E1-core/`).

Introduces `fynance/core/` — the spine the whole pipeline composes through.

### Added
- **`PriceSeries`** — thin, numpy-backed financial time-series. *Composition, never `ndarray` subclassing.* Read-only `float64` values + temporal index + metadata. Core price↔return identities (`to_returns` pct/log/raw, `to_prices`, `cumulative`, `pnl`), `drop_na`/`fillna`, `to_numpy`/`to_torch` bridges (lazy torch), and `.pipe()` delegation to free functions (no god-object).
- **Protocol seams** (`typing.Protocol`, `runtime_checkable`): `DataSource` (the only I/O *port*), `FeatureTransform`, `SignalModel`, `Allocator`, `CostModel`, `Metric`.

### Design
numpy is the lingua franca; pytorch produced only on demand. Causality enforced (`pnl` shifts positions; no-lookahead test).

## Test plan
- 20 new unit tests + doctests (`tests/core/`); full suite **405 passed**.
- ruff / mypy / interrogate (100%) green locally.