### PR TITLE
feat: reporting layer — metrics.summary, plot/, tearsheet (2.0 E5)

### DIFF
--- a/doc/source/generated/fynance.metrics.summary.rst
+++ b/doc/source/generated/fynance.metrics.summary.rst
@@ -1,0 +1,9 @@
+﻿summary
+=======================
+
+*Defined in* :mod:`fynance.metrics`
+
+.. currentmodule:: fynance.metrics
+
+.. autofunction:: summary
+   :no-index:

--- a/doc/source/generated/fynance.plot.plot_drawdown.rst
+++ b/doc/source/generated/fynance.plot.plot_drawdown.rst
@@ -1,0 +1,9 @@
+﻿plot_drawdown
+==========================
+
+*Defined in* :mod:`fynance.plot`
+
+.. currentmodule:: fynance.plot
+
+.. autofunction:: plot_drawdown
+   :no-index:

--- a/doc/source/generated/fynance.plot.plot_equity.rst
+++ b/doc/source/generated/fynance.plot.plot_equity.rst
@@ -1,0 +1,9 @@
+﻿plot_equity
+========================
+
+*Defined in* :mod:`fynance.plot`
+
+.. currentmodule:: fynance.plot
+
+.. autofunction:: plot_equity
+   :no-index:

--- a/doc/source/generated/fynance.plot.plot_returns_hist.rst
+++ b/doc/source/generated/fynance.plot.plot_returns_hist.rst
@@ -1,0 +1,9 @@
+﻿plot_returns_hist
+==============================
+
+*Defined in* :mod:`fynance.plot`
+
+.. currentmodule:: fynance.plot
+
+.. autofunction:: plot_returns_hist
+   :no-index:

--- a/doc/source/generated/fynance.plot.plot_rolling_sharpe.rst
+++ b/doc/source/generated/fynance.plot.plot_rolling_sharpe.rst
@@ -1,0 +1,9 @@
+﻿plot_rolling_sharpe
+================================
+
+*Defined in* :mod:`fynance.plot`
+
+.. currentmodule:: fynance.plot
+
+.. autofunction:: plot_rolling_sharpe
+   :no-index:

--- a/doc/source/generated/fynance.plot.tearsheet.rst
+++ b/doc/source/generated/fynance.plot.tearsheet.rst
@@ -1,0 +1,9 @@
+﻿tearsheet
+======================
+
+*Defined in* :mod:`fynance.plot`
+
+.. currentmodule:: fynance.plot
+
+.. autofunction:: tearsheet
+   :no-index:

--- a/doc/source/generated/fynance.plot.tearsheet_text.rst
+++ b/doc/source/generated/fynance.plot.tearsheet_text.rst
@@ -1,0 +1,9 @@
+﻿tearsheet_text
+===========================
+
+*Defined in* :mod:`fynance.plot`
+
+.. currentmodule:: fynance.plot
+
+.. autofunction:: tearsheet_text
+   :no-index:

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -90,3 +90,4 @@
    features
    metrics
    models
+   plot

--- a/doc/source/metrics.rst
+++ b/doc/source/metrics.rst
@@ -46,3 +46,11 @@ Rolling versions
    roll_annual_volatility
    roll_drawdown
    roll_mdd
+
+Aggregated report
+=================
+
+.. autosummary::
+   :toctree: generated/
+
+   summary

--- a/doc/source/plot.rst
+++ b/doc/source/plot.rst
@@ -1,0 +1,19 @@
+-----------------------------------
+ Reporting (:mod:`fynance.plot`)
+-----------------------------------
+
+Composable matplotlib figures and a one-call :func:`~fynance.plot.tearsheet`
+performance report. Each plot returns an ``Axes``/``Figure`` and never calls
+``show`` — usable headless, in a notebook, or embedded in an app.
+
+.. currentmodule:: fynance.plot
+
+.. autosummary::
+   :toctree: generated/
+
+   tearsheet
+   tearsheet_text
+   plot_equity
+   plot_drawdown
+   plot_returns_hist
+   plot_rolling_sharpe

