### PR TITLE
feat: Strategy orchestrator (2.0 E8)

### DIFF
--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -130,3 +130,22 @@ Template:
 - **Rejected alternatives**: full public parity with dccd (would publish the R&D
   roadmap — rejected on privacy); doing nothing (leaves `/finish-task`'s ADR/status
   steps with nowhere to write).
+
+### 2026-06-15 — fynance 2.0: layered architecture + protocols (D4: Strategy API)  [accepted]
+- **Choice**: the 2.0 refactor adopts a **layered architecture with `typing.Protocol`
+  seams** (`DataSource`, `FeatureTransform`, `SignalModel`, `Allocator`,
+  `CostModel`, `Metric`), ports&adapters **only** at I/O (`fynance.data`), **not**
+  full hexagonal. numpy is the lingua franca; pytorch stays confined to
+  `fynance.models`; numba for hot loops. New maillons: `core` (`PriceSeries`),
+  `data`, `metrics` (out of `features`), vectorized `backtest`, `signal`,
+  `portfolio` (ex-`algorithms`), `plot`/`tearsheet`, `strategy`.
+- **D4 — Strategy API**: a **fluent dataclass-style** constructor (protocol-typed
+  slots as keyword args) with `.run` / `.run_walk_forward`, **not** a declarative
+  config tree. Every slot is optional so the maillons stay usable standalone
+  (composition, not a forced pipeline).
+- **Why**: the domain is maths on arrays — full hexagonal adds ceremony with no
+  payoff; protocol composition gives the modularity/testability where it matters
+  while keeping the toolbox usable piecewise. Fluent slots match the scientific
+  Python idiom (sklearn-like) and keep the orchestrator optional.
+- **Note**: breaking 2.0 (no compat shims): `algorithms`→`portfolio`,
+  perf-metrics `features`→`metrics`. Flagged for the major bump in `CHANGELOG.md`.

--- a/doc/source/generated/fynance.strategy.Strategy.rst
+++ b/doc/source/generated/fynance.strategy.Strategy.rst
@@ -1,0 +1,13 @@
+﻿Strategy
+=========================
+
+*Defined in* :mod:`fynance.strategy`
+
+.. currentmodule:: fynance.strategy
+
+.. autoclass:: Strategy
+   :members:
+   :inherited-members:
+   :special-members: __call__, __iter__, __next__
+   :show-inheritance:
+   :no-index:

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -91,3 +91,4 @@
    metrics
    models
    plot
+   strategy

--- a/doc/source/strategy.rst
+++ b/doc/source/strategy.rst
@@ -1,0 +1,14 @@
+-------------------------------------
+ Strategy (:mod:`fynance.strategy`)
+-------------------------------------
+
+Optional orchestrator composing the pipeline maillons — features, model, signal
+and costs — into one runnable object. Every slot is optional; the pieces stay
+usable standalone.
+
+.. currentmodule:: fynance.strategy
+
+.. autosummary::
+   :toctree: generated/
+
+   Strategy

--- a/fynance/__init__.py
+++ b/fynance/__init__.py
@@ -71,11 +71,12 @@ from .metrics import *
 from .models import *
 from .plot import *
 from .portfolio import *
+from .strategy import *
 
 # Aggregate each subpackage's public surface. Use ``sys.modules`` rather than the
 # package attributes, which a star import may have shadowed with a name that
 # collides with a submodule (e.g. the ``backtest`` engine function).
-for _name in ("models", "estimator", "features", "metrics", "plot", "backtest", "portfolio"):
+for _name in ("models", "estimator", "features", "metrics", "plot", "backtest", "portfolio", "strategy"):
     __all__ += _sys.modules[f"{__name__}.{_name}"].__all__
 
 # Restore the subpackage attribute shadowed by such a collision so that

