### PR TITLE
feat: NN models conform to SignalModel (2.1 E7.04)

### DIFF
--- a/fynance/models/_base.py
+++ b/fynance/models/_base.py
@@ -236,17 +236,50 @@ class BaseNeuralNet(torch.nn.Module):
 
         return loss
 
+    def fit(self, X, y, epochs: int = 1, x_type=None, y_type=None):
+        """ Fit the model on ``(X, y)`` for ``epochs`` full-batch steps.
+
+        Convenience wrapper that makes the network conform to the
+        :class:`~fynance.core.protocols.SignalModel` protocol: it coerces the
+        data via :meth:`set_data` and runs :meth:`train_on` ``epochs`` times.
+        An optimizer must have been registered with :meth:`set_optimizer`.
+
+        Parameters
+        ----------
+        X, y : array-like
+            Input and output data (numpy / torch / polars), shapes ``(T, N)``
+            and ``(T, M)``.
+        epochs : int
+            Number of full-batch training steps.
+        x_type, y_type : torch.dtype, optional
+            Target dtypes forwarded to :meth:`set_data`.
+
+        Returns
+        -------
+        BaseNeuralNet
+            ``self``, to allow chaining.
+
+        """
+        self.set_data(X, y, x_type=x_type, y_type=y_type)
+
+        for _ in range(epochs):
+            self.train_on(self.X, self.y)  # type: ignore[has-type]
+
+        return self
+
     @torch.no_grad()
-    def predict(self, X: torch.Tensor) -> torch.Tensor:
+    def predict(self, X) -> torch.Tensor:
         """ Predicts outputs of neural network model.
 
         Runs ``self.forward(X)`` under :func:`torch.no_grad`, so no
         autograd graph is built. The returned tensor is detached and
-        lives on the same device as the model parameters.
+        lives on the same device as the model parameters. Array-like inputs
+        (numpy / polars) are coerced to a tensor first, so the method also
+        satisfies the :class:`~fynance.core.protocols.SignalModel` contract.
 
         Parameters
         ----------
-        X : torch.Tensor
+        X : array-like
            Inputs to compute prediction. Same shape and dtype contract
            as :meth:`train_on`.
 
@@ -256,6 +289,9 @@ class BaseNeuralNet(torch.nn.Module):
            Outputs prediction (detached, gradient-free).
 
         """
+        if not isinstance(X, torch.Tensor):
+            X = self._set_data(X)
+
         return self(X).detach()
 
     def set_data(self, X: NDArray | torch.Tensor | pl.DataFrame, y: NDArray | torch.Tensor | pl.DataFrame, x_type=None, y_type=None):

--- a/fynance/tests/models/test_signalmodel.py
+++ b/fynance/tests/models/test_signalmodel.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Models conform to the SignalModel protocol (fit/predict). """
+
+# Third-party packages
+import numpy as np
+import torch
+import torch.nn as nn
+
+# Local packages
+from fynance.core import SignalModel
+from fynance.models import MultiLayerPerceptron
+
+
+def _xy(n=40, feat=3):
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(n, feat)).astype(np.float32)
+    y = (X.sum(axis=1, keepdims=True)).astype(np.float32)
+    return X, y
+
+
+def test_mlp_conforms_and_fit_predict():
+    X, y = _xy()
+    model = MultiLayerPerceptron(X, y, layers=[8])
+    model.set_optimizer(nn.MSELoss, torch.optim.SGD, lr=1e-3)
+    assert isinstance(model, SignalModel)
+    out = model.fit(X, y, epochs=2).predict(X)
+    arr = np.asarray(out)
+    assert arr.shape[0] == X.shape[0]
+
+
+def test_predict_accepts_numpy_and_tensor():
+    X, y = _xy()
+    model = MultiLayerPerceptron(X, y, layers=[4])
+    model.set_optimizer(nn.MSELoss, torch.optim.SGD, lr=1e-3)
+    model.fit(X, y, epochs=1)
+    p_np = np.asarray(model.predict(X))
+    p_t = np.asarray(model.predict(torch.as_tensor(X)))
+    assert np.allclose(p_np, p_t, atol=1e-5)
+
+
+def test_fit_returns_self():
+    X, y = _xy()
+    model = MultiLayerPerceptron(X, y, layers=[4])
+    model.set_optimizer(nn.MSELoss, torch.optim.SGD, lr=1e-3)
+    assert model.fit(X, y) is model


### PR DESCRIPTION
First slice of **E7** (numba modernization, targeting 2.1).

### Added
- `BaseNeuralNet.fit(X, y, epochs)` — wraps `set_data` + a `train_on` loop, returns `self`.
- `predict()` now coerces array-like inputs (numpy/polars) to a tensor.

Together these make every NN model (MLP/RNN/GRU/LSTM/TCN/Transformer) structurally satisfy the `SignalModel` protocol, so they compose directly with `fynance.strategy.Strategy`. Backward-compatible (tensor in/out still works).

## Test plan
- 3 new tests (isinstance SignalModel, numpy↔tensor predict parity, fit chaining); full suite green; ruff/mypy/interrogate green.