### PR TITLE
fix: pure-Python wheel build (re-release v2.1.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,22 +7,31 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels
+    name: Build wheel
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build manylinux wheels
-        uses: pypa/cibuildwheel@v2.22
-        env:
-          CIBW_BUILD: cp310-manylinux_x86_64 cp311-manylinux_x86_64 cp312-manylinux_x86_64
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      # The package is pure-Python (Numba kernels, no compiled extensions), so a
+      # single universal wheel (py3-none-any) is built — not per-platform
+      # cibuildwheel manylinux wheels.
+      - name: Build pure-Python wheel
+        run: |
+          pip install build
+          python -m build --wheel
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
           name: wheels
-          path: ./wheelhouse/*.whl
+          path: dist/*.whl
 
   build_sdist:
     name: Build sdist


### PR DESCRIPTION
Brings the release.yml pure-Python wheel fix to master so the v2.1.0 tag can be re-pointed and the PyPI publish re-triggered.