### PR TITLE
docs: 2.0 status — 9/10 epics shipped, E7 (numba) remaining

### DIFF
--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -64,3 +64,18 @@ so an agent doesn't re-investigate settled ground or assume a known stub is a bu
 Larger axes parked for later: realistic backtesting (transaction costs, position
 sizing), market-regime conditioning, multi-resolution features, and the
 docs-hosting decision. Tracked in the roadmap; not bugs.
+
+## 2026-06-15 — fynance 2.0 refactor: 9/10 epics shipped
+
+The 2.0 architecture is **complete and releasable**. Shipped on `develop` (PRs
+#99–#108): E1 core (`PriceSeries`, protocols), E2 data (adapters, splits), E3
+metrics extraction, E4 vectorized backtest engine, E5 reporting (`tearsheet`),
+E6 signal + portfolio rename, E8 `Strategy`, E9 Streamlit playground, E10 docs
+(Sphinx, notebook, README, `MIGRATION-2.0.md`). Top-level API re-exports all
+maillons. 462 tests, 4 CI gates green per PR.
+
+**Remaining**: E7 (Cython→numba: estimator/econometric port, drop Cython build,
+`SignalModel` conformance). Deliberately deferred — correctness-critical
+numerical port (best done with golden-value parity), non-blocking for v2.0.0.
+Decision pending: do E7 before the release, or cut **v2.0.0** now and land numba
+in 2.1.

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -22,16 +22,16 @@ Turn the toolbox into a complete layered ML/DL backtesting tool
 **Detailed plan tree:** `doc/dev/plans/v2-refactor/` (global `00-plan.md` +
 per-epic `EN-*/00-plan.md` + per-task leaves). Ships epic-by-epic, leaf = 1 PR.
 
-- [ ] **E1 core** — `PriceSeries`, Protocol seams, numpy/torch bridges
-- [ ] **E2 data** — DataSource port, CSV/Parquet adapters, align, temporal splits
-- [ ] **E3 features+metrics** — regroup features, extract perf-metrics → `metrics/`
-- [ ] **E4 backtest** — CostModel + vectorized engine → `BacktestResult`
-- [ ] **E5 reporting** — metrics consolidation, `plot/`, `tearsheet()`
-- [ ] **E6 signal+portfolio** — `signal/` mappers, `portfolio/` (ex-algorithms)
-- [ ] **E7 models+numba** — estimator→numba, drop Cython, SignalModel conformance
-- [ ] **E8 strategy** — optional orchestrator + walk-forward run
-- [ ] **E9 ui** — optional Streamlit playground (deferrable to 2.1)
-- [ ] **E10 docs** — Sphinx restructure, example notebook, README + migration guide
+- [x] **E1 core** — `PriceSeries`, Protocol seams, numpy/torch bridges
+- [x] **E2 data** — DataSource port, CSV/Parquet adapters, align, temporal splits
+- [x] **E3 features+metrics** — regroup features, extract perf-metrics → `metrics/`
+- [x] **E4 backtest** — CostModel + vectorized engine → `BacktestResult`
+- [x] **E5 reporting** — metrics consolidation, `plot/`, `tearsheet()`
+- [x] **E6 signal+portfolio** — `signal/` mappers, `portfolio/` (ex-algorithms)
+- [ ] **E7 models+numba** — estimator→numba, drop Cython, SignalModel conformance  *(only epic remaining; correctness-critical numba port — deliberately deferred, non-blocking for v2.0.0)*
+- [x] **E8 strategy** — optional orchestrator + walk-forward run
+- [x] **E9 ui** — optional Streamlit playground (deferrable to 2.1)
+- [x] **E10 docs** — Sphinx restructure, example notebook, README + migration guide
 
 Order: E1 → (E2 ∥ E3 ∥ E6 ∥ E7) → E4 → E5 → E8 → (E9 ∥ E10).
 


### PR DESCRIPTION
Roadmap/status housekeeping: mark the shipped 2.0 epics (E1–E6, E8, E9, E10) done; record that E7 (Cython→numba) is the only remaining epic, deliberately deferred (correctness-critical, non-blocking for v2.0.0).

Docs only.

## Test plan
- N/A (doc index/status).