### PR TITLE
feat: Streamlit backtest playground (2.0 E9)

### DIFF
--- a/apps/__init__.py
+++ b/apps/__init__.py
@@ -1,0 +1,1 @@
+""" Optional applications built on top of the fynance library. """

--- a/apps/playground/README.md
+++ b/apps/playground/README.md
@@ -1,0 +1,21 @@
+# fynance backtest playground
+
+A thin Streamlit app over `fynance.plot.tearsheet`: write a
+`signal(prices) -> positions` function on the left, see its tearsheet on the
+right.
+
+## Run
+
+```bash
+pip install -e ".[ui]"
+streamlit run apps/playground/app.py
+```
+
+Upload a CSV/Parquet price file (or use the built-in demo series), optionally
+set a fee, edit the `signal` function, and click **Run backtest**.
+
+> **Security note**: the app executes the code you type via `exec`. It is a
+> *local-only* research tool — do not expose it as a hosted/multi-user service.
+
+The signal-running logic lives in `runner.py` (Streamlit-free, unit-tested);
+`app.py` is only the UI shell.

--- a/apps/playground/__init__.py
+++ b/apps/playground/__init__.py
@@ -1,0 +1,1 @@
+""" Streamlit backtest playground (optional, ``fynance[ui]``). """

--- a/apps/playground/app.py
+++ b/apps/playground/app.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Streamlit backtest playground.
+
+Code a ``signal(prices) -> positions`` function on the left; see its tearsheet
+on the right. Run with::
+
+    streamlit run apps/playground/app.py
+
+Requires the ``ui`` extra: ``pip install -e ".[ui]"``.
+
+**Security**: this executes user-entered Python via ``exec`` — it is a
+*local-only* research tool, not a hosted/multi-user surface.
+
+"""
+
+from __future__ import annotations
+
+# Built-in packages
+import io
+
+# Third-party packages
+import numpy as np
+
+# Local packages
+from apps.playground.runner import TEMPLATE, compile_signal, run_signal
+from fynance.data import load
+from fynance.plot import tearsheet
+
+
+def _demo_prices(n: int = 500) -> np.ndarray:
+    rng = np.random.default_rng(0)
+
+    return 100.0 * np.cumprod(1.0 + rng.normal(0.0003, 0.01, n))
+
+
+def main() -> None:
+    """ Render the playground app. """
+    import streamlit as st
+
+    st.set_page_config(page_title="fynance playground", layout="wide")
+    st.title("fynance — backtest playground")
+
+    left, right = st.columns(2)
+
+    with left:
+        st.subheader("Signal function")
+        upload = st.file_uploader("Price data (CSV/Parquet)", type=["csv", "parquet"])
+        fee = st.number_input("Fee (per unit traded)", value=0.0, step=0.0005,
+                              format="%.4f")
+        code = st.text_area("def signal(prices): ...", value=TEMPLATE, height=320)
+        run = st.button("Run backtest")
+
+    with right:
+        st.subheader("Performance")
+
+        if run:
+            try:
+                if upload is not None:
+                    suffix = "csv" if upload.name.endswith("csv") else "parquet"
+                    ps = load(io.BytesIO(upload.getvalue()), source=suffix)
+                    prices = np.asarray(getattr(ps, "values", ps), dtype=float)
+
+                else:
+                    prices = _demo_prices()
+
+                signal = compile_signal(code)
+                result = run_signal(prices, signal, fee=fee)
+                st.pyplot(tearsheet(result))
+                st.json(result.summary())
+
+            except Exception as exc:  # surface user-code errors in the UI
+                st.error(f"{type(exc).__name__}: {exc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/playground/runner.py
+++ b/apps/playground/runner.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Pure (Streamlit-free) helpers for the playground.
+
+Separated from the UI so the signal-running logic is unit-testable without a
+Streamlit runtime.
+
+"""
+
+from __future__ import annotations
+
+# Built-in packages
+from typing import Any, Callable
+
+# Third-party packages
+import numpy as np
+from numpy.typing import NDArray
+
+# Local packages
+from fynance.backtest.result import BacktestResult
+from fynance.strategy import Strategy
+
+__all__ = ['run_signal', 'compile_signal', 'TEMPLATE']
+
+TEMPLATE = '''\
+import numpy as np
+
+def signal(prices):
+    """Return a position series (in [-1, 1]) aligned with `prices`.
+
+    Example: long when price is above its 20-period moving average.
+    """
+    ma = np.convolve(prices, np.ones(20) / 20, mode="same")
+    return np.where(prices > ma, 1.0, -1.0)
+'''
+
+
+def compile_signal(code: str) -> Callable[[NDArray], NDArray]:
+    """ Compile user code defining a ``signal(prices)`` function.
+
+    Executes ``code`` (local-only tool; no sandbox) and returns its ``signal``
+    callable.
+    """
+    namespace: dict[str, Any] = {}
+    exec(code, namespace)  # noqa: S102 (local-only playground)
+
+    if "signal" not in namespace or not callable(namespace["signal"]):
+
+        raise ValueError("the code must define a callable `signal(prices)`")
+
+    return namespace["signal"]
+
+
+def run_signal(prices: NDArray, signal: Callable[[NDArray], NDArray],
+               fee: float = 0.0) -> BacktestResult:
+    """ Backtest a ``signal(prices) -> positions`` function on a price series. """
+    from fynance.backtest.cost import ProportionalCost
+
+    cost = ProportionalCost(fee=fee) if fee else None
+    strat = Strategy(features=lambda p: np.asarray(signal(p), dtype=np.float64),
+                     signal=lambda x: x, cost=cost)
+
+    return strat.run(np.asarray(prices, dtype=np.float64))

