### PR TITLE
fix(ci): pure-Python wheel build for release (unblocks v2.1.0 PyPI)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,22 +7,31 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels
+    name: Build wheel
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build manylinux wheels
-        uses: pypa/cibuildwheel@v2.22
-        env:
-          CIBW_BUILD: cp310-manylinux_x86_64 cp311-manylinux_x86_64 cp312-manylinux_x86_64
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      # The package is pure-Python (Numba kernels, no compiled extensions), so a
+      # single universal wheel (py3-none-any) is built — not per-platform
+      # cibuildwheel manylinux wheels.
+      - name: Build pure-Python wheel
+        run: |
+          pip install build
+          python -m build --wheel
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
           name: wheels
-          path: ./wheelhouse/*.whl
+          path: dist/*.whl
 
   build_sdist:
     name: Build sdist


### PR DESCRIPTION
The v2.1.0 release workflow failed at **Build manylinux wheels**: cibuildwheel refuses pure-Python wheels (`Build failed because a pure Python wheel was generated`). Since the 2.1 numba migration removed all compiled extensions, build the universal `py3-none-any` wheel via `python -m build --wheel`.

v2.1.0 was tagged but **not published** (publish never ran). After this lands in master, the tag is re-pointed to re-trigger the release.

## Test plan
- CI gates unaffected; release workflow validated on re-tag.