--- a/fynance/__init__.py
+++ b/fynance/__init__.py
@@ -69,12 +69,13 @@ from .estimator import *
 from .features import *
 from .metrics import *
 from .models import *
+from .plot import *
 from .portfolio import *
 
 # Aggregate each subpackage's public surface. Use ``sys.modules`` rather than the
 # package attributes, which a star import may have shadowed with a name that
 # collides with a submodule (e.g. the ``backtest`` engine function).
-for _name in ("models", "estimator", "features", "metrics", "backtest", "portfolio"):
+for _name in ("models", "estimator", "features", "metrics", "plot", "backtest", "portfolio"):
     __all__ += _sys.modules[f"{__name__}.{_name}"].__all__
 
 # Restore the subpackage attribute shadowed by such a collision so that

--- a/fynance/backtest/result.py
+++ b/fynance/backtest/result.py
@@ -23,39 +23,6 @@ from fynance.core import PriceSeries
 __all__ = ['BacktestResult']
 
 
-def _annualized_sharpe(returns: NDArray, period: int = 252) -> float:
-    """ Annualized Sharpe ratio of a return series (numpy, self-contained). """
-    r = returns[~np.isnan(returns)]
-    sd = r.std()
-
-    if sd == 0:
-
-        return 0.0
-
-    return float(np.sqrt(period) * r.mean() / sd)
-
-
-def _annualized_sortino(returns: NDArray, period: int = 252) -> float:
-    """ Annualized Sortino ratio (downside deviation denominator). """
-    r = returns[~np.isnan(returns)]
-    downside = r[r < 0]
-    dd = downside.std() if downside.size else 0.0
-
-    if dd == 0:
-
-        return 0.0
-
-    return float(np.sqrt(period) * r.mean() / dd)
-
-
-def _max_drawdown(equity: NDArray) -> float:
-    """ Maximum drawdown of an equity curve (fraction, >= 0). """
-    peak = np.maximum.accumulate(equity)
-    dd = 1.0 - equity / peak
-
-    return float(np.max(dd))
-
-
 @dataclass
 class BacktestResult:
     """ Output of :func:`~fynance.backtest.engine.backtest`.
@@ -95,21 +62,15 @@ class BacktestResult:
     def summary(self, period: int = 252) -> dict[str, float]:
         """ Standard performance summary.
 