--- a/fynance/tests/strategy/test_playground.py
+++ b/fynance/tests/strategy/test_playground.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Smoke tests for the Streamlit playground helpers (no Streamlit runtime). """
+
+# Built-in packages
+import sys
+from pathlib import Path
+
+# Third-party packages
+import numpy as np
+
+# Make the repo-root ``apps`` package importable.
+_ROOT = Path(__file__).resolve().parents[3]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+# Local packages
+from apps.playground.runner import (  # noqa: E402
+    TEMPLATE,
+    compile_signal,
+    run_signal,
+)
+from fynance.backtest import BacktestResult  # noqa: E402
+
+
+def _prices(n=200):
+    rng = np.random.default_rng(0)
+    return 100.0 * np.cumprod(1.0 + rng.normal(0.0003, 0.01, n))
+
+
+def test_template_compiles_and_runs():
+    signal = compile_signal(TEMPLATE)
+    res = run_signal(_prices(), signal)
+    assert isinstance(res, BacktestResult)
+    assert np.isfinite(res.summary()["sharpe"])
+
+
+def test_compile_rejects_missing_signal():
+    import pytest
+    with pytest.raises(ValueError):
+        compile_signal("x = 1")
+
+
+def test_run_signal_with_fee_charges_cost():
+    code = "import numpy as np\n\ndef signal(prices):\n    return np.resize([1.0, -1.0], len(prices))\n"
+    signal = compile_signal(code)
+    res = run_signal(_prices(), signal, fee=0.01)
+    assert res.summary()["total_cost"] > 0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,10 @@ doc = [
     "sphinx-design",
     "sphinx-copybutton",
 ]
+ui = [
+    "streamlit>=1.30",
+    "streamlit-ace",
+]
 
 [project.urls]
 Homepage = "https://github.com/ArthurBernard/Fynance"


### PR DESCRIPTION
Optional UI epic of **fynance 2.0** (plan: `E9-ui/`). Realizes the "code on the left, perf on the right" vision at ~5% of an IDE's cost — a thin Streamlit shell over `tearsheet()`, **not** a bespoke editor.

### Added — `apps/` (outside the importable package)
- **`apps/playground/app.py`** — two-column Streamlit app: a `signal(prices) -> positions` editor + data uploader on the left, the live `tearsheet` + summary on the right. Lazy `streamlit` import.
- **`apps/playground/runner.py`** — Streamlit-free, **unit-tested** helpers (`compile_signal`, `run_signal`, `TEMPLATE`).
- **`[project.optional-dependencies] ui`** = streamlit + streamlit-ace. Run: `pip install -e ".[ui]" && streamlit run apps/playground/app.py`.

### Security
The app `exec`s user-entered code — documented as a **local-only** research tool, not a hosted surface.

## Test plan
- 3 smoke tests on `runner` (template compiles+runs, missing-signal rejected, fee charges cost) — no Streamlit runtime.
- full suite **462 passed**; ruff / mypy / interrogate green (apps/ is outside the CI gate scope by design).