### PR TITLE
feat: data ingestion layer — adapters, align, splits (2.0 E2)

### DIFF
--- a/fynance/data/__init__.py
+++ b/fynance/data/__init__.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Data ingestion layer: ports & adapters, alignment, temporal splits.
+
+.. currentmodule:: fynance.data
+
+The only I/O boundary of the library. File adapters turn local CSV/Parquet into
+:class:`~fynance.core.PriceSeries`; :func:`align`/:func:`resample` reconcile
+multiple series; :func:`train_test_split`/:func:`walk_forward` build no-lookahead
+evaluation indices.
+
+"""
+
+# Local packages
+from .align import align, resample
+from .base import BaseDataSource, get_source, load, register
+from .csv import CSVSource
+from .parquet import ParquetSource
+from .split import train_test_split, walk_forward
+
+__all__ = [
+    'BaseDataSource',
+    'register',
+    'get_source',
+    'load',
+    'CSVSource',
+    'ParquetSource',
+    'align',
+    'resample',
+    'train_test_split',
+    'walk_forward',
+]

--- a/fynance/data/align.py
+++ b/fynance/data/align.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Multi-asset alignment and frequency resampling.
+
+All operations are causal: forward-fill uses only past values, and downsampling
+aggregations never look past a period's right edge.
+
+"""
+
+from __future__ import annotations
+
+# Built-in packages
+# Third-party packages
+import numpy as np
+
+# Local packages
+from fynance.core import PriceSeries
+
+__all__ = ['align', 'resample']
+
+
+def _ffill(values: np.ndarray) -> np.ndarray:
+    """ Forward-fill NaNs using past values only. """
+    out = values.copy()
+    mask = np.isnan(out)
+    idx = np.where(~mask, np.arange(out.size), 0)
+    np.maximum.accumulate(idx, out=idx)
+    out = out[idx]
+    # Leading NaNs (before the first valid value) stay NaN.
+    first_valid = np.argmax(~mask) if mask.any() and (~mask).any() else 0
+    out[:first_valid] = np.nan
+
+    return out
+
+
+def align(
+    series: dict[str, PriceSeries],
+    how: str = "outer",
+    fill: str | None = "ffill",
+) -> dict[str, PriceSeries]:
+    """ Align several series onto a common index.
+
+    Parameters
+    ----------
+    series : dict of str to PriceSeries
+        Named series to align.
+    how : {"outer", "inner"}
+        ``outer`` uses the union of indices, ``inner`` the intersection.
+    fill : {"ffill", None}
+        Forward-fill (past-only) missing values after an outer align.
+
+    Returns
+    -------
+    dict of str to PriceSeries
+        Series sharing a common index.
+
+    """
+    index_sets = [set(ps.index.tolist()) for ps in series.values()]
+
+    if how == "outer":
+        common = sorted(set().union(*index_sets))
+
+    elif how == "inner":
+        common = sorted(set(index_sets[0]).intersection(*index_sets[1:]))
+
+    else:
+
+        raise ValueError(f"unknown how: {how!r}")
+
+    common_arr = np.array(common)
+    out: dict[str, PriceSeries] = {}
+
+    for name, ps in series.items():
+        mapping = dict(zip(ps.index.tolist(), ps.values.tolist()))
+        vals = np.array([mapping.get(t, np.nan) for t in common], dtype=float)
+
+        if fill == "ffill" and how == "outer":
+            vals = _ffill(vals)
+
+        out[name] = PriceSeries(vals, index=common_arr, name=name, freq=ps.freq)
+
+    return out
+
+
+def resample(
+    ps: PriceSeries,
+    freq: str,
+    agg: str = "last",
+) -> PriceSeries | dict[str, PriceSeries]:
+    """ Downsample a series to a coarser frequency.
+
+    Parameters
+    ----------
+    ps : PriceSeries
+        Series with a datetime index.
+    freq : str
+        Target polars frequency (e.g. ``"1w"``, ``"1mo"``).
+    agg : {"last", "mean", "ohlc"}
+        Aggregation. ``ohlc`` returns a mapping with open/high/low/close.
+
+    """
+    import polars as pl
+
+    df = pl.DataFrame({"_t": ps.index, "_v": ps.values}).sort("_t")
+    gb = df.group_by_dynamic("_t", every=freq)
+
+    if agg == "last":
+        res = gb.agg(pl.col("_v").last())
+
+        return PriceSeries(res["_v"].to_numpy(), index=res["_t"].to_numpy(),
+                           name=ps.name, freq=freq)
+
+    if agg == "mean":
+        res = gb.agg(pl.col("_v").mean())
+
+        return PriceSeries(res["_v"].to_numpy(), index=res["_t"].to_numpy(),
+                           name=ps.name, freq=freq)
+
+    if agg == "ohlc":
+        res = gb.agg(
+            pl.col("_v").first().alias("open"),
+            pl.col("_v").max().alias("high"),
+            pl.col("_v").min().alias("low"),
+            pl.col("_v").last().alias("close"),
+        )
+        idx = res["_t"].to_numpy()
+
+        return {
+            c: PriceSeries(res[c].to_numpy(), index=idx, name=c, freq=freq)
+            for c in ("open", "high", "low", "close")
+        }
+
+    raise ValueError(f"unknown agg: {agg!r}")

