### PR TITLE
feat: signal layer — prediction to position (2.0 E6.01)

### DIFF
--- a/fynance/signal/__init__.py
+++ b/fynance/signal/__init__.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Signal layer: prediction -> position.
+
+.. currentmodule:: fynance.signal
+
+The bridge between :mod:`fynance.models` and :mod:`fynance.backtest`. Mappers
+turn model predictions into positions; :class:`SignalPipeline` composes a model
+with a mapper.
+
+"""
+
+# Local packages
+from .mappers import rank, sign, threshold, vol_target_position
+from .pipeline import SignalPipeline
+
+__all__ = [
+    'sign',
+    'threshold',
+    'rank',
+    'vol_target_position',
+    'SignalPipeline',
+]

--- a/fynance/signal/mappers.py
+++ b/fynance/signal/mappers.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Signal mappers: turn a model prediction into a position.
+
+Pure numpy and causal: the position at ``t`` depends only on the prediction at
+``t`` (the engine in :mod:`fynance.backtest` applies the causal one-step shift).
+
+"""
+
+from __future__ import annotations
+
+# Third-party packages
+import numpy as np
+from numpy.typing import NDArray
+
+# Local packages
+from fynance.algorithms.sizing import vol_target
+
+__all__ = ['sign', 'threshold', 'rank', 'vol_target_position']
+
+
+def sign(pred: NDArray) -> NDArray[np.float64]:
+    """ Long/short by the sign of the prediction (``+1`` / ``-1`` / ``0``).
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> sign(np.array([0.3, -0.1, 0.0]))
+    array([ 1., -1.,  0.])
+
+    """
+    return np.sign(np.asarray(pred, dtype=np.float64))
+
+
+def threshold(
+    pred: NDArray,
+    long: float = 0.0,
+    short: float = 0.0,
+) -> NDArray[np.float64]:
+    """ Position with a flat dead-band.
+
+    ``+1`` where ``pred > long``, ``-1`` where ``pred < short``, ``0`` between.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> threshold(np.array([0.5, 0.05, -0.5]), long=0.1, short=-0.1)
+    array([ 1.,  0., -1.])
+
+    """
+    p = np.asarray(pred, dtype=np.float64)
+    pos = np.zeros_like(p)
+    pos[p > long] = 1.0
+    pos[p < short] = -1.0
+
+    return pos
+
+
+def rank(pred: NDArray, top: int, bottom: int) -> NDArray[np.float64]:
+    """ Cross-sectional long/short by rank.
+
+    For each time step (row of a 2-D ``(T, n_assets)`` prediction), go long the
+    ``top`` highest-ranked assets and short the ``bottom`` lowest, equally
+    weighted within each leg (dollar-neutral).
+
+    Parameters
+    ----------
+    pred : array-like, shape (T, n_assets)
+        Cross-sectional predictions.
+    top, bottom : int
+        Number of assets in the long and short legs.
+
+    Returns
+    -------
+    numpy.ndarray
+        Weights of shape ``(T, n_assets)``.
+
+    """
+    p = np.asarray(pred, dtype=np.float64)
+
+    if p.ndim != 2:
+
+        raise ValueError("rank expects a 2-D (T, n_assets) prediction")
+
+    weights = np.zeros_like(p)
+    order = np.argsort(p, axis=1)
+
+    for t in range(p.shape[0]):
+        if bottom > 0:
+            weights[t, order[t, :bottom]] = -1.0 / bottom
+
+        if top > 0:
+            weights[t, order[t, -top:]] = 1.0 / top
+
+    return weights
+
+
+def vol_target_position(
+    signal: NDArray,
+    prices: NDArray,
+    target_vol: float = 0.15,
+    period: int = 252,
+    w: int = 21,
+    max_leverage: float = 5.0,
+) -> NDArray[np.float64]:
+    """ Scale a directional signal by causal volatility-targeting leverage.
+
+    Multiplies a directional ``signal`` by the leverage from
+    :func:`fynance.algorithms.sizing.vol_target` (inverse of *past* realized
+    volatility). Strictly causal.
+    """
+    sig = np.asarray(signal, dtype=np.float64)
+    lev = vol_target(
+        prices,
+        target_vol=target_vol,
+        period=period,
+        w=w,
+        max_leverage=max_leverage,
+    )
+
+    return sig * lev