--- a/fynance/strategy/__init__.py
+++ b/fynance/strategy/__init__.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Strategy orchestration layer.
+
+.. currentmodule:: fynance.strategy
+
+:class:`Strategy` composes the pipeline maillons (features, model, signal, cost)
+into one runnable object — optional, never required.
+
+"""
+
+# Local packages
+from .strategy import Strategy
+
+__all__ = ['Strategy']

--- a/fynance/strategy/strategy.py
+++ b/fynance/strategy/strategy.py
@@ -16,7 +16,7 @@ with a ``.run`` method, rather than a declarative config tree.
 from __future__ import annotations
 
 # Built-in packages
-from typing import Any, Callable, Sequence
+from typing import Any, Callable
 
 # Third-party packages
 import numpy as np

--- a/fynance/strategy/strategy.py
+++ b/fynance/strategy/strategy.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Optional orchestrator composing the fynance pipeline.
+
+:class:`Strategy` wires the protocol-based maillons — features -> model ->
+signal -> cost -> backtest -> metrics — into one runnable object. Every slot is
+optional and accepts any object conforming to its protocol, so the pieces stay
+usable standalone (this is composition, not a forced pipeline).
+
+Decision D4: a fluent dataclass-style constructor (slots as keyword arguments)
+with a ``.run`` method, rather than a declarative config tree.
+
+"""
+
+from __future__ import annotations
+
+# Built-in packages
+from typing import Any, Callable, Sequence
+
+# Third-party packages
+import numpy as np
+from numpy.typing import NDArray
+
+# Local packages
+from fynance.backtest import backtest
+from fynance.backtest.result import BacktestResult
+from fynance.data import walk_forward
+from fynance.signal import sign
+
+__all__ = ['Strategy']
+
+
+def _as_array(data: Any) -> NDArray:
+    """ Coerce a PriceSeries / array-like to a float64 numpy array. """
+    values = getattr(data, "values", None)
+    arr = values if values is not None else data
+
+    return np.asarray(arr, dtype=np.float64)
+
+
+class Strategy:
+    """ Compose features, a model, a signal mapper and costs into a backtest.
+
+    Parameters
+    ----------
+    model : SignalModel, optional
+        Object with ``fit(X, y)`` / ``predict(X)``. If omitted, the (featured)
+        input is fed straight to the signal mapper (rule-based strategy).
+    signal : callable, optional
+        Maps predictions/features to positions. Defaults to
+        :func:`fynance.signal.sign`.
+    features : callable, optional
+        Maps the price series to a feature array used as model/​signal input.
+        Defaults to the identity (the price series itself).
+    cost : CostModel, optional
+        Per-step transaction cost model.
+    period : int
+        Annualization factor passed to the summary.
+
+    """
+
+    def __init__(
+        self,
+        model: Any = None,
+        signal: Callable[..., NDArray] = sign,
+        features: Callable[[NDArray], NDArray] | None = None,
+        cost: Any = None,
+        period: int = 252,
+    ):
+        """ Store the pipeline slots. """
+        self.model = model
+        self.signal = signal
+        self.features = features
+        self.cost = cost
+        self.period = period
+
+    def _featurize(self, prices: NDArray) -> NDArray:
+        """ Build the feature array from a price series. """
+        if self.features is None:
+
+            return prices
+
+        return np.asarray(self.features(prices), dtype=np.float64)
+
+    def _positions(self, prices: NDArray, y: NDArray | None) -> NDArray:
+        """ Compute the (unshifted) position series from a price series. """
+        feats = self._featurize(prices)
+
+        if self.model is not None:
+            if y is not None:
+                self.model.fit(feats, y)
+
+            preds = np.asarray(self.model.predict(feats), dtype=np.float64)
+
+        else:
+            preds = feats
+
+        return np.asarray(self.signal(preds), dtype=np.float64).reshape(-1)
+
+    def run(self, data: Any, y: NDArray | None = None) -> BacktestResult:
+        """ Run the strategy on a price series, returning a backtest result.
+
+        Parameters
+        ----------
+        data : PriceSeries or array-like
+            Price series.
+        y : array-like, optional
+            Supervised target for the model (fit on the whole series; for
+            leak-free training use :meth:`run_walk_forward`).
+
+        Returns
+        -------
+        BacktestResult
+
+        """
+        prices = _as_array(data)
+        returns = prices[1:] / prices[:-1] - 1.0
+        positions = self._positions(prices, y)
+
+        # Align positions with the returns series (drop the first observation).
+        if positions.shape[0] == prices.shape[0]:
+            positions = positions[1:]
+
+        return backtest(returns, positions, cost=self.cost, shift=True)
+
+    def run_walk_forward(
+        self,
+        data: Any,
+        y: NDArray,
+        train: int,
+        test: int,
+        step: int | None = None,
+        purge: int = 0,
+    ) -> BacktestResult:
+        """ Walk-forward run: refit per window on train only, predict on test.
+
+        The model and features are fit on each train slice only; out-of-sample
+        positions are stitched together and backtested. Strictly no-lookahead.
+
+        Parameters
+        ----------
+        data : PriceSeries or array-like
+            Price series.
+        y : array-like
+            Supervised target aligned with ``data``.
+        train, test : int
+            Train and test window lengths.
+        step : int, optional
+            Roll step (defaults to ``test``).
+        purge : int
+            Embargo removed at the train/test boundary.
+
+        Returns
+        -------
+        BacktestResult
+            Backtest of the concatenated out-of-sample positions.
+
+        """
+        prices = _as_array(data)
+        y_arr = np.asarray(y, dtype=np.float64)
+        n = prices.shape[0]
+
+        oos_pos: list[float] = []
+        oos_ret: list[float] = []
+
+        for tr, te in walk_forward(n, train=train, test=test, step=step,
+                                   purge=purge):
+            feats_tr = self._featurize(prices[tr])
+            feats_te = self._featurize(prices[te])
+
+            if self.model is not None:
+                self.model.fit(feats_tr, y_arr[tr])
+                preds = np.asarray(self.model.predict(feats_te), dtype=np.float64)
+
+            else:
+                preds = feats_te
+
+            pos = np.asarray(self.signal(preds), dtype=np.float64).reshape(-1)
+
+            # Return realized over each test step (causal: position at t earns r_t
+            # within the OOS block; the engine applies the one-step shift).
+            block = prices[te]
+            ret = np.empty(block.shape[0])
+            ret[0] = np.nan
+            ret[1:] = block[1:] / block[:-1] - 1.0
+
+            oos_pos.extend(pos.tolist())
+            oos_ret.extend(ret.tolist())
+
+        positions = np.asarray(oos_pos)
+        returns = np.nan_to_num(np.asarray(oos_ret), nan=0.0)
+
+        return backtest(returns, positions, cost=self.cost, shift=True)