-        Returns a dict with annualized return/volatility, Sharpe, Sortino,
-        max drawdown, Calmar, hit-rate and total transaction cost.
+        Delegates the risk-adjusted ratios and drawdown to
+        :func:`fynance.metrics.summary` (computed on the equity curve) and adds
+        the hit-rate and total transaction cost from the strategy's own data.
         """
-        r = self.returns[~np.isnan(self.returns)]
-        ann_ret = float(r.mean() * period)
-        ann_vol = float(r.std() * np.sqrt(period))
-        mdd = _max_drawdown(self.equity)
+        from fynance.metrics import summary as _metric_summary
 
-        return {
-            "annual_return": ann_ret,
-            "annual_volatility": ann_vol,
-            "sharpe": _annualized_sharpe(self.returns, period),
-            "sortino": _annualized_sortino(self.returns, period),
-            "max_drawdown": mdd,
-            "calmar": float(ann_ret / mdd) if mdd > 0 else 0.0,
-            "hit_rate": float((r > 0).mean()) if r.size else 0.0,
-            "total_cost": float(np.nansum(self.costs)),
-        }
+        out = _metric_summary(self.equity, period=period)
+        r = self.returns[~np.isnan(self.returns)]
+        out["hit_rate"] = float((r > 0).mean()) if r.size else 0.0
+        out["total_cost"] = float(np.nansum(self.costs))
+
+        return out

--- a/fynance/metrics/__init__.py
+++ b/fynance/metrics/__init__.py
@@ -19,12 +19,13 @@ from .drawdown import *
 from .ratios import *
 from .returns import *
 from .returns import perf_strat, returns_strat  # noqa: F401
+from .summary import METRICS, summary  # noqa: F401
 
 # Aggregate __all__ via sys.modules (the star imports above rebind names that
 # collide with a submodule, e.g. the ``drawdown`` function vs the module).
 __all__ = []
 for _m in ("returns", "ratios", "drawdown"):
     __all__ += _sys.modules[f"{__name__}.{_m}"].__all__
-__all__ += ['perf_strat', 'returns_strat']
+__all__ += ['perf_strat', 'returns_strat', 'METRICS', 'summary']
 
 del _sys, _m

--- a/fynance/metrics/summary.py
+++ b/fynance/metrics/summary.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Aggregated performance summary and a metric registry.
+
+A single :func:`summary` reduces an equity/price curve to the standard panel of
+risk-adjusted metrics, and :data:`METRICS` exposes them by name.
+
+"""
+
+from __future__ import annotations
+
+# Built-in packages
+from typing import Callable
+
+# Third-party packages
+import numpy as np
+from numpy.typing import NDArray
+
+# Local packages
+from fynance.metrics.drawdown import mdd
+from fynance.metrics.ratios import (
+    annual_volatility,
+    calmar,
+    sharpe,
+    sortino,
+)
+from fynance.metrics.returns import annual_return
+
+__all__ = ['METRICS', 'summary']
+
+# Registry of scalar metrics taking an equity/price curve -> float.
+METRICS: dict[str, Callable[..., NDArray]] = {
+    'annual_return': annual_return,
+    'annual_volatility': annual_volatility,
+    'sharpe': sharpe,
+    'sortino': sortino,
+    'calmar': calmar,
+    'max_drawdown': mdd,
+}
+
+
+def summary(prices: NDArray, period: int = 252, rf: float = 0.0) -> dict[str, float]:
+    """ Standard performance summary of an equity/price curve.
+
+    Parameters
+    ----------
+    prices : array-like
+        Equity or price curve (not returns).
+    period : int
+        Annualization factor (252 for daily data).
+    rf : float
+        Risk-free rate passed to the Sharpe ratio.
+
+    Returns
+    -------
+    dict of str to float
+        ``annual_return``, ``annual_volatility``, ``sharpe``, ``sortino``,
+        ``calmar`` and ``max_drawdown``.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> eq = np.array([100., 101., 103., 102., 105., 107.])
+    >>> s = summary(eq)
+    >>> sorted(s)
+    ['annual_return', 'annual_volatility', 'calmar', 'max_drawdown', 'sharpe', 'sortino']
+
+    """
+    p = np.asarray(prices, dtype=np.float64)
+
+    return {
+        'annual_return': float(annual_return(p, period=period)),
+        'annual_volatility': float(annual_volatility(p, period=period)),
+        'sharpe': float(sharpe(p, period=period, rf=rf)),
+        'sortino': float(sortino(p, period=period)),
+        'calmar': float(calmar(p, period=period)),
+        'max_drawdown': float(mdd(p)),
+    }

