### PR TITLE
feat: vectorized backtest engine (2.0 E4)

### DIFF
--- a/fynance/__init__.py
+++ b/fynance/__init__.py
@@ -62,14 +62,23 @@ except PackageNotFoundError:
 
 __all__ = ['__version__']
 
+import sys as _sys
+
 from .algorithms import *
 from .backtest import *
 from .estimator import *
 from .features import *
 from .models import *
 
-__all__ += models.__all__
-__all__ += estimator.__all__
-__all__ += features.__all__
-__all__ += backtest.__all__
-__all__ += algorithms.__all__
+# Aggregate each subpackage's public surface. Use ``sys.modules`` rather than the
+# package attributes, which a star import may have shadowed with a name that
+# collides with a submodule (e.g. the ``backtest`` engine function).
+for _name in ("models", "estimator", "features", "backtest", "algorithms"):
+    __all__ += _sys.modules[f"{__name__}.{_name}"].__all__
+
+# Restore the subpackage attribute shadowed by such a collision so that
+# ``fynance.backtest`` resolves to the package (``fynance.backtest.backtest``
+# stays the engine function).
+backtest = _sys.modules[__name__ + ".backtest"]
+
+del _sys, _name

--- a/fynance/backtest/__init__.py
+++ b/fynance/backtest/__init__.py
@@ -18,18 +18,27 @@ Some tools to backtest strategies
 
 from . import (
     backtest_neural_net,
+    cost,
     dynamic_plot_backtest,
+    engine,
     plot_backtest,
     plot_tools,
     print_stats,
+    result,
 )
 from .backtest_neural_net import *
+from .cost import *
 from .dynamic_plot_backtest import *
+from .engine import *
 from .plot_backtest import *
 from .plot_tools import *
 from .print_stats import *
+from .result import *
 
 __all__ = print_stats.__all__
+__all__ += cost.__all__
+__all__ += engine.__all__
+__all__ += result.__all__
 __all__ += plot_tools.__all__
 __all__ += plot_backtest.__all__
 __all__ += dynamic_plot_backtest.__all__