--- a/fynance/signal/pipeline.py
+++ b/fynance/signal/pipeline.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Compose a predictive model with a signal mapper. """
+
+from __future__ import annotations
+
+# Built-in packages
+from typing import Any, Callable
+
+# Third-party packages
+from numpy.typing import NDArray
+
+__all__ = ['SignalPipeline']
+
+
+class SignalPipeline:
+    """ A :class:`~fynance.core.protocols.SignalModel` plus a position mapper.
+
+    Wraps a model exposing ``fit``/``predict`` and a mapper turning predictions
+    into positions, exposing :meth:`predict_position`.
+
+    Parameters
+    ----------
+    model : SignalModel
+        Object with ``fit(X, y)`` and ``predict(X)``.
+    mapper : callable
+        Function mapping a prediction array to positions (e.g.
+        :func:`fynance.signal.sign`).
+    mapper_kwargs : dict, optional
+        Extra keyword arguments forwarded to ``mapper``.
+
+    """
+
+    def __init__(
+        self,
+        model: Any,
+        mapper: Callable[..., NDArray],
+        mapper_kwargs: dict[str, Any] | None = None,
+    ):
+        """ Store the model and the mapper. """
+        self.model = model
+        self.mapper = mapper
+        self.mapper_kwargs = mapper_kwargs or {}
+
+    def fit(self, X: NDArray, y: NDArray) -> SignalPipeline:
+        """ Fit the underlying model and return ``self``. """
+        self.model.fit(X, y)
+
+        return self
+
+    def predict(self, X: NDArray) -> NDArray:
+        """ Return the raw model predictions. """
+        return self.model.predict(X)
+
+    def predict_position(self, X: NDArray) -> NDArray:
+        """ Predict, then map predictions to positions. """
+        return self.mapper(self.model.predict(X), **self.mapper_kwargs)

--- a/fynance/tests/signal/test_signal.py
+++ b/fynance/tests/signal/test_signal.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for the signal mappers and pipeline. """
+
+# Third-party packages
+import numpy as np
+
+# Local packages
+from fynance.core import SignalModel
+from fynance.signal import (
+    SignalPipeline,
+    rank,
+    sign,
+    threshold,
+    vol_target_position,
+)
+
+
+def test_sign():
+    assert np.array_equal(sign(np.array([0.3, -0.1, 0.0])), [1.0, -1.0, 0.0])
+
+
+def test_threshold_dead_band():
+    out = threshold(np.array([0.5, 0.05, -0.5]), long=0.1, short=-0.1)
+    assert np.array_equal(out, [1.0, 0.0, -1.0])
+
+
+def test_rank_long_short_dollar_neutral():
+    pred = np.array([[1.0, 2.0, 3.0, 4.0]])
+    w = rank(pred, top=1, bottom=1)
+    assert np.isclose(w.sum(), 0.0)          # dollar-neutral
+    assert w[0, 3] == 1.0                     # highest -> long
+    assert w[0, 0] == -1.0                    # lowest -> short
+    assert w[0, 1] == 0.0 and w[0, 2] == 0.0
+
+
+def test_rank_requires_2d():
+    import pytest
+    with pytest.raises(ValueError):
+        rank(np.array([1.0, 2.0, 3.0]), top=1, bottom=1)
+
+
+def test_vol_target_position_is_causal():
+    rng = np.random.default_rng(0)
+    prices = 100.0 * np.cumprod(1.0 + rng.normal(0, 0.01, 100))
+    signal = np.ones(100)
+    pos = vol_target_position(signal, prices, w=10)
+    assert pos.shape == (100,)
+    # perturbing a future price must not change earlier positions
+    p2 = prices.copy()
+    p2[60:] *= 1.5
+    pos2 = vol_target_position(signal, p2, w=10)
+    assert np.allclose(pos[:60], pos2[:60], equal_nan=True)
+
+
+def test_signal_pipeline():
+    class DummyModel:
+        def fit(self, X, y):
+            return self
+
+        def predict(self, X):
+            return np.asarray(X).reshape(-1) - 0.5
+
+    pipe = SignalPipeline(DummyModel(), sign)
+    pipe.fit(np.zeros((3, 1)), np.zeros(3))
+    pos = pipe.predict_position(np.array([0.9, 0.1, 0.5]))
+    assert np.array_equal(pos, [1.0, -1.0, 0.0])
+
+
+def test_dummy_model_conforms_to_signalmodel():
+    class DummyModel:
+        def fit(self, X, y):
+            return self
+
+        def predict(self, X):
+            return np.zeros(len(X))
+
+    assert isinstance(DummyModel(), SignalModel)


### PR DESCRIPTION
Part of **fynance 2.0** epic E6 (plan: `doc/dev/plans/v2-refactor/E6-signal-portfolio/01-signal.md`). The bridge from `models` to `backtest`.

### Added — `fynance/signal/`
- **mappers** (pure numpy, causal): `sign`, `threshold` (flat dead-band), `rank` (cross-sectional dollar-neutral long/short), `vol_target_position` (scale a directional signal by causal vol-targeting leverage).
- **`SignalPipeline`** — composes a `SignalModel` (fit/predict) with a mapper, exposing `predict_position`.

## Test plan
- 7 new tests (`tests/signal/`): dollar-neutrality, dead-band, **no-lookahead** probe on vol-targeting, pipeline round-trip.
- full suite **445 passed**; ruff / mypy / interrogate (100%) green.

*(E6.02 — `algorithms`→`portfolio` rename — ships as a separate PR.)*