### PR TITLE
docs: finalize 2.0 — API, Sphinx, notebook, README, migration (2.0 E10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- **2.0 refactor** into a layered ML/DL backtesting tool. No compatibility shims; see [`doc/MIGRATION-2.0.md`](doc/MIGRATION-2.0.md).
+- `fynance.algorithms` renamed to **`fynance.portfolio`** (allocation + sizing).
+- Performance metrics moved out of `fynance.features` into **`fynance.metrics`** (`sharpe`, `sortino`, `calmar`, `diversified_ratio`, `annual_return`/`annual_volatility`, `drawdown`, `mdd`, `perf_*`, `returns_strat`, `roll_*`); the `fynance.features.metrics` aggregator is removed. `mad`/`roll_mad` moved to `fynance.features.stats`.
+
 ### Added
+
+- **`fynance.core`** — `PriceSeries` (thin numpy-backed financial series; composition, not `ndarray` subclassing) with price↔return identities, numpy/torch bridges and `.pipe`; pipeline protocols (`DataSource`, `FeatureTransform`, `SignalModel`, `Allocator`, `CostModel`, `Metric`).
+- **`fynance.data`** — `DataSource` port + `load()` dispatcher, CSV/Parquet adapters, `align`/`resample` (causal), and no-lookahead `train_test_split`/`walk_forward` splitters.
+- **`fynance.backtest`** — vectorized `backtest()` engine (positions + returns/prices + cost → `BacktestResult`), `ProportionalCost`, and `BacktestResult` with `summary()`.
+- **`fynance.metrics.summary`** — one-call performance panel + `METRICS` registry.
+- **`fynance.plot`** — composable matplotlib figures and a one-call `tearsheet`/`tearsheet_text`.
+- **`fynance.signal`** — prediction→position mappers (`sign`, `threshold`, `rank`, `vol_target_position`) and `SignalPipeline`.
+- **`fynance.strategy.Strategy`** — optional orchestrator composing the pipeline, with `run` and no-lookahead `run_walk_forward`.
+- Top-level API: key names re-exported on `fynance` (`PriceSeries`, `load`, `Strategy`, `tearsheet`, `backtest`, …).
+- Optional **Streamlit playground** (`apps/playground/`, `pip install -e ".[ui]"`).
+- `Notebooks/quickstart_v2.ipynb` end-to-end tour; Sphinx pages for every 2.0 subpackage; `doc/MIGRATION-2.0.md`.
 
 ### Changed
 

--- a/Notebooks/quickstart_v2.ipynb
+++ b/Notebooks/quickstart_v2.ipynb
@@ -1,0 +1,149 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# fynance 2.0 — quickstart\n",
+    "\n",
+    "The end-to-end pipeline: **data → features → signal → backtest → metrics → report**.\n",
+    "Every piece is usable standalone; `Strategy` is an optional orchestrator."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import fynance as fy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Data\n",
+    "\n",
+    "Load a CSV/Parquet file with `fy.load(\"prices.csv\")`, or build a `PriceSeries` directly.\n",
+    "A `PriceSeries` is a thin, numpy-backed value object (no pandas)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rng = np.random.default_rng(1)\n",
+    "prices = fy.PriceSeries(100 * np.cumprod(1 + rng.normal(0.0004, 0.01, 750)), name=\"asset\")\n",
+    "prices"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Price → returns, and a quick metric\n",
+    "\n",
+    "Metrics live in `fynance.metrics` and operate on a price/equity curve."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "returns = prices.to_returns(\"log\")\n",
+    "print(\"buy & hold Sharpe:\", round(float(fy.sharpe(prices.values)), 3))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Compose a strategy\n",
+    "\n",
+    "A momentum feature → position → vectorized backtest with proportional costs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def momentum(p):\n",
+    "    return np.sign(np.diff(p, prepend=p[0]))\n",
+    "\n",
+    "strat = fy.Strategy(features=momentum, signal=lambda x: x,\n",
+    "                    cost=fy.ProportionalCost(fee=0.0005))\n",
+    "result = strat.run(prices)\n",
+    "result.summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Report\n",
+    "\n",
+    "`tearsheet` is the one-call report (equity, drawdown, rolling Sharpe, metrics table)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = fy.tearsheet(result)\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Walk-forward (no lookahead)\n",
+    "\n",
+    "Refit per window on the train slice only, predict out-of-sample, stitch and backtest."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class LastSign:\n",
+    "    def fit(self, X, y):\n",
+    "        return self\n",
+    "\n",
+    "    def predict(self, X):\n",
+    "        X = np.asarray(X)\n",
+    "        return np.sign(np.diff(X, prepend=X[0]))\n",
+    "\n",
+    "y = np.sign(np.diff(prices.values, prepend=prices.values[0]))\n",
+    "wf = fy.Strategy(model=LastSign(), signal=fy.sign).run_walk_forward(\n",
+    "    prices, y, train=200, test=50, step=50)\n",
+    "wf.summary()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/README.md
+++ b/README.md
@@ -35,27 +35,54 @@ pip install -e ".[dev]"
 python setup.py build_ext --inplace
 ```
 
+## Architecture
+
+A complete, layered ML/DL backtesting tool — **data → features → signal →
+portfolio → backtest → metrics** — composed through `typing.Protocol` seams.
+numpy is the lingua franca; PyTorch is confined to `fynance.models`. Each piece
+is usable standalone; `fynance.strategy.Strategy` is an *optional* orchestrator.
+
+> **2.0 is a breaking release.** See [`doc/MIGRATION-2.0.md`](doc/MIGRATION-2.0.md)
+> for the import-path map (e.g. `fynance.algorithms` → `fynance.portfolio`,
+> performance metrics → `fynance.metrics`).
+
 ## Subpackages
 
-**Algorithms** `fynance.algorithms`  
-Portfolio allocation methods (ERC, HRP, IVP, MDP, MVP), walk-forward wrappers, and position sizing (fractional Kelly, volatility targeting, transaction costs).
+**Core** `fynance.core` — `PriceSeries` value object (thin, numpy-backed) and the
+pipeline protocols (`DataSource`, `FeatureTransform`, `SignalModel`, `Allocator`,
+`CostModel`, `Metric`).
 
-**Backtest** `fynance.backtest`  
-Profit-and-loss plotting and performance measurement.
+**Data** `fynance.data` — file adapters (`load` for CSV/Parquet → `PriceSeries`),
+alignment/resampling, and no-lookahead temporal splits (`train_test_split`,
+`walk_forward`).
 
-**Estimator** `fynance.estimator`  
-Cython ARMA / GARCH parameter estimation.
+**Features** `fynance.features` — technical indicators (Bollinger, RSI, MACD, ROC,
+realized volatility, rolling skew/kurtosis/autocorr, …), momentums (SMA, EMA, WMA),
+scaling (incl. rolling rank), statistics, feature engineering (multi-resolution,
+Granger causality) and market-regime detection.
 
-**Features** `fynance.features`  
-Kalman filter, technical indicators (Bollinger, RSI, MACD, ROC, realized volatility, rolling skew/kurtosis/autocorr, …),
-statistical momentums (SMA, EMA, WMA, …), metrics (Sharpe, Sortino, Calmar, drawdown, tail ratio, …), scaling
-(incl. rolling rank), feature-engineering tools (multi-resolution, Granger causality), and market-regime detection.
+**Metrics** `fynance.metrics` — performance/evaluation metrics (Sharpe, Sortino,
+Calmar, drawdown, …) and a one-call `summary`.
 
-**Models** `fynance.models`  
-Econometric models (MA, ARMA, ARMA-GARCH), neural networks with PyTorch (MLP, RNN, GRU, LSTM,
-MultiHeadAttention, **TCN**, **Transformer**), a **direction+magnitude stacking ensemble**,
-differentiable loss functions (Sharpe, Sortino, Calmar, Omega, directional, hybrid),
-robust-training utilities (purged CV, early stopping, sample weighting), and walk-forward rolling evaluation.
+**Signal** `fynance.signal` — prediction → position mappers (`sign`, `threshold`,
+`rank`, vol-targeting) and a model+mapper pipeline.
+
+**Portfolio** `fynance.portfolio` — allocation (ERC, HRP, IVP, MDP, MVP) and
+sizing (fractional Kelly, volatility targeting, transaction costs).
+
+**Backtest** `fynance.backtest` — vectorized engine (`backtest`: positions +
+returns/prices + cost → `BacktestResult`) and cost models.
+
+**Plot** `fynance.plot` — composable matplotlib figures and a one-call
+`tearsheet` report.
+
+**Models** `fynance.models` — econometric models (MA, ARMA, ARMA-GARCH) and
+PyTorch nets (MLP, RNN, GRU, LSTM, MultiHeadAttention, TCN, Transformer), a
+direction+magnitude stacking ensemble, differentiable losses (Sharpe, Sortino,
+Calmar, Omega, directional, hybrid), and robust-training utilities.
+
+**Strategy** `fynance.strategy` — optional orchestrator composing the maillons
+end-to-end, with single-run and walk-forward evaluation.
 
 ## Quick start
 
@@ -63,33 +90,26 @@ robust-training utilities (purged CV, early stopping, sample weighting), and wal
 import numpy as np
 import fynance as fy
 
-# Sharpe ratio
-returns = np.random.randn(252) * 0.01
-print(fy.sharpe(returns))
+# 1. Data — load a CSV/Parquet file, or build a PriceSeries directly
+prices = fy.PriceSeries(100 * np.cumprod(1 + np.random.randn(750) * 0.01))
 
-# ERC portfolio allocation
-cov = np.cov(np.random.randn(5, 252))
-weights = fy.ERC(cov)
-print(weights)
+# 2. Compose a strategy: momentum feature -> position -> backtest with costs
+strat = fy.Strategy(
+    features=lambda p: np.sign(np.diff(p, prepend=p[0])),
+    signal=lambda x: x,
+    cost=fy.ProportionalCost(fee=0.0005),
+)
+result = strat.run(prices)
+
+# 3. Evaluate and report
+print(result.summary())     # Sharpe, Sortino, Calmar, max drawdown, ...
+fig = fy.tearsheet(result)  # one-call performance report
 ```
 
-Rolling walk-forward training with a neural network:
-
-```python
-import torch
-import torch.nn as nn
-from fynance.models.rolling import RollMultiLayerPerceptron
-
-model = RollMultiLayerPerceptron(X, y, layers=[64, 32])
-model.set_optimizer(nn.MSELoss, torch.optim.Adam, lr=1e-3)
-model(train_period=252, test_period=21, roll_period=21)  # walk-forward windows
-for eval_set, test_set in model:   # each step trains on the past, tests the next
-    model._training()
-```
-
-See [`Notebooks/pytorch_examples.ipynb`](Notebooks/pytorch_examples.ipynb) for a
-runnable tour (metrics, allocation, MLP/TCN/Transformer with custom losses,
-walk-forward CV).
+See [`Notebooks/quickstart_v2.ipynb`](Notebooks/quickstart_v2.ipynb) for the full
+runnable tour (data, features, walk-forward, reporting). An optional Streamlit
+playground ships under [`apps/playground/`](apps/playground/)
+(`pip install -e ".[ui]" && streamlit run apps/playground/app.py`).
 
 ## Links
 

--- a/doc/MIGRATION-2.0.md
+++ b/doc/MIGRATION-2.0.md
@@ -1,0 +1,55 @@
+# Migrating to fynance 2.0
+
+fynance 2.0 is a **breaking** release that turns the toolbox into a layered,
+composable backtesting tool. There are **no compatibility shims** — update your
+imports per the map below.
+
+## Import-path map
+
+| 1.x | 2.0 |
+|-----|-----|
+| `fynance.algorithms` | **`fynance.portfolio`** (allocation + sizing) |
+| `fynance.features.metrics` (Sharpe, Sortino, Calmar, drawdown, mdd, annual_return/volatility, perf_strat, …) | **`fynance.metrics`** |
+| `fynance.features` `mad` / `roll_mad` | **`fynance.features.stats`** (dispersion stats) |
+| ad-hoc plotting in `fynance.backtest` | **`fynance.plot`** (`tearsheet`, `plot_equity`, …) |
+
+Most public names are also re-exported at the top level, so `fy.sharpe`,
+`fy.ERC`, `fy.PriceSeries`, `fy.Strategy`, `fy.tearsheet`, `fy.backtest` work
+directly.
+
+## New maillons (2.0)
+
+- **`fynance.core`** — `PriceSeries` (thin numpy-backed series; **not** a
+  pandas/ndarray subclass) and the pipeline protocols.
+- **`fynance.data`** — `load(path)` for CSV/Parquet, `align`/`resample`,
+  `train_test_split`/`walk_forward` (no-lookahead).
+- **`fynance.signal`** — prediction → position mappers.
+- **`fynance.backtest.backtest`** — vectorized engine → `BacktestResult`.
+- **`fynance.strategy.Strategy`** — optional end-to-end orchestrator.
+
+## Behavioural changes
+
+- **numpy everywhere; no pandas.** Inputs accept polars/numpy; outputs are
+  numpy / `PriceSeries`. (pandas was already removed in 1.x at the edges.)
+- **Causality is explicit.** The backtest engine shifts positions one step
+  (the position decided at `t` earns the return at `t+1`); `PriceSeries.pnl`
+  does the same. Walk-forward refits on the train slice only.
+- **`fynance.backtest`** is now the engine + `BacktestResult` + cost models;
+  the legacy plotting stack is superseded by `fynance.plot`.
+
+## Example
+
+```python
+import numpy as np
+import fynance as fy
+
+prices = fy.load("prices.csv")            # was: manual numpy / pandas
+strat = fy.Strategy(
+    features=lambda p: np.sign(np.diff(p, prepend=p[0])),
+    signal=lambda x: x,
+    cost=fy.ProportionalCost(fee=0.0005),
+)
+result = strat.run(prices)
+print(result.summary())                    # was: scattered metric calls
+fig = fy.tearsheet(result)                  # was: manual plotting
+```

--- a/doc/source/core.rst
+++ b/doc/source/core.rst
@@ -1,0 +1,19 @@
+-------------------------------
+ Core (:mod:`fynance.core`)
+-------------------------------
+
+The spine of the library: the :class:`~fynance.core.PriceSeries` value object
+and the :mod:`typing.Protocol` seams the pipeline composes through.
+
+.. currentmodule:: fynance.core
+
+.. autosummary::
+   :toctree: generated/
+
+   PriceSeries
+   DataSource
+   FeatureTransform
+   SignalModel
+   Allocator
+   CostModel
+   Metric

--- a/doc/source/data.rst
+++ b/doc/source/data.rst
@@ -1,0 +1,19 @@
+-------------------------------
+ Data (:mod:`fynance.data`)
+-------------------------------
+
+Ingestion layer: file adapters into :class:`~fynance.core.PriceSeries`,
+alignment/resampling, and no-lookahead temporal splits.
+
+.. currentmodule:: fynance.data
+
+.. autosummary::
+   :toctree: generated/
+
+   load
+   CSVSource
+   ParquetSource
+   align
+   resample
+   train_test_split
+   walk_forward

--- a/doc/source/generated/fynance.core.Allocator.rst
+++ b/doc/source/generated/fynance.core.Allocator.rst
@@ -1,0 +1,13 @@
+﻿Allocator
+======================
+
+*Defined in* :mod:`fynance.core`
+
+.. currentmodule:: fynance.core
+
+.. autoclass:: Allocator
+   :members:
+   :inherited-members:
+   :special-members: __call__, __iter__, __next__
+   :show-inheritance:
+   :no-index:

--- a/doc/source/generated/fynance.core.CostModel.rst
+++ b/doc/source/generated/fynance.core.CostModel.rst
@@ -1,0 +1,13 @@
+﻿CostModel
+======================
+
+*Defined in* :mod:`fynance.core`
+
+.. currentmodule:: fynance.core
+
+.. autoclass:: CostModel
+   :members:
+   :inherited-members:
+   :special-members: __call__, __iter__, __next__
+   :show-inheritance:
+   :no-index:

--- a/doc/source/generated/fynance.core.DataSource.rst
+++ b/doc/source/generated/fynance.core.DataSource.rst
@@ -1,0 +1,13 @@
+﻿DataSource
+=======================
+
+*Defined in* :mod:`fynance.core`
+
+.. currentmodule:: fynance.core
+
+.. autoclass:: DataSource
+   :members:
+   :inherited-members:
+   :special-members: __call__, __iter__, __next__
+   :show-inheritance:
+   :no-index:

--- a/doc/source/generated/fynance.core.FeatureTransform.rst
+++ b/doc/source/generated/fynance.core.FeatureTransform.rst
@@ -1,0 +1,13 @@
+﻿FeatureTransform
+=============================
+
+*Defined in* :mod:`fynance.core`
+
+.. currentmodule:: fynance.core
+
+.. autoclass:: FeatureTransform
+   :members:
+   :inherited-members:
+   :special-members: __call__, __iter__, __next__
+   :show-inheritance:
+   :no-index:

--- a/doc/source/generated/fynance.core.Metric.rst
+++ b/doc/source/generated/fynance.core.Metric.rst
@@ -1,0 +1,13 @@
+﻿Metric
+===================
+
+*Defined in* :mod:`fynance.core`
+
+.. currentmodule:: fynance.core
+
+.. autoclass:: Metric
+   :members:
+   :inherited-members:
+   :special-members: __call__, __iter__, __next__
+   :show-inheritance:
+   :no-index:

--- a/doc/source/generated/fynance.core.PriceSeries.rst
+++ b/doc/source/generated/fynance.core.PriceSeries.rst
@@ -1,0 +1,13 @@
+﻿PriceSeries
+========================
+
+*Defined in* :mod:`fynance.core`
+
+.. currentmodule:: fynance.core
+
+.. autoclass:: PriceSeries
+   :members:
+   :inherited-members:
+   :special-members: __call__, __iter__, __next__
+   :show-inheritance:
+   :no-index:

--- a/doc/source/generated/fynance.core.SignalModel.rst
+++ b/doc/source/generated/fynance.core.SignalModel.rst
@@ -1,0 +1,13 @@
+﻿SignalModel
+========================
+
+*Defined in* :mod:`fynance.core`
+
+.. currentmodule:: fynance.core
+
+.. autoclass:: SignalModel
+   :members:
+   :inherited-members:
+   :special-members: __call__, __iter__, __next__
+   :show-inheritance:
+   :no-index:

--- a/doc/source/generated/fynance.data.CSVSource.rst
+++ b/doc/source/generated/fynance.data.CSVSource.rst
@@ -1,0 +1,13 @@
+﻿CSVSource
+======================
+
+*Defined in* :mod:`fynance.data`
+
+.. currentmodule:: fynance.data
+
+.. autoclass:: CSVSource
+   :members:
+   :inherited-members:
+   :special-members: __call__, __iter__, __next__
+   :show-inheritance:
+   :no-index:

--- a/doc/source/generated/fynance.data.ParquetSource.rst
+++ b/doc/source/generated/fynance.data.ParquetSource.rst
@@ -1,0 +1,13 @@
+﻿ParquetSource
+==========================
+
+*Defined in* :mod:`fynance.data`
+
+.. currentmodule:: fynance.data
+
+.. autoclass:: ParquetSource
+   :members:
+   :inherited-members:
+   :special-members: __call__, __iter__, __next__
+   :show-inheritance:
+   :no-index:

--- a/doc/source/generated/fynance.data.align.rst
+++ b/doc/source/generated/fynance.data.align.rst
@@ -1,0 +1,9 @@
+﻿align
+==================
+
+*Defined in* :mod:`fynance.data`
+
+.. currentmodule:: fynance.data
+
+.. autofunction:: align
+   :no-index:

--- a/doc/source/generated/fynance.data.load.rst
+++ b/doc/source/generated/fynance.data.load.rst
@@ -1,0 +1,9 @@
+﻿load
+=================
+
+*Defined in* :mod:`fynance.data`
+
+.. currentmodule:: fynance.data
+
+.. autofunction:: load
+   :no-index:

--- a/doc/source/generated/fynance.data.resample.rst
+++ b/doc/source/generated/fynance.data.resample.rst
@@ -1,0 +1,9 @@
+﻿resample
+=====================
+
+*Defined in* :mod:`fynance.data`
+
+.. currentmodule:: fynance.data
+
+.. autofunction:: resample
+   :no-index:

--- a/doc/source/generated/fynance.data.train_test_split.rst
+++ b/doc/source/generated/fynance.data.train_test_split.rst
@@ -1,0 +1,9 @@
+﻿train_test_split
+=============================
+
+*Defined in* :mod:`fynance.data`
+
+.. currentmodule:: fynance.data
+
+.. autofunction:: train_test_split
+   :no-index:

--- a/doc/source/generated/fynance.data.walk_forward.rst
+++ b/doc/source/generated/fynance.data.walk_forward.rst
@@ -1,0 +1,9 @@
+﻿walk_forward
+=========================
+
+*Defined in* :mod:`fynance.data`
+
+.. currentmodule:: fynance.data
+
+.. autofunction:: walk_forward
+   :no-index:

--- a/doc/source/generated/fynance.signal.SignalPipeline.rst
+++ b/doc/source/generated/fynance.signal.SignalPipeline.rst
@@ -1,0 +1,13 @@
+﻿SignalPipeline
+=============================
+
+*Defined in* :mod:`fynance.signal`
+
+.. currentmodule:: fynance.signal
+
+.. autoclass:: SignalPipeline
+   :members:
+   :inherited-members:
+   :special-members: __call__, __iter__, __next__
+   :show-inheritance:
+   :no-index:

--- a/doc/source/generated/fynance.signal.rank.rst
+++ b/doc/source/generated/fynance.signal.rank.rst
@@ -1,0 +1,9 @@
+﻿rank
+===================
+
+*Defined in* :mod:`fynance.signal`
+
+.. currentmodule:: fynance.signal
+
+.. autofunction:: rank
+   :no-index:

--- a/doc/source/generated/fynance.signal.sign.rst
+++ b/doc/source/generated/fynance.signal.sign.rst
@@ -1,0 +1,9 @@
+﻿sign
+===================
+
+*Defined in* :mod:`fynance.signal`
+
+.. currentmodule:: fynance.signal
+
+.. autofunction:: sign
+   :no-index:

--- a/doc/source/generated/fynance.signal.threshold.rst
+++ b/doc/source/generated/fynance.signal.threshold.rst
@@ -1,0 +1,9 @@
+﻿threshold
+========================
+
+*Defined in* :mod:`fynance.signal`
+
+.. currentmodule:: fynance.signal
+
+.. autofunction:: threshold
+   :no-index:

--- a/doc/source/generated/fynance.signal.vol_target_position.rst
+++ b/doc/source/generated/fynance.signal.vol_target_position.rst
@@ -1,0 +1,9 @@
+﻿vol_target_position
+==================================
+
+*Defined in* :mod:`fynance.signal`
+
+.. currentmodule:: fynance.signal
+
+.. autofunction:: vol_target_position
+   :no-index:

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -84,6 +84,9 @@
    :hidden:
    :caption: Reference
 
+   core
+   data
+   signal
    portfolio
    backtest
    estimator

--- a/doc/source/signal.rst
+++ b/doc/source/signal.rst
@@ -1,0 +1,16 @@
+-----------------------------------
+ Signal (:mod:`fynance.signal`)
+-----------------------------------
+
+The bridge from predictions to positions: mappers and a model+mapper pipeline.
+
+.. currentmodule:: fynance.signal
+
+.. autosummary::
+   :toctree: generated/
+
+   sign
+   threshold
+   rank
+   vol_target_position
+   SignalPipeline

--- a/fynance/__init__.py
+++ b/fynance/__init__.py
@@ -65,18 +65,22 @@ __all__ = ['__version__']
 import sys as _sys
 
 from .backtest import *
+from .core import *
+from .data import *
 from .estimator import *
 from .features import *
 from .metrics import *
 from .models import *
 from .plot import *
 from .portfolio import *
+from .signal import *
 from .strategy import *
 
 # Aggregate each subpackage's public surface. Use ``sys.modules`` rather than the
 # package attributes, which a star import may have shadowed with a name that
 # collides with a submodule (e.g. the ``backtest`` engine function).
-for _name in ("models", "estimator", "features", "metrics", "plot", "backtest", "portfolio", "strategy"):
+for _name in ("core", "data", "models", "estimator", "features", "metrics",
+              "plot", "signal", "backtest", "portfolio", "strategy"):
     __all__ += _sys.modules[f"{__name__}.{_name}"].__all__
 
 # Restore the subpackage attribute shadowed by such a collision so that


### PR DESCRIPTION
Closing epic of **fynance 2.0** (plan: `E10-docs/`). Brings all docs in line with the new layout and tells users how to move from 1.x.

### Added / Changed
- **Top-level API**: `core`/`data`/`signal` re-exported on `fynance` — `fy.PriceSeries`, `fy.load`, `fy.Strategy`, `fy.tearsheet`, `fy.sign`, … all importable directly (175 public names).
- **Sphinx**: new `core`/`data`/`signal` pages; every 2.0 subpackage in the Reference toctree; autosummary stubs regenerated.
- **`Notebooks/quickstart_v2.ipynb`** — end-to-end runnable tour (data → strategy → tearsheet → walk-forward); every cell verified.
- **README** rewritten around the 2.0 pipeline + a verified quickstart snippet.
- **`doc/MIGRATION-2.0.md`** — import-path map + behavioural changes.
- **CHANGELOG** — `Breaking Changes` + `Added` sections for the 2.0 (drives the major bump at release).

## Test plan
- full suite **462 passed**; ruff / mypy (131 files) / interrogate (93.7%) green; Sphinx `-W` single-build clean (CI-simulated).
- README and notebook snippets executed successfully.