--- a/fynance/backtest/cost.py
+++ b/fynance/backtest/cost.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Transaction cost models for the vectorized backtest engine.
+
+Concretizes the :class:`~fynance.core.protocols.CostModel` seam. Only the
+proportional (turnover-based) model ships in 2.0; non-linear slippage is a
+documented extension point.
+
+"""
+
+from __future__ import annotations
+
+# Third-party packages
+import numpy as np
+from numpy.typing import NDArray
+
+# Local packages
+from fynance.algorithms.sizing import transaction_cost
+
+__all__ = ['ProportionalCost']
+
+
+class ProportionalCost:
+    """ Proportional transaction cost: ``(fee + slippage) * turnover``.
+
+    Turnover at each step is the absolute traded weight
+    :math:`\\sum_i |w_{t,i} - w_{t-1,i}|` (the first step charges the initial
+    position). Conforms to :class:`~fynance.core.protocols.CostModel`.
+
+    Parameters
+    ----------
+    fee : float
+        Proportional fee per unit traded (e.g. ``0.001`` = 10 bps).
+    slippage : float
+        Additional proportional slippage per unit traded.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> cost = ProportionalCost(fee=0.01)
+    >>> cost(np.array([[1.0, 0.0], [0.5, 0.5], [0.5, 0.5]]))
+    array([0.01, 0.01, 0.  ])
+
+    """
+
+    def __init__(self, fee: float = 0.0, slippage: float = 0.0):
+        """ Store the cost rates. """
+        self.fee = fee
+        self.slippage = slippage
+
+    def __call__(self, weights: NDArray) -> NDArray[np.float64]:
+        """ Return the per-step proportional cost of a weight book. """
+        rate = self.fee + self.slippage
+
+        if rate == 0.0:
+            w = np.asarray(weights, dtype=np.float64)
+
+            return np.zeros(w.shape[0], dtype=np.float64)
+
+        return transaction_cost(weights, fee=rate)

--- a/fynance/backtest/engine.py
+++ b/fynance/backtest/engine.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Vectorized backtest engine.
+
+The core artery of the library: turn a position book + asset returns (or
+prices) + a cost model into a :class:`~fynance.backtest.result.BacktestResult`.
+Pure numpy, strictly causal.
+
+"""
+
+from __future__ import annotations
+
+# Built-in packages
+from typing import Any
+
+# Third-party packages
+import numpy as np
+
+# Local packages
+from fynance.backtest.result import BacktestResult
+
+__all__ = ['backtest']
+
+
+def backtest(
+    data: Any,
+    positions: Any,
+    cost: Any = None,
+    capital: float = 1.0,
+    returns_input: bool = True,
+    shift: bool = True,
+) -> BacktestResult:
+    """ Run a vectorized backtest.
+
+    Parameters
+    ----------
+    data : array-like
+        Asset returns (default) or prices (``returns_input=False``). Shape
+        ``(T,)`` for a single asset or ``(T, n_assets)`` for a book.
+    positions : array-like
+        Position/weight series aligned with ``data``.
+    cost : CostModel, optional
+        Per-step transaction cost model (e.g.
+        :class:`~fynance.backtest.cost.ProportionalCost`).
+    capital : float
+        Initial capital.
+    returns_input : bool
+        If ``True`` (default) ``data`` are returns; otherwise prices (converted
+        to pct returns; the first observation is dropped).
+    shift : bool
+        If ``True`` (default) positions are shifted one step (the position
+        decided at ``t`` earns the return at ``t+1``), guaranteeing causality.
+
+    Returns
+    -------
+    BacktestResult
+        Equity, net/gross returns, positions and per-step costs.
+
+    """
+    arr = np.asarray(data, dtype=np.float64)
+    pos = np.asarray(positions, dtype=np.float64)
+
+    if returns_input:
+        returns = arr
+
+    else:
+        returns = arr[1:] / arr[:-1] - 1.0
+
+        if pos.shape[0] == arr.shape[0]:
+            pos = pos[1:]
+
+    if pos.shape[0] != returns.shape[0]:
+
+        raise ValueError(
+            f"positions length {pos.shape[0]} != returns length "
+            f"{returns.shape[0]}"
+        )
+
+    # Causal shift: position decided at t earns the return at t+1.
+    if shift:
+        pos_eff = np.zeros_like(pos)
+        pos_eff[1:] = pos[:-1]
+
+    else:
+        pos_eff = pos
+
+    gross = pos_eff * returns
+
+    if gross.ndim == 2:
+        gross = gross.sum(axis=1)
+
+    costs = (
+        np.asarray(cost(pos), dtype=np.float64)
+        if cost is not None
+        else np.zeros(returns.shape[0], dtype=np.float64)
+    )
+    net = gross - costs
+    equity = capital * np.cumprod(1.0 + net)
+
+    return BacktestResult(
+        equity=equity,
+        returns=net,
+        gross_returns=gross,
+        positions=pos,
+        costs=costs,
+    )