--- a/fynance/data/base.py
+++ b/fynance/data/base.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Data-source port: base class, adapter registry and the ``load`` dispatcher.
+
+:class:`DataSource` (in :mod:`fynance.core.protocols`) is the only I/O boundary
+of the library. Concrete adapters (CSV, Parquet, ...) register here and the
+:func:`load` dispatcher picks one by file extension.
+
+"""
+
+from __future__ import annotations
+
+# Built-in packages
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any, Callable
+
+# Local packages
+from fynance.core import PriceSeries
+
+__all__ = ['BaseDataSource', 'register', 'get_source', 'load']
+
+_REGISTRY: dict[str, type["BaseDataSource"]] = {}
+
+# Map file extensions to registered source names.
+_EXT = {
+    ".csv": "csv",
+    ".txt": "csv",
+    ".parquet": "parquet",
+    ".pq": "parquet",
+}
+
+
+class BaseDataSource(ABC):
+    """ Abstract base for data-source adapters (the I/O port). """
+
+    @abstractmethod
+    def load(self, path: str | Path, **kwargs: Any) -> Any:
+        """ Load ``path`` into a :class:`PriceSeries` or a mapping of them. """
+        ...
+
+
+def register(name: str) -> Callable[[type[BaseDataSource]], type[BaseDataSource]]:
+    """ Class decorator registering a data-source adapter under ``name``. """
+    def deco(cls: type[BaseDataSource]) -> type[BaseDataSource]:
+        _REGISTRY[name] = cls
+
+        return cls
+
+    return deco
+
+
+def get_source(name: str) -> BaseDataSource:
+    """ Instantiate a registered data source by name. """
+    if name not in _REGISTRY:
+
+        raise ValueError(
+            f"unknown data source {name!r}; registered: {sorted(_REGISTRY)}"
+        )
+
+    return _REGISTRY[name]()
+
+
+def load(
+    path: str | Path,
+    source: str = "auto",
+    **kwargs: Any,
+) -> PriceSeries | dict[str, PriceSeries]:
+    """ Load a file into a :class:`PriceSeries` (or mapping for multi-column).
+
+    Parameters
+    ----------
+    path : str or pathlib.Path
+        File to read.
+    source : str
+        Adapter name, or ``"auto"`` to select by file extension.
+    **kwargs
+        Forwarded to the adapter's ``load``.
+
+    """
+    if source == "auto":
+        ext = Path(path).suffix.lower()
+
+        if ext not in _EXT:
+
+            raise ValueError(
+                f"cannot infer data source from extension {ext!r}; "
+                f"pass source= explicitly"
+            )
+
+        source = _EXT[ext]
+
+    return get_source(source).load(path, **kwargs)
+
+
+def frame_to_series(
+    df: Any,
+    value_col: str | None = None,
+    index_col: str | None = None,
+    freq: str | None = None,
+) -> PriceSeries | dict[str, PriceSeries]:
+    """ Convert a polars DataFrame to a :class:`PriceSeries` or a mapping.
+
+    Shared by the CSV and Parquet adapters: resolves the temporal index column
+    and the value column(s).
+    """
+    import polars as pl
+
+    if index_col is None:
+        temporal = [
+            c for c, dt in zip(df.columns, df.dtypes)
+            if dt in (pl.Date, pl.Datetime)
+        ]
+        index_col = temporal[0] if temporal else None
+
+    index = df[index_col].to_numpy() if index_col is not None else None
+    value_cols = [c for c in df.columns if c != index_col]
+
+    if value_col is not None:
+
+        return PriceSeries(
+            df[value_col].to_numpy(),
+            index=index,
+            name=value_col,
+            freq=freq,
+        )
+
+    if len(value_cols) == 1:
+
+        return PriceSeries(
+            df[value_cols[0]].to_numpy(),
+            index=index,
+            name=value_cols[0],
+            freq=freq,
+        )
+
+    return {
+        c: PriceSeries(df[c].to_numpy(), index=index, name=c, freq=freq)
+        for c in value_cols
+    }

--- a/fynance/data/csv.py
+++ b/fynance/data/csv.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" CSV data-source adapter (polars-backed). """
+
+from __future__ import annotations
+
+# Built-in packages
+from pathlib import Path
+from typing import Any
+
+# Local packages
+from fynance.core import PriceSeries
+from fynance.data.base import BaseDataSource, frame_to_series, register
+
+__all__ = ['CSVSource']
+
+
+@register("csv")
+class CSVSource(BaseDataSource):
+    """ Read a CSV file into a :class:`PriceSeries` (or a mapping). """
+
+    def load(
+        self,
+        path: str | Path,
+        value_col: str | None = None,
+        index_col: str | None = None,
+        freq: str | None = None,
+        **kwargs: Any,
+    ) -> PriceSeries | dict[str, PriceSeries]:
+        """ Load ``path``.
+
+        Parameters
+        ----------
+        path : str or pathlib.Path
+            CSV file.
+        value_col : str, optional
+            Value column; if omitted, the single non-index column is used, or a
+            mapping is returned for several value columns.
+        index_col : str, optional
+            Temporal index column; if omitted, the first date/datetime column.
+        freq : str, optional
+            Frequency tag carried onto the series.
+        **kwargs
+            Forwarded to :func:`polars.read_csv`.
+
+        """
+        import polars as pl
+
+        df = pl.read_csv(path, try_parse_dates=True, **kwargs)
+
+        return frame_to_series(df, value_col, index_col, freq)

