### PR TITLE
chore: release v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
+### Added
+
+### Changed
+
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [2.1.0] - 2026-06-15
+
+### Breaking Changes
+
 - **All Cython removed** (E7 numba modernization). The `*_cy` kernels — features `momentums`/`metrics`/`roll_functions` and the ARMA/GARCH `econometric_models`/`estimator` — were ported to **Numba `@njit`**; the `*_cy` modules and their public `*_cy_1d/2d` / `MA_cy`/`ARMA_cy`/… symbols are gone. The build is now pure-Python (no `setup.py`, no compile step).
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fynance"
-version = "2.0.0"
+version = "2.1.0"
 description = "Python and Cython scripts of machine learning, econometrics and statistical features for financial analysis"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Freezes `[Unreleased]` into **`[2.1.0]`** and bumps 2.0.0 → 2.1.0.

**2.1 = the E7 numba modernization**: all Cython removed (estimator ARMA/GARCH + features kernels → Numba `@njit`), pure-Python build (no `setup.py`), NN models conform to `SignalModel`, and a fix for the `roll_annual_volatility`/`roll_sharpe` NaN bug (Cython buffer aliasing).

> Note: technically the `*_cy` low-level symbols were removed (breaking), but the public functions (`MA`/`ARMA`/`sma`/`sharpe`/…) are unchanged — shipped as **minor** per maintainer direction.

## Test plan
- CI green on develop (495 tests, ruff/mypy/interrogate, Sphinx -W); pure-Python install (no compile step); golden-value parity to 1e-9/1e-10.