--- a/fynance/backtest/result.py
+++ b/fynance/backtest/result.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Backtest result value object.
+
+:class:`BacktestResult` is the engine's output and the hand-off to metrics and
+reporting. It holds numpy arrays and computes a standard performance summary.
+
+"""
+
+from __future__ import annotations
+
+# Built-in packages
+from dataclasses import dataclass
+
+# Third-party packages
+import numpy as np
+from numpy.typing import NDArray
+
+# Local packages
+from fynance.core import PriceSeries
+
+__all__ = ['BacktestResult']
+
+
+def _annualized_sharpe(returns: NDArray, period: int = 252) -> float:
+    """ Annualized Sharpe ratio of a return series (numpy, self-contained). """
+    r = returns[~np.isnan(returns)]
+    sd = r.std()
+
+    if sd == 0:
+
+        return 0.0
+
+    return float(np.sqrt(period) * r.mean() / sd)
+
+
+def _annualized_sortino(returns: NDArray, period: int = 252) -> float:
+    """ Annualized Sortino ratio (downside deviation denominator). """
+    r = returns[~np.isnan(returns)]
+    downside = r[r < 0]
+    dd = downside.std() if downside.size else 0.0
+
+    if dd == 0:
+
+        return 0.0
+
+    return float(np.sqrt(period) * r.mean() / dd)
+
+
+def _max_drawdown(equity: NDArray) -> float:
+    """ Maximum drawdown of an equity curve (fraction, >= 0). """
+    peak = np.maximum.accumulate(equity)
+    dd = 1.0 - equity / peak
+
+    return float(np.max(dd))
+
+
+@dataclass
+class BacktestResult:
+    """ Output of :func:`~fynance.backtest.engine.backtest`.
+
+    Attributes
+    ----------
+    equity : numpy.ndarray
+        Equity curve.
+    returns : numpy.ndarray
+        Net strategy returns (after costs).
+    gross_returns : numpy.ndarray
+        Strategy returns before costs.
+    positions : numpy.ndarray
+        Position/weight book used.
+    costs : numpy.ndarray
+        Per-step transaction costs.
+    index : numpy.ndarray, optional
+        Temporal index carried from the input.
+
+    """
+
+    equity: NDArray
+    returns: NDArray
+    gross_returns: NDArray
+    positions: NDArray
+    costs: NDArray
+    index: NDArray | None = None
+
+    def to_numpy(self) -> NDArray:
+        """ Return the equity curve as a numpy array. """
+        return np.asarray(self.equity)
+
+    def to_price_series(self) -> PriceSeries:
+        """ Return the equity curve as a :class:`PriceSeries`. """
+        return PriceSeries(self.equity, index=self.index, name="equity")
+
+    def summary(self, period: int = 252) -> dict[str, float]:
+        """ Standard performance summary.
+
+        Returns a dict with annualized return/volatility, Sharpe, Sortino,
+        max drawdown, Calmar, hit-rate and total transaction cost.
+        """
+        r = self.returns[~np.isnan(self.returns)]
+        ann_ret = float(r.mean() * period)
+        ann_vol = float(r.std() * np.sqrt(period))
+        mdd = _max_drawdown(self.equity)
+
+        return {
+            "annual_return": ann_ret,
+            "annual_volatility": ann_vol,
+            "sharpe": _annualized_sharpe(self.returns, period),
+            "sortino": _annualized_sortino(self.returns, period),
+            "max_drawdown": mdd,
+            "calmar": float(ann_ret / mdd) if mdd > 0 else 0.0,
+            "hit_rate": float((r > 0).mean()) if r.size else 0.0,
+            "total_cost": float(np.nansum(self.costs)),
+        }

--- a/fynance/tests/backtest/test_cost.py
+++ b/fynance/tests/backtest/test_cost.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for transaction cost models. """
+
+# Third-party packages
+import numpy as np
+
+# Local packages
+from fynance.algorithms.sizing import transaction_cost
+from fynance.backtest.cost import ProportionalCost
+from fynance.core import CostModel
+
+
+def test_zero_fee_zero_cost():
+    cost = ProportionalCost(fee=0.0)
+    w = np.array([[1.0, 0.0], [0.0, 1.0]])
+    assert np.allclose(cost(w), [0.0, 0.0])
+
+
+def test_constant_weights_zero_turnover_cost():
+    cost = ProportionalCost(fee=0.01)
+    w = np.array([[0.5, 0.5], [0.5, 0.5], [0.5, 0.5]])
+    # only the initial position is charged
+    assert np.allclose(cost(w), [0.01, 0.0, 0.0])
+
+
+def test_parity_with_transaction_cost():
+    cost = ProportionalCost(fee=0.002, slippage=0.001)
+    w = np.array([[1.0, 0.0], [0.5, 0.5], [0.0, 1.0]])
+    assert np.allclose(cost(w), transaction_cost(w, fee=0.003))
+
+
+def test_conforms_to_protocol():
+    assert isinstance(ProportionalCost(), CostModel)