--- a/fynance/tests/strategy/test_strategy.py
+++ b/fynance/tests/strategy/test_strategy.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for the Strategy orchestrator. """
+
+# Third-party packages
+import numpy as np
+
+# Local packages
+from fynance.backtest import BacktestResult
+from fynance.backtest.cost import ProportionalCost
+from fynance.core import PriceSeries
+from fynance.signal import sign
+from fynance.strategy import Strategy
+
+
+def _prices(n=300, seed=0):
+    rng = np.random.default_rng(seed)
+    return 100.0 * np.cumprod(1.0 + rng.normal(0.0003, 0.01, n))
+
+
+def test_rule_based_run_returns_result():
+    # momentum rule: position = sign of last return
+    def momentum(prices):
+        r = np.zeros_like(prices)
+        r[1:] = np.sign(prices[1:] - prices[:-1])
+        return r
+
+    strat = Strategy(features=momentum, signal=lambda x: x)
+    res = strat.run(_prices())
+    assert isinstance(res, BacktestResult)
+    assert np.isfinite(res.summary()["sharpe"])
+
+
+def test_run_accepts_price_series():
+    strat = Strategy(features=lambda p: p, signal=sign)
+    res = strat.run(PriceSeries(_prices()))
+    assert isinstance(res, BacktestResult)
+
+
+def test_run_with_model_supervised():
+    class MeanModel:
+        def fit(self, X, y):
+            self._m = float(np.mean(y))
+            return self
+
+        def predict(self, X):
+            return np.full(np.asarray(X).shape[0], self._m)
+
+    prices = _prices()
+    y = np.sign(np.diff(prices, prepend=prices[0]))
+    strat = Strategy(model=MeanModel(), signal=sign)
+    res = strat.run(prices, y=y)
+    assert isinstance(res, BacktestResult)
+
+
+def test_cost_reduces_performance():
+    prices = _prices()
+
+    def alt(prices):  # alternating churn to create turnover
+        return np.resize([1.0, -1.0], prices.shape[0])
+
+    no_cost = Strategy(features=alt, signal=lambda x: x).run(prices)
+    with_cost = Strategy(features=alt, signal=lambda x: x,
+                         cost=ProportionalCost(fee=0.01)).run(prices)
+    assert with_cost.summary()["total_cost"] > 0.0
+    assert np.sum(with_cost.returns) <= np.sum(no_cost.returns) + 1e-9
+
+
+def test_swappable_signal_slot():
+    prices = _prices()
+
+    def momentum(prices):  # sign-varying feature
+        r = np.zeros_like(prices)
+        r[1:] = prices[1:] - prices[:-1]
+        return r
+
+    r1 = Strategy(features=momentum, signal=sign).run(prices)
+    r2 = Strategy(features=momentum,
+                  signal=lambda x: np.ones_like(x)).run(prices)
+    assert not np.allclose(r1.positions, r2.positions)
+
+
+def test_walk_forward_no_lookahead():
+    class LastSignModel:
+        def fit(self, X, y):
+            return self
+
+        def predict(self, X):
+            X = np.asarray(X)
+            return np.sign(np.diff(X, prepend=X[0]))
+
+    prices = _prices(400)
+    y = np.sign(np.diff(prices, prepend=prices[0]))
+    strat = Strategy(model=LastSignModel(), signal=sign)
+    base = strat.run_walk_forward(prices, y, train=100, test=20, step=20)
+    assert isinstance(base, BacktestResult)
+    assert np.isfinite(base.summary()["sharpe"])
+
+    # corrupting the far-future target must not change the result
+    y2 = y.copy()
+    y2[-30:] *= -1
+    pert = strat.run_walk_forward(prices, y2, train=100, test=20, step=20)
+    # OOS coverage identical in length
+    assert base.equity.shape == pert.equity.shape


### PR DESCRIPTION
Capstone epic of **fynance 2.0** (plan: `E8-strategy/`). The optional orchestrator that makes the toolbox a runnable end-to-end tool.

### Added — `fynance/strategy/`
- **`Strategy`** — fluent, dataclass-style orchestrator composing protocol-typed slots: `features` → `model` (`SignalModel`) → `signal` mapper → `cost` → vectorized `backtest`. **Every slot optional** (rule-based or supervised); the maillons stay usable standalone — composition, not a forced pipeline.
- **`.run(data, y)`** — single end-to-end run → `BacktestResult`.
- **`.run_walk_forward(data, y, train, test, step, purge)`** — refit features+model **per window on train only**, stitch out-of-sample positions, backtest the concatenation. Strictly no-lookahead.

### Decision
**D4** recorded in `03-decisions.md`: fluent slots over a declarative config tree; layered + `typing.Protocol` seams (not full hexagonal).

## Test plan
- 6 new tests (`tests/strategy/`): rule-based, supervised, cost impact, swappable signal slot, walk-forward sanity.
- full suite green; ruff / mypy / interrogate green; Sphinx `-W` clean.