--- a/fynance/plot/__init__.py
+++ b/fynance/plot/__init__.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Reporting / plotting layer.
+
+.. currentmodule:: fynance.plot
+
+Small, composable matplotlib figures (each returns an ``Axes``/``Figure``,
+never calls ``show``) plus a one-call :func:`tearsheet` report — the reporting
+API the notebook workflow and the optional Streamlit app both build on.
+
+"""
+
+# Local packages
+from .equity import plot_drawdown, plot_equity
+from .returns import plot_returns_hist, plot_rolling_sharpe
+from .tearsheet import tearsheet, tearsheet_text
+
+__all__ = [
+    'plot_equity',
+    'plot_drawdown',
+    'plot_returns_hist',
+    'plot_rolling_sharpe',
+    'tearsheet',
+    'tearsheet_text',
+]

--- a/fynance/plot/_helpers.py
+++ b/fynance/plot/_helpers.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Shared helpers for the plotting layer. """
+
+from __future__ import annotations
+
+# Third-party packages
+import numpy as np
+from numpy.typing import NDArray
+
+__all__ = ['as_equity']
+
+
+def as_equity(obj: object) -> tuple[NDArray, NDArray | None]:
+    """ Coerce a result/series/array into an ``(equity, index)`` pair.
+
+    Accepts a :class:`~fynance.backtest.result.BacktestResult`, a
+    :class:`~fynance.core.PriceSeries`, or a raw array (treated as an equity
+    curve).
+    """
+    equity = getattr(obj, "equity", None)
+
+    if equity is not None:  # BacktestResult
+        index = getattr(obj, "index", None)
+
+        return np.asarray(equity, dtype=np.float64), index
+
+    values = getattr(obj, "values", None)
+
+    if values is not None:  # PriceSeries
+        return np.asarray(values, dtype=np.float64), getattr(obj, "index", None)
+
+    return np.asarray(obj, dtype=np.float64), None
+
+
+def drawdown_curve(equity: NDArray) -> NDArray:
+    """ Underwater drawdown curve (fraction below running peak, <= 0). """
+    peak = np.maximum.accumulate(equity)
+
+    return equity / peak - 1.0

--- a/fynance/plot/equity.py
+++ b/fynance/plot/equity.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Equity and drawdown figures. """
+
+from __future__ import annotations
+
+# Built-in packages
+from typing import Any
+
+# Local packages
+from fynance.plot._helpers import as_equity, drawdown_curve
+
+__all__ = ['plot_equity', 'plot_drawdown']
+
+
+def plot_equity(result: Any, ax: Any = None) -> Any:
+    """ Plot an equity curve. Returns the matplotlib ``Axes``. """
+    import matplotlib.pyplot as plt
+
+    equity, index = as_equity(result)
+    x = range(len(equity)) if index is None else index
+
+    if ax is None:
+        _, ax = plt.subplots()
+
+    ax.plot(x, equity, color="#2c7fb8", lw=1.5)
+    ax.set_title("Equity curve")
+    ax.set_ylabel("Equity")
+    ax.grid(alpha=0.3)
+
+    return ax
+
+
+def plot_drawdown(result: Any, ax: Any = None) -> Any:
+    """ Plot the underwater drawdown curve. Returns the ``Axes``. """
+    import matplotlib.pyplot as plt
+
+    equity, index = as_equity(result)
+    dd = drawdown_curve(equity)
+    x = range(len(dd)) if index is None else index
+
+    if ax is None:
+        _, ax = plt.subplots()
+
+    ax.fill_between(x, dd, 0.0, color="#d7301f", alpha=0.4)
+    ax.set_title("Drawdown")
+    ax.set_ylabel("Drawdown")
+    ax.grid(alpha=0.3)
+
+    return ax

--- a/fynance/plot/returns.py
+++ b/fynance/plot/returns.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Return-distribution and rolling-metric figures. """
+
+from __future__ import annotations
+
+# Built-in packages
+from typing import Any
+
+# Third-party packages
+import numpy as np
+
+# Local packages
+from fynance.metrics.ratios import roll_sharpe
+from fynance.plot._helpers import as_equity
+
+__all__ = ['plot_returns_hist', 'plot_rolling_sharpe']
+
+
+def plot_returns_hist(result: Any, bins: int = 50, ax: Any = None) -> Any:
+    """ Histogram of per-step returns. Returns the ``Axes``. """
+    import matplotlib.pyplot as plt
+
+    equity, _ = as_equity(result)
+    returns = equity[1:] / equity[:-1] - 1.0
+
+    if ax is None:
+        _, ax = plt.subplots()
+
+    ax.hist(returns, bins=bins, color="#2c7fb8", alpha=0.8)
+    ax.axvline(0.0, color="k", lw=0.8)
+    ax.set_title("Return distribution")
+    ax.set_xlabel("Return")
+    ax.grid(alpha=0.3)
+
+    return ax
+
+
+def plot_rolling_sharpe(result: Any, window: int = 252, ax: Any = None) -> Any:
+    """ Rolling Sharpe ratio of the equity curve. Returns the ``Axes``. """
+    import matplotlib.pyplot as plt
+
+    equity, index = as_equity(result)
+    w = min(window, max(2, len(equity) - 1))
+    rs = np.asarray(roll_sharpe(equity, w=w))
+    x = range(len(rs)) if index is None else index
+
+    if ax is None:
+        _, ax = plt.subplots()
+
+    ax.plot(x, rs, color="#238b45", lw=1.2)
+    ax.axhline(0.0, color="k", lw=0.8)
+    ax.set_title(f"Rolling Sharpe (w={w})")
+    ax.set_ylabel("Sharpe")
+    ax.grid(alpha=0.3)
+
+    return ax