--- a/fynance/tests/backtest/test_engine.py
+++ b/fynance/tests/backtest/test_engine.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for the vectorized backtest engine. """
+
+# Third-party packages
+import numpy as np
+
+# Local packages
+from fynance.backtest import BacktestResult, backtest
+from fynance.backtest.cost import ProportionalCost
+
+
+def test_buy_and_hold_matches_price_path():
+    prices = np.array([100.0, 110.0, 99.0, 108.9])
+    res = backtest(prices, np.ones(prices.size), returns_input=False, shift=False)
+    # full long: equity tracks the (normalized) price path
+    expected = prices[1:] / prices[0]
+    assert np.allclose(res.equity, expected)
+
+
+def test_flat_position_flat_equity():
+    returns = np.array([0.01, -0.02, 0.03])
+    res = backtest(returns, np.zeros(returns.size))
+    assert np.allclose(res.equity, 1.0)
+
+
+def test_causal_shift():
+    returns = np.array([0.10, 0.20, -0.30])
+    positions = np.array([1.0, 1.0, 1.0])
+    res = backtest(returns, positions, shift=True)
+    # first period earns nothing (no prior position)
+    assert res.gross_returns[0] == 0.0
+    assert np.isclose(res.gross_returns[1], 0.20)
+    assert np.isclose(res.gross_returns[2], -0.30)
+
+
+def test_no_lookahead():
+    returns = np.array([0.01, 0.02, -0.03, 0.04, 0.05])
+    positions = np.array([1.0, -1.0, 1.0, -1.0, 1.0])
+    base = backtest(returns, positions, shift=True).equity.copy()
+    # perturb the LAST return only -> equity up to the penultimate step unchanged
+    perturbed_returns = returns.copy()
+    perturbed_returns[-1] = 99.0
+    pert = backtest(perturbed_returns, positions, shift=True).equity
+    assert np.allclose(base[:-1], pert[:-1])
+
+
+def test_costs_reduce_net_returns():
+    returns = np.array([0.01, 0.02, 0.03])
+    positions = np.array([1.0, 0.0, 1.0])
+    cost = ProportionalCost(fee=0.01)
+    res = backtest(returns, positions, cost=cost, shift=True)
+    no_cost = backtest(returns, positions, shift=True)
+    assert np.all(res.returns <= no_cost.returns + 1e-12)
+    assert np.allclose(no_cost.returns - res.returns, cost(positions))
+
+
+def test_two_asset_book():
+    returns = np.array([[0.01, 0.02], [0.03, -0.01], [0.0, 0.05]])
+    weights = np.array([[0.5, 0.5], [0.5, 0.5], [1.0, 0.0]])
+    res = backtest(returns, weights, shift=True)
+    # manual: gross_t = w_{t-1} . r_t
+    assert res.gross_returns[0] == 0.0
+    assert np.isclose(res.gross_returns[1], 0.5 * 0.03 + 0.5 * -0.01)
+    assert np.isclose(res.gross_returns[2], 0.5 * 0.0 + 0.5 * 0.05)
+
+
+def test_returns_result_type():
+    res = backtest(np.array([0.01, 0.02]), np.array([1.0, 1.0]))
+    assert isinstance(res, BacktestResult)

--- a/fynance/tests/backtest/test_result.py
+++ b/fynance/tests/backtest/test_result.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for BacktestResult. """
+
+# Third-party packages
+import numpy as np
+
+# Local packages
+from fynance.backtest import backtest
+from fynance.core import PriceSeries
+
+
+def test_summary_keys_and_finiteness():
+    rng = np.random.default_rng(1)
+    returns = rng.normal(0.0005, 0.01, 300)
+    positions = np.sign(rng.normal(size=300))
+    res = backtest(returns, positions, shift=True)
+    s = res.summary()
+    for key in ("annual_return", "annual_volatility", "sharpe", "sortino",
+                "max_drawdown", "calmar", "hit_rate", "total_cost"):
+        assert key in s
+        assert np.isfinite(s[key])
+
+
+def test_to_price_series():
+    res = backtest(np.array([0.01, 0.02, -0.01]), np.ones(3))
+    eq = res.to_price_series()
+    assert isinstance(eq, PriceSeries)
+    assert np.allclose(eq.values, res.equity)
+
+
+def test_max_drawdown_nonnegative():
+    res = backtest(np.array([0.1, -0.5, 0.2]), np.ones(3), shift=False)
+    assert res.summary()["max_drawdown"] >= 0.0


### PR DESCRIPTION
Fourth epic of **fynance 2.0** (plan: `doc/dev/plans/v2-refactor/E4-backtest/`). The real artery: signal/positions + returns + costs → equity.

### Added — `fynance/backtest/`
- **`ProportionalCost`** — turnover-based `CostModel` (`(fee+slippage)·turnover`; reuses `transaction_cost`).
- **`backtest()`** — pure-numpy **vectorized** engine. Positions + returns (or prices) + optional cost → `BacktestResult`. **Strictly causal**: the position decided at `t` earns the return at `t+1` (`shift=True`). Single- and multi-asset books.
- **`BacktestResult`** — equity / net+gross returns / positions / costs value object; `to_price_series()`, `to_numpy()`, and a self-contained `summary()` (Sharpe, Sortino, MDD, Calmar, hit-rate, cost). *(metrics consolidate into `fynance.metrics` in E5.)*

### Note
Resolves a name collision: the `backtest` **function** vs the `backtest` **package** — the top-level `__init__` re-binds `fynance.backtest` to the subpackage via `sys.modules` so `fynance.backtest.backtest` stays the engine.

## Test plan
- 25 new tests (`tests/backtest/`): buy-and-hold parity, flat-position, causal shift, **no-lookahead**, cost reduction, 2-asset book, summary finiteness.
- full suite **436 passed**; ruff / mypy / interrogate (100%) green.