--- a/fynance/data/parquet.py
+++ b/fynance/data/parquet.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Parquet data-source adapter (polars-backed). """
+
+from __future__ import annotations
+
+# Built-in packages
+from pathlib import Path
+from typing import Any
+
+# Local packages
+from fynance.core import PriceSeries
+from fynance.data.base import BaseDataSource, frame_to_series, register
+
+__all__ = ['ParquetSource']
+
+
+@register("parquet")
+class ParquetSource(BaseDataSource):
+    """ Read a Parquet file into a :class:`PriceSeries` (or a mapping). """
+
+    def load(
+        self,
+        path: str | Path,
+        value_col: str | None = None,
+        index_col: str | None = None,
+        freq: str | None = None,
+        **kwargs: Any,
+    ) -> PriceSeries | dict[str, PriceSeries]:
+        """ Load ``path`` (see :meth:`CSVSource.load` for parameters). """
+        import polars as pl
+
+        df = pl.read_parquet(path, **kwargs)
+
+        return frame_to_series(df, value_col, index_col, freq)

--- a/fynance/data/split.py
+++ b/fynance/data/split.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Strictly time-ordered splits for ML evaluation.
+
+No shuffling, ever. Provides a simple train/test split with an optional embargo
+and a purged walk-forward window generator. These are pure index generators,
+decoupled from any model (mirroring the walk-forward semantics of
+:class:`fynance.models.rolling._RollingBasis`).
+
+"""
+
+from __future__ import annotations
+
+# Built-in packages
+from typing import Iterator
+
+# Third-party packages
+import numpy as np
+from numpy.typing import NDArray
+
+__all__ = ['train_test_split', 'walk_forward']
+
+
+def train_test_split(
+    n: int,
+    test_size: float | int,
+    gap: int = 0,
+) -> tuple[NDArray[np.int64], NDArray[np.int64]]:
+    """ Time-ordered train/test index split.
+
+    Parameters
+    ----------
+    n : int
+        Number of observations.
+    test_size : float or int
+        Fraction (``0 < x < 1``) or absolute count of the trailing test set.
+    gap : int
+        Embargo: observations dropped between train end and test start.
+
+    Returns
+    -------
+    (train_idx, test_idx) : tuple of numpy.ndarray
+        ``test_idx`` is strictly after ``train_idx`` (no leakage).
+
+    """
+    n_test = int(round(n * test_size)) if 0 < test_size < 1 else int(test_size)
+    split = n - n_test
+
+    if split - gap <= 0:
+
+        raise ValueError("train set is empty; reduce test_size/gap")
+
+    train_idx = np.arange(0, split - gap, dtype=np.int64)
+    test_idx = np.arange(split, n, dtype=np.int64)
+
+    return train_idx, test_idx
+
+
+def walk_forward(
+    n: int,
+    train: int,
+    test: int,
+    step: int | None = None,
+    purge: int = 0,
+) -> Iterator[tuple[NDArray[np.int64], NDArray[np.int64]]]:
+    """ Generate purged walk-forward windows.
+
+    Each window trains on ``[t-train : t-purge]`` and tests on ``[t : t+test]``.
+
+    Parameters
+    ----------
+    n : int
+        Number of observations.
+    train, test : int
+        Train and test window lengths.
+    step : int, optional
+        Roll step (defaults to ``test``, i.e. non-overlapping test windows).
+    purge : int
+        Observations removed at the train/test boundary (embargo).
+
+    Yields
+    ------
+    (train_idx, test_idx) : tuple of numpy.ndarray
+        Index arrays with ``test_idx`` strictly after ``train_idx``.
+
+    """
+    if step is None:
+        step = test
+
+    t = train
+
+    while t + test <= n:
+        train_idx = np.arange(max(0, t - train), t - purge, dtype=np.int64)
+        test_idx = np.arange(t, t + test, dtype=np.int64)
+
+        yield train_idx, test_idx
+
+        t += step