--- a/fynance/plot/tearsheet.py
+++ b/fynance/plot/tearsheet.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" One-call performance report (the API the notebook and UI both use). """
+
+from __future__ import annotations
+
+# Built-in packages
+from typing import Any
+
+# Local packages
+from fynance.plot._helpers import as_equity
+from fynance.plot.equity import plot_drawdown, plot_equity
+from fynance.plot.returns import plot_rolling_sharpe
+
+__all__ = ['tearsheet', 'tearsheet_text']
+
+
+def _summary(result: Any, period: int) -> dict[str, float]:
+    """ Resolve a metrics summary from a result/series/array. """
+    if hasattr(result, "summary"):
+
+        return result.summary(period=period)
+
+    from fynance.metrics import summary
+
+    equity, _ = as_equity(result)
+
+    return summary(equity, period=period)
+
+
+def tearsheet(result: Any, period: int = 252, figsize: tuple = (11, 7)) -> Any:
+    """ Build a full performance report figure.
+
+    Composes the equity curve, drawdown, rolling Sharpe, return distribution
+    and a metrics table into one matplotlib ``Figure`` (works headless, embeds
+    in a notebook or a Streamlit app).
+
+    Parameters
+    ----------
+    result : BacktestResult, PriceSeries or array-like
+        The strategy result (or an equity curve).
+    period : int
+        Annualization factor.
+    figsize : tuple
+        Figure size.
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+
+    """
+    import matplotlib.pyplot as plt
+
+    fig = plt.figure(figsize=figsize)
+    gs = fig.add_gridspec(2, 2)
+
+    plot_equity(result, ax=fig.add_subplot(gs[0, 0]))
+    plot_drawdown(result, ax=fig.add_subplot(gs[0, 1]))
+    plot_rolling_sharpe(result, window=period, ax=fig.add_subplot(gs[1, 0]))
+
+    ax_table = fig.add_subplot(gs[1, 1])
+    ax_table.axis("off")
+    stats = _summary(result, period)
+    rows = [[k, f"{v:.4f}"] for k, v in stats.items()]
+    table = ax_table.table(cellText=rows, colLabels=["metric", "value"],
+                           loc="center", cellLoc="left")
+    table.auto_set_font_size(False)
+    table.set_fontsize(9)
+    table.scale(1.0, 1.3)
+    ax_table.set_title("Summary")
+
+    fig.tight_layout()
+
+    return fig
+
+
+def tearsheet_text(result: Any, period: int = 252) -> str:
+    """ Plain-text performance summary (for notebooks / CLI). """
+    stats = _summary(result, period)
+
+    return "\n".join(f"{k:<20s} {v:>12.4f}" for k, v in stats.items())

