### PR TITLE
chore: dead-code + debug-print cleanup (audit M2/M3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Dead private helpers `_roll_annual_return_py` / `_roll_annual_volatility_py` (superseded numpy fallbacks) from `fynance.features._metrics_helpers`.
+
 ## [2.1.1] - 2026-06-16
 
 ### Breaking Changes
@@ -28,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Removed a leftover debug `print` in `portfolio.allocation` (singular-covariance error path now re-raises cleanly).
 - Performance: rolling extrema (`roll_min`/`roll_max`) reimplemented with an O(n) monotonic deque (was O(n·w)) — ~10× faster at w=250, now flat in window size; their 2-D versions and `roll_mdd` run column-parallel (`numba` `prange`) and `roll_mdd` no longer allocates per window (~2×). Results are bit-identical to the previous implementation (verified against a naive reference).
 
 ### Fixed

--- a/fynance/features/_metrics_helpers.py
+++ b/fynance/features/_metrics_helpers.py
@@ -215,7 +215,7 @@ def _roll_mad_2d(X, w):
         out[:, n] = _roll_mad_1d(X[:, n].copy(), w)
     return out
 
-__all__ = ['_annual_return', '_compute_returns', '_annual_volatility', '_annual_downside_volatility', '_drawdown', '_roll_annual_return', '_roll_annual_volatility', '_roll_drawdown', '_roll_mdd', '_roll_annual_return_py', '_roll_annual_volatility_py', '_handler_ma', '_handler_mstd', '_roll_mad_1d', '_roll_mad_2d']
+__all__ = ['_annual_return', '_compute_returns', '_annual_volatility', '_annual_downside_volatility', '_drawdown', '_roll_annual_return', '_roll_annual_volatility', '_roll_drawdown', '_roll_mdd', '_handler_ma', '_handler_mstd', '_roll_mad_1d', '_roll_mad_2d']
 
 _handler_ma = {'s': _sma, 'w': _wma, 'e': _ema}
 _handler_mstd = {'s': _smstd, 'w': _wmstd, 'e': _emstd}
@@ -334,52 +334,3 @@ def _roll_mdd(X, w, raw):
         return _roll_mdd_2d(X, w, int(raw))
 
     return _roll_mdd_1d(X, w, int(raw))
-
-
-def _roll_annual_return_py(X, period, w, ddof):
-    """ Old function. """
-    if (X[0] == 0).any():
-
-        raise ValueError('initial value X[0] cannot be null.')
-
-    cum_ret = np.zeros(X.shape)
-    cum_ret[: w] = X[: w] / X[0]
-    cum_ret[w:] = X[w:] / X[: -w]
-
-    if (cum_ret < 0).any():
-
-        raise ValueError('all values of X must be of the same sign.')
-
-    T = X.shape[0]
-    power = period / np.arange(1, T - ddof + 1, dtype=np.float64)
-
-    if len(X.shape) == 2:
-        power = power.reshape([T, 1])
-
-    sign = np.sign(X[0])
-
-    anu_ret = np.zeros(X.shape)
-    anu_ret[ddof:] = sign * np.float_power(cum_ret[ddof:], power) - 1.
-
-    return anu_ret
-
-
-def _roll_annual_volatility_py(X, period, log, w, axis, ddof):
-    """ Old function. """
-    shape = X.shape
-    T = shape[0]
-    R = np.zeros(shape)
-    anu_vol = np.zeros(shape)
-
-    if log:
-        R[1:] = np.log(X[1:] / X[:-1])
-
-    else:
-        R[1:] = X[1:] / X[:-1] - 1.
-
-    for t in range(ddof + 1, T):
-        t0 = max(0, t - w)
-        anu_vol[t] = np.std(R[t0:t + 1], axis=axis, ddof=ddof)
-
-    return np.sqrt(period) * anu_vol
-

--- a/fynance/portfolio/allocation.py
+++ b/fynance/portfolio/allocation.py
@@ -452,8 +452,7 @@ def MVP(
         try:
             iv = np.linalg.pinv(mat_cov)
         except np.linalg.LinAlgError:
-            print(mat_cov)
-            raise np.linalg.LinAlgError
+            raise
 
     e = np.ones([iv.shape[0], 1])
     w = (iv @ e) / (e.T @ iv @ e)


### PR DESCRIPTION
Audit hygiene findings.

### Removed (M2)
- Dead `_roll_annual_return_py` / `_roll_annual_volatility_py` numpy fallbacks (superseded by the numba kernels) + their `__all__` entries.

### Fixed (M3)
- Leftover `print(mat_cov)` in `portfolio.allocation` (singular-covariance branch now re-raises cleanly).

> The `rolling._display_kpi` `print` flagged in the audit is **intentional** (opt-in KPI display gated by `backtest_kpi`) — left as-is.

## Test plan
- full suite **501 passed**; ruff/mypy green.