--- a/fynance/tests/data/test_align.py
+++ b/fynance/tests/data/test_align.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for alignment and resampling. """
+
+# Third-party packages
+import numpy as np
+
+# Local packages
+from fynance.core import PriceSeries
+from fynance.data import align
+
+
+def test_outer_align_ffill_is_causal():
+    a = PriceSeries([1.0, 2.0, 3.0], index=[1, 2, 3], name="a")
+    b = PriceSeries([10.0, 30.0], index=[1, 3], name="b")
+    out = align({"a": a, "b": b}, how="outer", fill="ffill")
+    assert np.array_equal(out["a"].index, [1, 2, 3])
+    # b has no value at t=2 -> forward-filled from t=1 (past only)
+    assert np.allclose(out["b"].values, [10.0, 10.0, 30.0])
+
+
+def test_outer_align_no_fill_keeps_nan():
+    a = PriceSeries([1.0, 2.0, 3.0], index=[1, 2, 3], name="a")
+    b = PriceSeries([10.0, 30.0], index=[1, 3], name="b")
+    out = align({"a": a, "b": b}, how="outer", fill=None)
+    assert np.isnan(out["b"].values[1])
+
+
+def test_inner_align_intersection():
+    a = PriceSeries([1.0, 2.0, 3.0], index=[1, 2, 3], name="a")
+    b = PriceSeries([10.0, 30.0], index=[1, 3], name="b")
+    out = align({"a": a, "b": b}, how="inner")
+    assert np.array_equal(out["a"].index, [1, 3])
+    assert np.allclose(out["a"].values, [1.0, 3.0])
+    assert np.allclose(out["b"].values, [10.0, 30.0])
+
+
+def test_ffill_leading_nan_stays_nan():
+    a = PriceSeries([1.0, 2.0, 3.0], index=[1, 2, 3], name="a")
+    b = PriceSeries([30.0], index=[3], name="b")
+    out = align({"a": a, "b": b}, how="outer", fill="ffill")
+    # no past value before t=3 -> leading NaNs
+    assert np.isnan(out["b"].values[0])
+    assert np.isnan(out["b"].values[1])
+    assert out["b"].values[2] == 30.0

--- a/fynance/tests/data/test_csv.py
+++ b/fynance/tests/data/test_csv.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for the CSV adapter. """
+
+# Third-party packages
+import numpy as np
+
+# Local packages
+from fynance.core import PriceSeries
+from fynance.data import load
+
+
+def test_csv_single_value_column(tmp_path):
+    p = tmp_path / "px.csv"
+    p.write_text("date,close\n2020-01-01,100.0\n2020-01-02,101.0\n2020-01-03,99.5\n")
+    ps = load(p)
+    assert isinstance(ps, PriceSeries)
+    assert ps.name == "close"
+    assert ps.values.dtype == np.float64
+    assert np.allclose(ps.values, [100.0, 101.0, 99.5])
+    assert ps.index.shape == (3,)
+
+
+def test_csv_multi_value_columns_returns_mapping(tmp_path):
+    p = tmp_path / "multi.csv"
+    p.write_text("date,a,b\n2020-01-01,1.0,10.0\n2020-01-02,2.0,20.0\n")
+    out = load(p)
+    assert isinstance(out, dict)
+    assert set(out) == {"a", "b"}
+    assert np.allclose(out["a"].values, [1.0, 2.0])
+    assert np.allclose(out["b"].values, [10.0, 20.0])
+
+
+def test_csv_no_datetime_index(tmp_path):
+    p = tmp_path / "noidx.csv"
+    p.write_text("v\n1.0\n2.0\n3.0\n")
+    ps = load(p)
+    assert isinstance(ps, PriceSeries)
+    assert np.allclose(ps.values, [1.0, 2.0, 3.0])