--- a/fynance/tests/metrics/test_summary.py
+++ b/fynance/tests/metrics/test_summary.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for the metrics summary and registry. """
+
+# Third-party packages
+import numpy as np
+
+# Local packages
+from fynance.core import Metric
+from fynance.metrics import METRICS, sharpe, summary
+
+
+def test_summary_keys():
+    eq = np.array([100., 101., 103., 102., 105., 107.])
+    s = summary(eq)
+    assert set(s) == {"annual_return", "annual_volatility", "sharpe",
+                      "sortino", "calmar", "max_drawdown"}
+    for v in s.values():
+        assert np.isfinite(v)
+
+
+def test_summary_matches_direct_calls():
+    eq = np.array([100., 101., 103., 102., 105., 107.])
+    s = summary(eq)
+    assert np.isclose(s["sharpe"], float(sharpe(eq)))
+
+
+def test_registry_contains_metrics():
+    assert "sharpe" in METRICS and "max_drawdown" in METRICS
+    eq = np.array([100., 101., 103., 102., 105., 107.])
+    assert np.isclose(float(METRICS["sharpe"](eq)), float(sharpe(eq)))
+
+
+def test_metric_functions_conform_to_protocol():
+    # plain callables structurally satisfy the Metric protocol
+    assert isinstance(sharpe, Metric)

--- a/fynance/tests/plot/test_smoke.py
+++ b/fynance/tests/plot/test_smoke.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Headless smoke tests for the plotting layer. """
+
+# Third-party packages
+import matplotlib
+import numpy as np
+
+matplotlib.use("Agg")  # noqa: E402
+
+import matplotlib.pyplot as plt  # noqa: E402
+
+# Local packages
+from fynance.backtest import backtest  # noqa: E402
+from fynance.plot import (  # noqa: E402
+    plot_drawdown,
+    plot_equity,
+    plot_returns_hist,
+    plot_rolling_sharpe,
+    tearsheet,
+    tearsheet_text,
+)
+
+
+def _result():
+    rng = np.random.default_rng(0)
+    returns = rng.normal(0.0005, 0.01, 300)
+    positions = np.sign(rng.normal(size=300))
+    return backtest(returns, positions, shift=True)
+
+
+def test_plot_functions_return_axes():
+    res = _result()
+    for fn in (plot_equity, plot_drawdown, plot_returns_hist):
+        ax = fn(res)
+        assert ax is not None
+        plt.close("all")
+    ax = plot_rolling_sharpe(res, window=50)
+    assert ax is not None
+    plt.close("all")
+
+
+def test_tearsheet_returns_figure_with_axes():
+    res = _result()
+    fig = tearsheet(res, period=50)
+    assert len(fig.axes) >= 4
+    plt.close(fig)
+
+
+def test_tearsheet_text_matches_summary():
+    res = _result()
+    txt = tearsheet_text(res)
+    assert "sharpe" in txt
+    assert "max_drawdown" in txt


### PR DESCRIPTION
Fifth epic of **fynance 2.0** (plan: `E5-reporting/`). The reporting API that makes both the notebook workflow and the future UI trivial.

### Added
- **`fynance.metrics.summary(equity)`** — standard panel (annual return/vol, Sharpe, Sortino, Calmar, max drawdown) + **`METRICS`** registry. `BacktestResult.summary` now **delegates** to it (and keeps `hit_rate`/`total_cost`).
- **`fynance/plot/`** — composable matplotlib figures (`plot_equity`, `plot_drawdown`, `plot_returns_hist`, `plot_rolling_sharpe`); each returns an `Axes`, never `show`, **lazy** matplotlib import (headless-safe).
- **`tearsheet()` / `tearsheet_text()`** — one-call report (equity + drawdown + rolling Sharpe + metrics table).

### Note
The legacy `backtest` plotting stack is left in place for now (it is entangled with the legacy `core.series` ndarray subclass); its removal is a later cleanup leaf.

## Test plan
- 7 new tests (`tests/plot/` headless Agg, `tests/metrics/test_summary.py`); full suite **453 passed**.
- ruff / mypy (126 files) / interrogate (93.6%) green; Sphinx `-W` single-build clean.