### PR TITLE
chore: release v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [2.1.1] - 2026-06-16
+
+### Breaking Changes
+
+### Added
+
+### Changed
+
 - Performance: rolling extrema (`roll_min`/`roll_max`) reimplemented with an O(n) monotonic deque (was O(n·w)) — ~10× faster at w=250, now flat in window size; their 2-D versions and `roll_mdd` run column-parallel (`numba` `prange`) and `roll_mdd` no longer allocates per window (~2×). Results are bit-identical to the previous implementation (verified against a naive reference).
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fynance"
-version = "2.1.0"
+version = "2.1.1"
 description = "Python and Cython scripts of machine learning, econometrics and statistical features for financial analysis"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Patch release: bit-identical **performance** optimization of the rolling kernels (O(n) deque rolling extrema ~10×, parallel/alloc-free `roll_mdd`). No API or behaviour change.

Bump 2.1.0 → 2.1.1; freezes `[Unreleased]` into `[2.1.1]`.

## Test plan
- CI green on develop (499 tests; ruff/mypy/interrogate; Sphinx -W); perf parity asserted bit-identical.