--- a/fynance/tests/data/test_parquet.py
+++ b/fynance/tests/data/test_parquet.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for the Parquet adapter (parity with CSV behaviour). """
+
+# Third-party packages
+import numpy as np
+import pytest
+
+# Local packages
+from fynance.core import PriceSeries
+from fynance.data import load
+
+
+def test_parquet_roundtrip(tmp_path):
+    pl = pytest.importorskip("polars")
+    p = tmp_path / "px.parquet"
+    pl.DataFrame({"close": [100.0, 101.0, 99.5]}).write_parquet(p)
+    ps = load(p)
+    assert isinstance(ps, PriceSeries)
+    assert ps.name == "close"
+    assert np.allclose(ps.values, [100.0, 101.0, 99.5])

--- a/fynance/tests/data/test_registry.py
+++ b/fynance/tests/data/test_registry.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for the data-source registry / dispatcher. """
+
+# Third-party packages
+import pytest
+
+# Local packages
+from fynance.data import get_source, load
+
+
+def test_get_source_known():
+    from fynance.data import CSVSource, ParquetSource
+
+    assert isinstance(get_source("csv"), CSVSource)
+    assert isinstance(get_source("parquet"), ParquetSource)
+
+
+def test_get_source_unknown():
+    with pytest.raises(ValueError):
+        get_source("nope")
+
+
+def test_load_unknown_extension():
+    with pytest.raises(ValueError):
+        load("data.xyz")

--- a/fynance/tests/data/test_split.py
+++ b/fynance/tests/data/test_split.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for time-ordered splits (no lookahead). """
+
+# Third-party packages
+import numpy as np
+
+# Local packages
+from fynance.data import train_test_split, walk_forward
+
+
+def test_train_test_split_fraction():
+    train, test = train_test_split(100, test_size=0.2)
+    assert train[-1] < test[0]            # strictly ordered
+    assert len(test) == 20
+    assert len(train) == 80
+
+
+def test_train_test_split_gap_embargo():
+    train, test = train_test_split(100, test_size=10, gap=5)
+    assert len(test) == 10
+    # embargo of 5 between train end and test start
+    assert test[0] - train[-1] == 1 + 5
+
+
+def test_walk_forward_windows_ordered_and_disjoint():
+    windows = list(walk_forward(100, train=40, test=10, step=10))
+    assert len(windows) == 6  # t = 40,50,...,90
+    for tr, te in windows:
+        assert tr[-1] < te[0]                      # no leakage
+        assert len(set(tr) & set(te)) == 0         # disjoint fold
+
+
+def test_walk_forward_purge():
+    windows = list(walk_forward(100, train=40, test=10, step=10, purge=3))
+    for tr, te in windows:
+        # purge removes 3 obs at the train/test boundary
+        assert te[0] - tr[-1] == 1 + 3
+
+
+def test_walk_forward_no_future_leak():
+    # every train index must be strictly before its test window
+    for tr, te in walk_forward(60, train=20, test=5, step=5):
+        assert np.all(tr < te[0])


### PR DESCRIPTION
Second epic of **fynance 2.0** (plan: `doc/dev/plans/v2-refactor/E2-data/`). The missing *data* maillon.

### Added — `fynance/data/`
- **DataSource port** + adapter registry + `load(path, source="auto")` dispatcher (selects by extension).
- **CSV / Parquet adapters** (polars): single value column → `PriceSeries`, several → `dict[str, PriceSeries]`; auto datetime-index detection.
- **`align` / `resample`**: causal multi-asset alignment (outer/inner; **past-only** forward-fill) and downsampling (`last`/`mean`/`ohlc`).
- **`train_test_split` / `walk_forward`**: strictly time-ordered, embargo/purge, **no-lookahead** index generators (decoupled from any model).

### Design
numpy/`PriceSeries` output; polars only as the read engine. No shuffling, ever.

## Test plan
- 16 new tests (`tests/data/`) incl. causal ffill, embargo, fold-disjointness, no-future-leak.
- full suite **421 passed**; ruff / mypy / interrogate (95%) green.