### PR TITLE
docs: refresh docs for post-2.1 reality

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@
 
 ___
 
-Python and Cython package providing **machine learning**, **econometric** and **statistical** tools
-for **financial analysis** and **backtesting of trading strategies**.
+Pure-Python package (Numba-accelerated kernels) providing **machine learning**,
+**econometric** and **statistical** tools for **financial analysis** and
+**backtesting of trading strategies**.
 
 ## Installation
 
@@ -32,8 +33,10 @@ From source:
 git clone https://github.com/ArthurBernard/Fynance.git
 cd Fynance
 pip install -e ".[dev]"
-python setup.py build_ext --inplace
 ```
+
+The build is pure-Python — there is no compile step (numerical kernels are
+Numba `@njit`, JIT-compiled on first call).
 
 ## Architecture
 

--- a/doc/dev/01-overview.md
+++ b/doc/dev/01-overview.md
@@ -2,20 +2,27 @@
 
 ## What fynance is
 
-**fynance** is a Python + Cython library of machine-learning, econometric, and
-statistical tools for **financial time-series analysis**. It bundles four things
-that usually live in separate packages:
+**fynance** is a pure-Python library (Numba-accelerated kernels) of
+machine-learning, econometric, and statistical tools for **financial time-series
+analysis and backtesting**. Since 2.0 it is a **layered backtesting tool**
+(data → features → signal → portfolio → backtest → metrics) composed through
+`typing.Protocol` seams, not just a grab-bag of functions:
 
-- **Features** — financial indicators, metrics, filters, momentums, scaling
-  (Sharpe/Sortino/Calmar, drawdowns, rolling stats, …), with Cython-accelerated
-  hot paths.
-- **Algorithms** — portfolio allocation (ERC, HRP, IVP, MDP, MVP) and a generic
-  rolling/walk-forward driver.
-- **Models** — econometric (ARMA/GARCH via a Cython estimator) and neural
-  (MLP, RNN/GRU/LSTM, attention, TCN, Transformer, stacking ensemble) with a
-  walk-forward training base, plus custom PyTorch losses (Sharpe/Sortino/Calmar/
-  Omega/directional/hybrid).
-- **Backtest** — evaluation, P&L/perf plotting (static + dynamic), stat printing.
+- **Core** — `PriceSeries` (thin numpy-backed value object) and the pipeline
+  protocols (`DataSource`/`FeatureTransform`/`SignalModel`/`Allocator`/
+  `CostModel`/`Metric`).
+- **Data** — `load()` + CSV/Parquet adapters, causal align/resample, no-lookahead
+  temporal splits.
+- **Features** — financial indicators, momentums, filters, scaling, feature
+  engineering, regime detection (Numba-accelerated hot paths).
+- **Metrics** — Sharpe/Sortino/Calmar, drawdowns, rolling stats, one-call summary.
+- **Signal / Portfolio** — prediction→position mappers; allocation (ERC/HRP/IVP/
+  MDP/MVP) + sizing.
+- **Models** — econometric (ARMA/GARCH) and neural (MLP, RNN/GRU/LSTM, attention,
+  TCN, Transformer, stacking ensemble) on a walk-forward training base, plus custom
+  PyTorch losses (Sharpe/Sortino/Calmar/Omega/directional/hybrid).
+- **Backtest / Plot / Strategy** — vectorized engine + cost models →
+  `BacktestResult`; `tearsheet` reporting; optional `Strategy` orchestrator.
 
 The throughline is **strict temporal causality**: every rolling feature and every
 training window is computed from the past only — no lookahead. This is the
@@ -23,44 +30,49 @@ library's core invariant, enforced in tests.
 
 ## Current state (snapshot)
 
-- **Version `1.3.4`** (in `pyproject.toml`, static), released on `master` and
+- **Version `2.1.1`** (in `pyproject.toml`, static), released on `master` and
   published to PyPI; `Development Status :: 5 - Production/Stable`.
-- **Python 3.10–3.13** (CI matrix). Build is `setuptools` + **Cython 3** +
-  **NumPy 2**.
-- **~300 tests** under `fynance/tests/` (mirrors the package), **plus doctests**
+- **Python 3.10–3.13** (CI matrix). Build is **pure-Python** (setuptools, no
+  compile step) — numerical kernels are Numba `@njit`. No Cython.
+- **501 tests** under `fynance/tests/` (mirrors the package), **plus doctests**
   run on every module via `--doctest-modules` — docstring examples are part of
-  the suite and must stay runnable. `ruff` + `mypy` configured; Sphinx docs build
-  (furo).
-- **Core stack**: NumPy 2, pandas 2, SciPy, Numba (`@njit`), **PyTorch** (the ML
-  backend — Keras/TensorFlow is being retired), matplotlib/seaborn.
+  the suite and must stay runnable.
+- **Four CI gates**: pytest (3.10–3.13), `ruff`, `interrogate` (docstring
+  coverage ≥ 80%), Sphinx build `-W`, and `mypy` clean.
+- **Core stack**: NumPy, SciPy, Numba (`@njit`), **PyTorch** (the ML backend —
+  no TensorFlow/Keras), matplotlib/seaborn (lazy — `import fynance` stays
+  matplotlib-free).
 
 ## Repo map
 
 ```
 fynance/
-  features/      # indicators, metrics, momentums, filters, scale,
-                 #   roll_functions, money_management
-                 #   (each hot path has a .py + a compiled *_cy.pyx twin)
-  algorithms/    # allocation (ERC/HRP/IVP/MDP/MVP), rolling_allocation
-  models/        # econometric_models (ARMA/GARCH) + neural (mlp/rnn/gru/lstm/
-                 #   attention) on a rolling/walk-forward base; loss/ (torch losses)
-  estimator/     # estimator_cy.pyx — ARMA/GARCH parameter estimation (Cython)
-  backtest/      # plotting (static + dynamic), loss, print_stats
-  core/          # series helpers
-  _exceptions.py # ArraySizeError and friends (shared error types)
-  tests/         # mirrors the package; pytest + doctests
+  core/        # PriceSeries value object + pipeline protocols
+  data/        # load() + CSV/Parquet adapters, align/resample, temporal splits
+  features/    # indicators, momentums, filters, scale, engineering, regime,
+               #   _metrics_helpers (Numba kernels), money_management
+  metrics/     # ratios, drawdown, returns, summary (perf/eval metrics)
+  signal/      # prediction→position mappers + SignalPipeline
+  portfolio/   # allocation (ERC/HRP/IVP/MDP/MVP) + sizing
+  models/      # econometric_models (ARMA/GARCH, Numba) + neural (mlp/rnn/gru/
+               #   lstm/attention/tcn/transformer) on a walk-forward base;
+               #   loss/ (torch losses), training, ensemble
+  backtest/    # vectorized engine + cost + result; legacy live-viz plot stack
+  plot/        # composable matplotlib figures + tearsheet (lazy import)
+  strategy/    # optional Strategy orchestrator + walk-forward run
+  estimator/   # ARMA/GARCH parameter estimation (Numba)
+  tests/       # mirrors the package; pytest + doctests
 doc/
-  source/        # Sphinx (furo) end-user docs
-  dev/           # THIS folder — agent-facing brief
-setup.py         # Cython extension build only (metadata is in pyproject.toml)
+  source/      # Sphinx (furo) end-user docs
+  dev/         # THIS folder — agent-facing brief
+pyproject.toml # authoritative build config (pure-Python; no setup.py)
 ```
 
 ## Three things an agent should never break
 
 1. **No lookahead bias** — any feature at `t` must be `f(data[..t])`; any training
    window trains on the strict past. See `03-decisions.md` and `05-testing.md`.
-2. **The Cython fallback** — `setup.py` compiles `.pyx` if Cython is present, else
-   falls back to shipped `.c`. New numeric code uses **Numba `@njit`**, not new
-   Cython.
+2. **Numba kernels with golden-value parity** — performance-critical numeric code
+   is Numba `@njit`; every kernel has a parity test (1e-9/1e-10). No Cython.
 3. **Doctests are tests** — every docstring example runs under
    `--doctest-modules`; a broken example fails CI.

--- a/doc/dev/02-architecture.md
+++ b/doc/dev/02-architecture.md
@@ -1,21 +1,24 @@
 # 2 — Architecture
 
-fynance is a **layered numerical library**, not a service. There's no I/O layer
-and no daemon: callers pass arrays/DataFrames in and get arrays/models out. The
-structure is by *concern* (features → algorithms/models → backtest), with a
-shared causal-windowing pattern running through all of them.
+fynance is a **layered numerical library**, not a service. Ports & adapters live
+only at the I/O edge (`data/`); everything else passes arrays in and gets arrays
+or models out. The structure is by *concern*, wired through `typing.Protocol`
+seams, with a shared causal-windowing pattern running through it.
 
 ```
-backtest        evaluate + plot results
+strategy            optional orchestrator (compose the maillons end-to-end)
+   │  composes
+   ▼
+backtest · plot     vectorized engine + cost → BacktestResult; tearsheet reporting
    │  consumes
    ▼
-algorithms · models      allocation, walk-forward training, econometrics
-   │  build on
+signal · portfolio · models   position mappers, allocation/sizing, walk-forward
+   │  build on                training, econometrics
    ▼
-features · estimator     indicators, metrics, ARMA/GARCH params (hot paths in Cython)
-   │  operate on
+features · metrics · estimator   indicators, perf metrics, ARMA/GARCH params
+   │  operate on                  (hot paths in Numba @njit)
    ▼
-core                     series helpers, array wrappers
+core · data         PriceSeries + protocols; adapters, align, temporal splits
 ```
 
 ## Subpackage by subpackage
@@ -23,43 +26,43 @@ core                     series helpers, array wrappers
 (See [`04-subpackages.md`](04-subpackages.md) for the public API surface and the
 stability policy per package.)
 
-- **`features/`** — the numerical kernels: `metrics` (Sharpe/Sortino/Calmar,
-  drawdowns, accuracy, z-score…), `momentums` (EMA/SMA/…), `indicators`,
-  `filters`, `roll_functions`, `scale`, `money_management`. The heavy ones ship a
-  `.py` *and* a compiled `*_cy.pyx` twin (see below).
-- **`algorithms/`** — `allocation.py`: ERC, HRP, IVP, MDP, MVP portfolio methods
-  plus `rolling_allocation()` (walk-forward driver for allocation). Stable
-  public API.
-- **`estimator/`** — `estimator_cy.pyx`: the Cython ARMA/GARCH parameter
-  estimator. **Authoritative** — parameter logic lives here, not duplicated in
-  Python.
-- **`models/`** — econometric (`econometric_models.py` wrapping the estimator) and
-  neural (`mlp`, `rnn`, `gru`, `lstm`, `attention`) on a rolling/walk-forward
-  base; `loss/` holds custom PyTorch losses.
-- **`backtest/`** — `plot_backtest`, `dynamic_plot_backtest`,
-  `backtest_neural_net`, `print_stats`, `loss`; evaluation and visualisation.
-  Improve freely.
-- **`core/`** — `series.py` array/series helpers shared across packages.
+- **`core/`** — `PriceSeries` (numpy-backed value object; compose, don't subclass
+  `ndarray`) and the pipeline protocols (`DataSource`/`FeatureTransform`/
+  `SignalModel`/`Allocator`/`CostModel`/`Metric`, `runtime_checkable`).
+- **`data/`** — the only I/O layer: `load()` dispatcher + CSV/Parquet adapters,
+  causal `align`/`resample`, no-lookahead `train_test_split`/`walk_forward`.
+- **`features/`** — numerical kernels: `momentums` (EMA/SMA/…), `indicators`,
+  `filters`, `roll_functions`, `scale`, `engineering`, `regime`,
+  `_metrics_helpers` (the Numba metric kernels), `money_management`.
+- **`metrics/`** — performance/evaluation metrics split by concern: `ratios`
+  (Sharpe/Sortino/Calmar/…), `drawdown`, `returns`, `summary` (one-call panel).
+- **`signal/` · `portfolio/`** — `sign`/`threshold`/`rank`/vol-target mappers +
+  `SignalPipeline`; `allocation.py` (ERC/HRP/IVP/MDP/MVP + `rolling_allocation()`,
+  stable public API) and `sizing.py`.
+- **`models/`** — econometric (`econometric_models.py`, Numba ARMA/GARCH) and
+  neural (`mlp`, `rnn`, `gru`, `lstm`, `attention`, `tcn`, `transformer`) on a
+  rolling/walk-forward base; `loss/` (torch losses), `training.py`, `ensemble.py`.
+- **`backtest/`** — vectorized `engine` + `cost` + `result`; the legacy live-viz
+  plot stack (`plot_backtest`/`dynamic_plot_backtest`/`backtest_neural_net`) is
+  kept for `RollMultiLayerPerceptron` but off the eager public surface.
+- **`plot/` · `strategy/`** — composable matplotlib figures + `tearsheet` (lazy
+  import); the optional `Strategy` orchestrator + `run_walk_forward`.
+- **`estimator/`** — Numba ARMA/GARCH parameter estimation. **Authoritative** —
+  parameter logic lives here / in `econometric_models`, not duplicated.
 
 ## Three cross-cutting patterns
 
-### 1. Cython / Python dual implementation (`features/`)
+### 1. Numba kernels with golden-value parity (`features/`, `models/`, `estimator/`)
 
-Each performance-critical kernel exists twice: a compiled `*_cy.pyx` (e.g.
-`momentums_cy`, `roll_functions_cy`, `metrics_cy`) and a thin Python wrapper that
-calls it (`momentums.py`, `roll_functions.py`, …). `features/__init__.py` imports
-both layers. `setup.py`'s `USE_CYTHON='auto'` guard compiles the `.pyx` if Cython
-is available, else falls back to pre-compiled `.c` files — **do not break this
-fallback**. Kernel correctness is cross-checked against independent NumPy
-references by the property tests (`tests/features/test_property.py`).
-
-> The metrics surface is now split across `returns.py`, `ratios.py`,
-> `drawdown.py`, `stats.py` + `_metrics_helpers.py`, with `metrics.py` kept as a
-> thin re-export aggregator (public API unchanged).
-
-> **Going forward**: new performance-critical code uses **Numba `@njit`** in the
-> Python file, *not* new Cython. The Cython twins are kept (extend-only), not
-> grown. See [`03-decisions.md`](03-decisions.md).
+Performance-critical kernels are private Numba `@njit` functions (e.g.
+`_ema`/`_sma` in `momentums`, the `_roll_*` kernels in `_metrics_helpers`, the
+`_arma`/`_arma_garch` kernels in `econometric_models`) wrapped by thin public
+functions. There is **no Cython** — the former `*_cy.pyx` twins were ported to
+Numba in 2.1 (E7) and the build is pure-Python. Each kernel is cross-checked
+against an independent NumPy reference *and* a golden value captured from the
+former Cython (1e-9/1e-10) by the property/parity tests
+(`tests/features/test_property.py`, the `*_parity` tests). New numeric code uses
+Numba `@njit`, not Cython. See [`03-decisions.md`](03-decisions.md).
 
 ### 2. Rolling / walk-forward (the causal core)
 
@@ -67,21 +70,22 @@ references by the property tests (`tests/features/test_property.py`).
 It is an **iterator**: `__call__` sets the window (`n` = train length, `s` = test
 length, `r` = roll step); each `__next__` trains on `X[t-n:t]` and predicts on
 `X[t:t+s]`. `RollMultiLayerPerceptron` subclasses it; `rolling_allocation()`
-(`algorithms/`) replicates the same shape as a decorator for portfolio methods.
+(`portfolio/`) replicates the same shape as a decorator for portfolio methods.
 
 This pattern is *the* lookahead guard: a window can only ever see its own past.
 Any new model or feature must preserve it.
 
 ### 3. Estimator → models pipeline
 
-`estimator/estimator_cy.pyx` estimates ARMA/GARCH parameters; `models/
-econometric_models.py` wraps it via `get_parameters()`. The Python layer never
-re-implements parameter estimation — the Cython estimator is the single source.
+`estimator/estimator.py` and `models/econometric_models.py` hold the Numba ARMA/
+GARCH kernels; `models` wraps them via `get_parameters()`. The wrapper layer never
+re-implements parameter estimation — the Numba kernels are the single source.
 
 ## ML backend
 
-PyTorch is the ML backend. Legacy Keras/TensorFlow code is being **retired, not
-extended**: new architectures (TCN, Transformer, custom losses) target PyTorch,
-with `nn.Module` models trained through the walk-forward base and financial loss
-functions (Sharpe/Sortino/directional) implemented as pure torch ops in
-`models/loss/`.
+PyTorch is the ML backend, confined to `models/`. TensorFlow/Keras is fully
+retired (none in the package). New architectures (TCN, Transformer, custom losses)
+target PyTorch, with `nn.Module` models trained through the walk-forward base and
+financial loss functions (Sharpe/Sortino/directional) implemented as pure torch
+ops in `models/loss/`. Every NN model conforms to the `SignalModel` protocol
+(`fit`/`predict`) so it composes with `strategy.Strategy`.

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -7,13 +7,14 @@ is the running, dated ADR log.
 
 ## Numerical core
 
-- **Cython for the existing hot paths, kept extend-only.** `features/` and
-  `estimator/` ship compiled `*_cy.pyx` kernels with pure-Python twins and a `.c`
-  fallback. They're fast and correct; we don't rewrite them.
-- **Numba `@njit` for *new* numerical code, not new Cython.** New kernels live in
-  the Python file alongside the existing implementation. Rationale: `@njit` gives
-  near-C speed without a compile step, a `.pyx`/`.c` pair to maintain, or breaking
-  the build fallback. New Cython is only acceptable when wrapping a C library.
+- **Numba `@njit` for all numerical kernels — no Cython.** The former `*_cy.pyx`
+  kernels (features `momentums`/`metrics`/`roll_functions`, the ARMA/GARCH
+  `estimator`/`econometric_models`) were ported to Numba `@njit` in the Python
+  modules (E7 / 2.1.0); the build is now pure-Python with no compile step.
+  Rationale: `@njit` gives near-C speed without a `.pyx`/`.c` pair to maintain or a
+  C toolchain to ship. New Cython is only acceptable when wrapping a C library.
+  See the dated ADR entry below — this tombstones the earlier "Cython extend-only"
+  decision.
 - **NumPy at the core; polars only at the I/O edges (pandas removed).** The
   linear-algebra-heavy core (allocation, rolling windows) is raw NumPy — fastest
   and the natural input for torch. Array-like *inputs* are accepted as
@@ -28,7 +29,7 @@ is the running, dated ADR log.
   training target `torch`.
 - **Loss functions: two independent paths (the "Option C" split).** Evaluation/
   backtest metrics (Sharpe/Sortino/…) stay as NumPy formulas in
-  `features/metrics.py`; the *training* losses are re-implemented as pure torch
+  `fynance.metrics`; the *training* losses are re-implemented as pure torch
   ops in `models/loss/`. The two paths never convert numpy↔torch — each is native
   to its context. Cost: the formula exists twice; benefit: no autograd-breaking
   conversions, no numpy in the training graph.
@@ -42,10 +43,10 @@ is the running, dated ADR log.
 
 ## Build & packaging
 
-- **`pyproject.toml` is the authoritative build config; `setup.py` only compiles
-  Cython.** Single static `version` in `pyproject.toml` (one source of truth for
-  `/release`). Wheels are built with `cibuildwheel` (manylinux) + an sdist, then
-  trusted-published to PyPI on a `v*` tag.
+- **`pyproject.toml` is the authoritative (pure-Python) build config; there is no
+  `setup.py` and no compile step.** Single static `version` in `pyproject.toml`
+  (one source of truth for `/release`). A pure-Python universal wheel
+  (`py3-none-any`) + an sdist are built and trusted-published to PyPI on a `v*` tag.
 
 ## Decision journal (ADR)
 
@@ -70,6 +71,24 @@ Template:
 ```
 
 <!-- new entries below, newest first -->
+
+### 2026-06-15 — All Cython ported to Numba; pure-Python build (E7 / 2.1.0)  [tombstone]
+- **Choice**: remove **all** Cython. The `*_cy.pyx`/`.c` kernels — features
+  `momentums`/`metrics`/`roll_functions` and the ARMA/GARCH `econometric_models`/
+  `estimator` — were ported to **Numba `@njit`** functions living in the `.py`
+  modules; `setup.py` and the whole compile step were deleted. The build is now
+  pure-Python and `release.yml` ships a single `py3-none-any` wheel (no
+  `cibuildwheel`/manylinux).
+- **Why**: one implementation per kernel instead of a `.pyx`/`.c`/Python triple;
+  no C toolchain to ship or maintain; `@njit` matches the former Cython speed.
+  Parity was captured as golden values from the compiled `.so` **before** deletion
+  and asserted to 1e-9/1e-10 — this strictness surfaced two real bugs
+  (`roll_annual_volatility` buffer aliasing, a missing `roll_annual_return` term).
+- **Tombstones**: the earlier "Cython for the existing hot paths, kept extend-only"
+  and "`setup.py` only compiles Cython / `cibuildwheel` manylinux wheels"
+  decisions — purged from the prose above.
+- **Rejected alternatives**: keeping the Cython twins (the maintenance/build cost
+  the port removes); a C-extension rewrite (no payoff over `@njit`).
 
 ### 2026-06-14 — Read the Docs is the canonical docs host (roadmap §3.1)  [accepted]
 - **Choice**: keep **Read the Docs** as the single documentation host. `.readthedocs.yaml`

--- a/doc/dev/04-subpackages.md
+++ b/doc/dev/04-subpackages.md
@@ -9,43 +9,55 @@ modernisation).
 
 | Subpackage | Policy | Why |
 |---|---|---|
-| `features` (`.py`, Numba kernels) | **Extend freely** — numerical kernels are Numba `@njit` | Fast, correct, depended on |
-| `algorithms.allocation` | **Stable public API** — deprecation path required for breaking changes | Users call ERC/HRP/IVP/MDP/MVP directly |
+| `core` | **Change with care** (wide blast radius) — `PriceSeries` + protocols | The seams everything composes through |
+| `data` | **Extend freely** — the only I/O layer (ports & adapters) | New sources/formats are additive |
+| `features` / `metrics` | **Extend freely** — numerical kernels are Numba `@njit` | Fast, correct, depended on |
+| `portfolio.allocation` | **Stable public API** — deprecation path required for breaking changes | Users call ERC/HRP/IVP/MDP/MVP directly |
 | `estimator` / `models.econometric_models` | **Single Numba implementation** — do not duplicate parameter logic | One source for ARMA/GARCH estimation |
-| `models` | **Modernise freely** (PyTorch) | The active R&D surface |
-| `backtest` | **Improve freely** | Plotting/eval, no external API contract |
-| `core` | Shared helpers — change with care (wide blast radius) | Used everywhere |
+| `signal` / `models` | **Modernise freely** (PyTorch) | The active R&D surface |
+| `backtest` / `plot` / `strategy` | **Improve freely** | Engine/reporting/orchestration, no frozen contract |
 
 ## Public API surface (what callers import)
 
-- **`features`** — `sharpe`, `sortino`, `calmar`, `drawdown`/`mdd`,
-  `roll_*` rolling variants, `z_score`, `accuracy`, momentums (EMA/SMA…),
-  filters, `scale`, `roll_functions`, `money_management`. Re-exported from
-  `features/__init__.py` (which pulls both the Python and `_cy` implementations).
-- **`algorithms`** — portfolio allocation (`ERC`, `HRP`, `IVP`, `MDP`, `MVP`,
-  `rolling_allocation()`) and position sizing (`sizing.py`: `kelly_fraction`,
-  `vol_target`, `transaction_cost`).
+- **`core`** — `PriceSeries`; the protocols (`DataSource`/`FeatureTransform`/
+  `SignalModel`/`Allocator`/`CostModel`/`Metric`).
+- **`data`** — `load()`, `CSVSource`/`ParquetSource`, `align`/`resample`,
+  `train_test_split`/`walk_forward`.
+- **`features`** — momentums (EMA/SMA/WMA…), indicators (RSI/MACD/Bollinger/…),
+  `filters`, `scale`, `engineering`, `regime`, `money_management`. Numba `@njit`
+  kernels live in the `.py` modules (no `_cy` twins).
+- **`metrics`** — `sharpe`, `sortino`, `calmar`, `diversified_ratio`,
+  `annual_return`/`annual_volatility`, `drawdown`/`mdd`, `perf_*`, `roll_*`
+  variants, plus one-call `summary`.
+- **`signal` / `portfolio`** — `sign`/`threshold`/`rank`/vol-target mappers +
+  `SignalPipeline`; allocation (`ERC`/`HRP`/`IVP`/`MDP`/`MVP`,
+  `rolling_allocation()`) and sizing (`kelly_fraction`/`vol_target`/
+  `transaction_cost`).
 - **`models`** — econometric (`ARMA`/`GARCH` family via `get_parameters`) and
   neural (`MultiLayerPerceptron`, `RollMultiLayerPerceptron`, RNN/`GRU`/`LSTM`,
   attention, `TemporalConvNet`, `Transformer`), `StackingEnsemble`; custom losses
   under `models/loss/` (Sharpe/Sortino/Calmar/Omega/directional/hybrid); training
   utils in `models/training.py`.
-- **`backtest`** — `BackTest`/plotting objects (`PlotBackTest`,
-  `DynaPlotBackTest`, …), `print_stats`.
+- **`backtest` / `plot` / `strategy`** — `backtest()` + `BacktestResult` +
+  `ProportionalCost`; `tearsheet`/`tearsheet_text`; `Strategy` +
+  `run_walk_forward`. (The legacy live-viz objects `PlotBackTest`/
+  `DynaPlotBackTest`/`display_perf` remain as lazy submodules, off the eager
+  surface.)
 
 ## Known sharp edges (by design)
 
-- **`features/metrics.py`** is a thin **re-export aggregator** — the
-  implementations live in `returns.py`, `ratios.py`, `drawdown.py`, `stats.py`
-  and `_metrics_helpers.py`. Import from `fynance.features` (or
-  `fynance.features.metrics`) as before; the split is transparent.
+- **Performance metrics live in `fynance.metrics`** (since 2.0), not
+  `fynance.features` — `ratios.py`/`drawdown.py`/`returns.py`/`summary.py`. The
+  Numba metric kernels are in `features/_metrics_helpers.py`; `mad`/`roll_mad`
+  are in `features/stats.py`.
 - **`estimator.estimation()`** is an experimental stub that raises
   `NotImplementedError` — use `models.econometric_models.get_parameters`
   (Numba-backed) for ARMA/GARCH estimation.
 - **`lstm.py`/`gru.py` internal hierarchies** (`_LSTMCell → LSTMCell →
   LongShortTermMemory`) and `_RollingBasis`/`RollMultiLayerPerceptron` are
   intentionally **not** split — too tightly coupled.
-- **Inputs** accept numpy / torch / **polars**; **outputs** are numpy (no pandas).
+- **numpy is the lingua franca** at every seam; PyTorch is confined to `models/`;
+  table inputs are coerced to numpy at the `data/` edge (no pandas in the core).
 
 > Open work lives in `07-roadmap.md`; this file only notes settled design points
 > so an agent doesn't mistake one for a bug.

--- a/doc/dev/05-testing.md
+++ b/doc/dev/05-testing.md
@@ -4,7 +4,7 @@
 
 | Layer | Command | Catches |
 |-------|---------|---------|
-| **Unit** | `pytest` | logic, shapes, regressions (~300 tests under `fynance/tests/`) |
+| **Unit** | `pytest` | logic, shapes, regressions (501 tests under `fynance/tests/`) |
 | **Doctests** | `pytest --doctest-modules` (on by default in `pyproject.toml`) | every docstring `>>>` example — they are part of the suite |
 | **Benchmarks** | `pytest-benchmark` (e.g. `test_filters_benchmark.py`) | perf regressions on hot paths |
 | **Coverage** | `pytest --cov=fynance --cov-report=term-missing` | untested branches |
@@ -42,5 +42,5 @@ GitHub Actions (`.github/workflows/ci.yml`) runs **four gates** on every PR:
 the test suite across the Python matrix (`test`), `ruff` + `interrogate`
 (docstring coverage ≥ 80%) in `lint`, a Sphinx build with warnings-as-errors
 (`docs`, `sphinx-build -W`), and `mypy` (`typecheck`, 0 errors). `release.yml`
-builds `cibuildwheel` manylinux wheels + sdist, publishes to PyPI, and creates
+builds a pure-Python universal wheel + sdist, publishes to PyPI, and creates
 the GitHub Release on a `v*` tag. Badges via `badges.yml`.

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -5,77 +5,96 @@ so an agent doesn't re-investigate settled ground or assume a known stub is a bu
 
 ## Done & working
 
-- **Stable numerical core**: `features` (metrics/momentums/filters/scale/roll) with
-  Cython kernels + Python wrappers; `algorithms.allocation` (ERC/HRP/IVP/MDP/MVP)
-  with a stable public API; `estimator` (Cython ARMA/GARCH).
-- **`features/metrics.py` split** by concern into `returns.py`, `ratios.py`,
-  `drawdown.py`, `stats.py` + `_metrics_helpers.py`; `metrics.py` kept as a thin
-  re-export aggregator (public API + import paths unchanged).
-- **Walk-forward base**: `_RollingBasis` iterator + `RollMultiLayerPerceptron` and
-  `rolling_allocation()` — the causal windowing used everywhere.
+- **Layered 2.x architecture** (data → features → signal → portfolio → backtest →
+  metrics) composed through `typing.Protocol` seams; numpy is the lingua franca,
+  PyTorch is confined to `models/`, every maillon is usable standalone and
+  `strategy.Strategy` is an optional orchestrator.
+- **Core**: `PriceSeries` (thin numpy-backed value object — composition, not
+  `ndarray` subclassing; price↔return identities, numpy/torch bridges, `.pipe`)
+  and the pipeline protocols (`DataSource`/`FeatureTransform`/`SignalModel`/
+  `Allocator`/`CostModel`/`Metric`).
+- **Data**: `load()` dispatcher + CSV/Parquet adapters, causal `align`/`resample`,
+  and no-lookahead `train_test_split`/`walk_forward` (embargo/purge).
+- **Features**: technical indicators (RSI/MACD/Bollinger/CCI/HMA/ROC/realized-vol/
+  skew/kurt/autocorr), momentums (SMA/EMA/WMA + std variants), scaling (z-score,
+  rolling rank), statistics, feature engineering (multi-resolution, Granger,
+  incremental moments) and k-means market-regime detection.
+- **Metrics**: `fynance.metrics` (Sharpe/Sortino/Calmar/diversified-ratio,
+  annual return/vol, drawdown/mdd, perf_*, roll_*) + one-call `summary`.
 - **Models**: econometric (ARMA/GARCH) + neural (MLP, RNN/GRU/LSTM, attention,
-  **TCN**, **Transformer**) on PyTorch; a **StackingEnsemble** (direction+magnitude
-  OOF meta-model); custom losses (Sharpe/Sortino/Calmar/Omega/directional/hybrid)
-  in `models/loss/`; robust-training utils (purged CV, early stopping, sample
-  weighting) in `models/training.py`.
-- **Data frames**: **polars** at the input edges (`set_data`, `MA`), **numpy** at
-  the output edges (`rolling_allocation`, `get_stats`); pandas removed.
-- **Backtest**: static + dynamic plotting (orchestrator `BacktestNeuralNet` split
-  into `backtest/backtest_neural_net.py`), perf/stat printing.
-- **Quality gates (all 4 enforced in CI)**: ~300 unit tests + doctests on every
-  module (`--doctest-modules`) incl. property tests (kernel parity + no-lookahead);
-  `ruff`; `interrogate` (docstring coverage ≥ 80%); Sphinx build `-W`; **`mypy`
-  clean (0 errors)**.
-- **Released**: `v1.3.4` on `master` + PyPI; `Production/Stable`. CI matrix
-  3.10–3.13; release builds manylinux wheels + sdist and creates the GitHub
-  Release from the CHANGELOG on tag.
+  TCN, Transformer) on PyTorch; `StackingEnsemble` (direction+magnitude OOF
+  meta-model); differentiable losses (Sharpe/Sortino/Calmar/Omega/directional/
+  hybrid) in `models/loss/`; robust-training utils (purged CV, early stopping,
+  sample weighting) in `models/training.py`. All NN models conform to
+  `SignalModel` (`fit`/`predict`).
+- **Signal / Portfolio**: `signal/` mappers (`sign`/`threshold`/`rank`/
+  vol-targeting + `SignalPipeline`); `portfolio/` allocation (ERC/HRP/IVP/MDP/MVP)
+  + sizing (fractional Kelly, vol-targeting, transaction costs).
+- **Backtest / Plot**: vectorized `backtest()` engine → `BacktestResult`,
+  `ProportionalCost`; reporting via `fynance.plot` (`tearsheet`, composable
+  figures, lazy matplotlib so `import fynance` stays matplotlib-free).
+- **Numerical kernels on Numba `@njit`** — no Cython anywhere; the build is
+  pure-Python (no `setup.py`, no compile step). Every kernel has a golden-value
+  parity test (1e-9/1e-10) captured from the former Cython.
+- **Quality gates (all 4 enforced in CI)**: 501 unit tests + doctests on every
+  module (`--doctest-modules`), incl. property tests (kernel parity + no-lookahead);
+  `ruff`; `interrogate` (docstring coverage ≥ 80%, currently ~93.6%); Sphinx
+  build `-W`; **`mypy` clean (0 errors)**.
+- **Released**: `v2.1.1` on `master` + PyPI; `Production/Stable`. CI matrix
+  3.10–3.13; release builds a pure-Python universal wheel + sdist and creates the
+  GitHub Release from the CHANGELOG on tag.
 
 ## In progress / active surface
 
-- **ML modernisation** (`models/`): Keras/TensorFlow fully retired (no TF/Keras in
-  the package); new architectures (TCN, Transformer) and custom multi-objective
-  losses are the active R&D axis. See the roadmap (§1, §5).
+- **R&D** (`models/`): empirical comparison of losses / architectures / feature
+  normalization on real out-of-sample data, market-regime conditioning, and
+  multi-series OHLCV indicators — see the roadmap (§1). Most items are blocked on
+  having a real dataset / orchestration rather than on missing code.
 
 ## Known gaps / sharp edges (by design or deferred)
 
 - **`estimator.estimation()`** is an explicit experimental stub: it raises
   `NotImplementedError` and points to `models.econometric_models.get_parameters`
-  (the Cython-backed authoritative path).
-- **Notebooks** (`Notebooks/`) still carry Keras examples — to be rewritten in
-  PyTorch (roadmap §3.2).
+  (the Numba-backed authoritative path).
+- **Legacy `backtest` plot stack** (`PlotBackTest`/`DynaPlotBackTest`/
+  `display_perf`) still powers `RollMultiLayerPerceptron` live-training viz; it is
+  off the eager public surface (lazy-imported submodules) and conceptually
+  superseded by `fynance.plot` — a candidate for retirement onto `fynance.plot`.
+- **Notebooks** (`Notebooks/`): `quickstart_v2.ipynb` is the current tour; older
+  Keras-era notebooks may remain and are not maintained.
 - **`# type: ignore`** markers exist for genuinely-unmodellable cases (torch
-  multiple-inheritance mixins, decorator-filled `w`, star-imported Cython names);
-  `warn_return_any` is off (numpy/Cython return `Any` pervasively).
+  multiple-inheritance mixins, decorator-filled `w`); `warn_return_any` is off
+  (numpy returns `Any` pervasively).
 
 ## Tooling & process
 
 - **Dev loop**: tooled by user-level skills (`/pick-task → /plan → /execute-leaf
   → /finish-task → /release`, plus `/abandon-task`, `/groom-docs`). Docs of record
   wired in `.claude/workflow.json` (`roadmap`/`decisions`/`status`/`plans_dir`).
-- **Tracked docs**: the full descriptive pack `01–07` (including the roadmap),
-  `README.md`, `plans/README.md` and `CLAUDE.md` are tracked, mirroring dccd. Only
-  the plan trees (`doc/dev/plans/<epic>/`), any `_archive` snapshot and the Claude
-  harness settings (`.claude/`) stay local.
+- **Tracked docs**: the descriptive pack `01–07` (including the roadmap),
+  `README.md`, `plans/README.md` and `CLAUDE.md` are tracked. Only the plan trees
+  (`doc/dev/plans/<epic>/`), any `_archive` snapshot and the Claude harness
+  settings (`.claude/`) stay local.
 - **Git Flow**: `master`/`develop` + `feat/fix/chore/docs` branches, one PR per
   concern (see `CLAUDE.md`).
 
 ## Deferred
 
-Larger axes parked for later: realistic backtesting (transaction costs, position
-sizing), market-regime conditioning, multi-resolution features, and the
-docs-hosting decision. Tracked in the roadmap; not bugs.
+Larger axes parked for later: realistic backtesting beyond proportional cost
+(non-linear slippage / market impact), market-regime conditioning of the
+architecture, adaptive windows, and multi-series OHLCV indicators (ATR/ADX/OBV/
+VWAP) requiring a multi-series input API. Tracked in the roadmap; not bugs.
 
-## 2026-06-15 — fynance 2.0 refactor: 9/10 epics shipped
+## 2026-06-16 — fynance 2.1.x shipped; post-release audit clean
 
-The 2.0 architecture is **complete and releasable**. Shipped on `develop` (PRs
-#99–#108): E1 core (`PriceSeries`, protocols), E2 data (adapters, splits), E3
-metrics extraction, E4 vectorized backtest engine, E5 reporting (`tearsheet`),
-E6 signal + portfolio rename, E8 `Strategy`, E9 Streamlit playground, E10 docs
-(Sphinx, notebook, README, `MIGRATION-2.0.md`). Top-level API re-exports all
-maillons. 462 tests, 4 CI gates green per PR.
-
-**Remaining**: E7 (Cython→numba: estimator/econometric port, drop Cython build,
-`SignalModel` conformance). Deliberately deferred — correctness-critical
-numerical port (best done with golden-value parity), non-blocking for v2.0.0.
-Decision pending: do E7 before the release, or cut **v2.0.0** now and land numba
-in 2.1.
+The full 2.0 + 2.1 refactor is **complete and released**: 2.0 (E1–E10 — layered
+architecture, `PriceSeries`, protocols, data adapters, metrics extraction,
+vectorized backtest, `tearsheet`, signal/portfolio, `Strategy`, Streamlit
+playground, Sphinx/notebook/README/migration docs), 2.1.0 (E7 — all Cython ported
+to Numba, pure-Python build, `SignalModel` conformance), 2.1.1 (O(n) rolling
+extrema perf pass + allocation cleanup). A full object-by-object audit (501 tests,
+4 gates green) found one real correctness bug — `ARMAX_GARCH` swapped its `psi`/
+`theta` coefficients (long-standing, preserved verbatim through the Cython→Numba
+port) — plus minor dead code, a leftover debug print, and eager matplotlib import.
+All fixed on `develop`. Remaining open work is the empirical R&D (§1), blocked on
+data rather than code.

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -12,53 +12,35 @@ shipped, `03-decisions.md` for *why*. Keep it short and true.
 > Loop : `/pick-task` → `/plan` (arbre dans `plans/`) → `/execute-leaf` →
 > `/finish-task`. Release : `/release` quand `[Unreleased]` est suffisamment rempli.
 
----
-
-
-## 1. fynance 2.0 — full refactor  ⭐ active
-
-Turn the toolbox into a complete layered ML/DL backtesting tool
-(data→features→signal→portfolio→backtest→metrics). Breaking 2.0, no compat.
-**Detailed plan tree:** `doc/dev/plans/v2-refactor/` (global `00-plan.md` +
-per-epic `EN-*/00-plan.md` + per-task leaves). Ships epic-by-epic, leaf = 1 PR.
-
-- [x] **E1 core** — `PriceSeries`, Protocol seams, numpy/torch bridges
-- [x] **E2 data** — DataSource port, CSV/Parquet adapters, align, temporal splits
-- [x] **E3 features+metrics** — regroup features, extract perf-metrics → `metrics/`
-- [x] **E4 backtest** — CostModel + vectorized engine → `BacktestResult`
-- [x] **E5 reporting** — metrics consolidation, `plot/`, `tearsheet()`
-- [x] **E6 signal+portfolio** — `signal/` mappers, `portfolio/` (ex-algorithms)
-- [x] **E7 models+numba** — estimator+features Cython→numba, Cython build dropped, SignalModel conformance (2.1)
-- [x] **E8 strategy** — optional orchestrator + walk-forward run
-- [x] **E9 ui** — optional Streamlit playground (deferrable to 2.1)
-- [x] **E10 docs** — Sphinx restructure, example notebook, README + migration guide
-
-Order: E1 → (E2 ∥ E3 ∥ E6 ∥ E7) → E4 → E5 → E8 → (E9 ∥ E10).
+> **fynance 2.0 + 2.1 livrés** (v2.1.1 sur `master`/PyPI). Le refactor en couches,
+> le port Cython→Numba (build pure-Python) et la passe perf sont terminés — voir
+> `CHANGELOG.md` / `03-decisions.md`. Reste l'axe R&D ci-dessous, majoritairement
+> bloqué sur la disponibilité de données réelles plutôt que sur du code manquant.
 
 ---
 
-## 5. R&D — Loss, architecture, données
+## 1. R&D — Loss, architecture, données
 
 Objectif : identifier empiriquement la meilleure combinaison loss / architecture / features
 pour les séries temporelles financières. Chaque sous-tâche est exploratoire :
 elle peut déboucher sur du code dans `fynance/models/` ou rester à l'état de
 notebook/rapport.
 
-### 5.1 Nouvelles loss functions
+### 1.1 Nouvelles loss functions
 
 Fait (PR #88) : `CalmarLoss`, `OmegaLoss`, `HybridLoss` (α fixe ou learnable).
 
 - [ ] 🟡 **Benchmark empirique** : comparer les loss sur un jeu de données réel
   (out-of-sample Sharpe/Sortino/Calmar/accuracy/drawdown) — nécessite des données.
 
-### 5.2 Architecture : ensemble direction + magnitude avec meta-modèle
+### 1.2 Architecture : ensemble direction + magnitude avec meta-modèle
 
 Fait (PR #93) : `StackingEnsemble` — bases direction/magnitude + méta-modèle
 entraîné sur les prédictions **out-of-fold** (leak-free).
 
 - [ ] 🟡 Comparer empiriquement vs modèle unique `SharpeLoss` (besoin de données).
 
-### 5.3 Régimes de marché
+### 1.3 Régimes de marché
 
 Fait (PR #92) : `detect_regimes` (k-means in-sample sur vol/return, labels
 ordonnés par vol). Reste 🟡 (besoin de données / orchestration) :
@@ -66,7 +48,7 @@ ordonnés par vol). Reste 🟡 (besoin de données / orchestration) :
 - [ ] Conditionner l'architecture (mixture-of-experts / embedding de régime).
 - [ ] Assignation online causale + évaluer l'impact sur le Sharpe out-of-sample.
 
-### 5.4 Features / indicateurs techniques
+### 1.4 Features / indicateurs techniques
 
 Fait (single-série, causaux) : `roc`, `realized_volatility`, `rolling_skewness`,
 `rolling_kurtosis`, `rolling_autocorr` (PR #86) ; déjà présents : EMA/MACD/RSI/
@@ -76,7 +58,7 @@ Bollinger/CCI/HMA. Reste **différé** (nécessite une API multi-séries OHLCV) 
   des entrées OHLCV ; concevoir une API multi-séries d'abord.
 - [ ] **GARCH(1,1) comme feature** (via `fynance.estimator`).
 
-### 5.5 Normalisation des features
+### 1.5 Normalisation des features
 
 Couvert : rolling z-score (`roll_standardize`/`roll_z_score`), vol-targeting
 (`sizing.vol_target`), rank-based (`scale.roll_rank`, PR #89).
@@ -84,7 +66,7 @@ Couvert : rolling z-score (`roll_standardize`/`roll_z_score`), vol-targeting
 - [ ] 🟡 Comparer empiriquement les trois approches sur le Sharpe out-of-sample
   (nécessite des données).
 
-### 5.6 Protocole d'entraînement robuste
+### 1.6 Protocole d'entraînement robuste
 
 Fait (PR #90) : purged walk-forward CV (`cross_validate(..., purge=)`),
 `exp_sample_weights` (décroissance exponentielle), `EarlyStopping` (sur métrique).
@@ -93,17 +75,17 @@ La construction causale des features reste garantie par les property tests
 
 - [ ] (optionnel) down-weight basse vol dans `exp_sample_weights` (variante).
 
-### 5.7 R&D rolling — features multi-résolution et efficacité
+### 1.7 R&D rolling — features multi-résolution et efficacité
 
 Fait (PR #91) : `multi_resolution`, `granger_causality`, `IncrementalMoments`
 (Welford O(1)) dans `features/engineering.py`.
 
 - [ ] **Fenêtres adaptatives** : `window` variable selon le régime de vol
-  (dépend de §5.3 détection de régime).
+  (dépend de §1.3 détection de régime).
 
-### 5.8 Backtest réaliste
+### 1.8 Backtest réaliste
 
-Fait (PR #87) : `algorithms/sizing.py` (`kelly_fraction`, causal `vol_target`,
+Fait (PR #87) : `portfolio/sizing.py` (`kelly_fraction`, causal `vol_target`,
 `transaction_cost` turnover-based) ; métriques `percent_positive`, `tail_ratio`.
 Reste optionnel :
 

--- a/doc/dev/README.md
+++ b/doc/dev/README.md
@@ -17,7 +17,7 @@ live in the repo-root `CLAUDE.md`.
 1. [`01-overview.md`](01-overview.md) — what fynance is, the current state, the
    repo map, the subpackages.
 2. [`02-architecture.md`](02-architecture.md) — the package layout, the
-   Cython/Python dual implementation, the rolling/walk-forward pattern, the
+   Numba kernels (golden-value parity), the rolling/walk-forward pattern, the
    estimator→models pipeline.
 3. [`03-decisions.md`](03-decisions.md) — the design choices and *why* (Numba over
    new Cython, PyTorch over Keras, the loss-function split, NumPy over polars),
@@ -34,9 +34,9 @@ live in the repo-root `CLAUDE.md`.
 - [`plans/`](plans/) — **active plan trees** (durable, hierarchical task plans).
   Each roadmap item being worked on expands into a `plans/<epic>/` tree of a
   global map + precise leaf specs that drive `/plan` → `/execute-leaf` →
-  `/finish-task`. See [`plans/README.md`](plans/README.md). **The trees and the
-  roadmap (`07-roadmap.md`) are gitignored** (kept local — R&D / strategy stays
-  private); only this format reference and the descriptive docs above are tracked.
+  `/finish-task`. See [`plans/README.md`](plans/README.md). **The plan trees are
+  gitignored** (kept local — R&D / strategy stays private); the descriptive docs
+  above, the roadmap (`07-roadmap.md`) and `plans/README.md` are tracked.
 
 ## Conventions for keeping this current
 

--- a/doc/source/estimator.rst
+++ b/doc/source/estimator.rst
@@ -2,8 +2,8 @@
  Estimator (:mod:`fynance.estimator`)
 --------------------------------------
 
-Internal Cython module implementing ARMA / GARCH parameter estimation
-via maximum likelihood.
+Internal Numba-accelerated module implementing ARMA / GARCH parameter
+estimation via maximum likelihood.
 
 .. note::
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -26,9 +26,9 @@
      <a href="https://pepy.tech/project/fynance"><img src="https://pepy.tech/badge/fynance" alt="Downloads"></a>
    </div>
 
-**Fynance** is a Python and Cython package providing **machine learning**,
-**econometric** and **statistical** tools for **financial analysis** and
-**backtesting of trading strategies**.
+**Fynance** is a pure-Python package (Numba-accelerated kernels) providing
+**machine learning**, **econometric** and **statistical** tools for
+**financial analysis** and **backtesting of trading strategies**.
 
 .. code-block:: bash
 
@@ -39,24 +39,24 @@
    :margin: 0
    :padding: 0
 
-   .. grid-item-card:: :octicon:`goal;1.2em;sd-mr-1` Algorithms
+   .. grid-item-card:: :octicon:`goal;1.2em;sd-mr-1` Portfolio
       :link: portfolio
       :link-type: doc
 
-      Portfolio allocation (ERC, HRP, IVP, MDP, MVP) and rolling
-      walk-forward wrappers.
+      Portfolio allocation (ERC, HRP, IVP, MDP, MVP), position sizing and
+      rolling walk-forward wrappers.
 
    .. grid-item-card:: :octicon:`rocket;1.2em;sd-mr-1` Backtest
       :link: backtest
       :link-type: doc
 
-      Profit-and-loss plotting and performance measurement.
+      Vectorized backtesting engine, cost models and performance reporting.
 
    .. grid-item-card:: :octicon:`pulse;1.2em;sd-mr-1` Estimator
       :link: estimator
       :link-type: doc
 
-      Cython ARMA / GARCH parameter estimation.
+      Numba-accelerated ARMA / GARCH parameter estimation.
 
    .. grid-item-card:: :octicon:`stack;1.2em;sd-mr-1` Features
       :link: features
@@ -70,7 +70,7 @@
       :link-type: doc
 
       Econometric models, neural networks (MLP, RNN, GRU, LSTM,
-      attention) and walk-forward training.
+      attention, TCN, Transformer) and walk-forward training.
 
 .. toctree::
    :hidden:

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -5,10 +5,11 @@ Installation
 Requirements
 ------------
 
-- Python **3.8** or later
-- NumPy, SciPy, PyTorch (installed automatically via pip)
-- A C compiler and Cython are needed only when building from source
-  (pre-compiled binaries are bundled in the PyPI wheel)
+- Python **3.10** or later
+- NumPy, SciPy, Numba, PyTorch (installed automatically via pip)
+
+The package is **pure-Python** — there is no compile step. The numerical
+kernels are Numba ``@njit`` functions, JIT-compiled on first call.
 
 Install with pip
 ----------------
@@ -25,10 +26,6 @@ Install from source
    git clone https://github.com/ArthurBernard/Fynance.git
    cd Fynance
    pip install -e ".[dev]"
-   python setup.py build_ext --inplace
-
-The ``build_ext`` step compiles the Cython extensions (``estimator``,
-``features``). It must be re-run after editing any ``.pyx`` file.
 
 Verify the installation
 -----------------------


### PR DESCRIPTION
The README, Sphinx pages (`doc/source/`) and the Claude-oriented dev brief (`doc/dev/`) still described the **pre-2.0** toolbox — "Python and Cython package", `setup.py build_ext`, `algorithms/`, `*_cy.pyx` twins, `v1.3.4`, ~300 tests, manylinux wheels. This brings them in line with the released **2.1.x** reality (pure-Python / Numba, layered architecture).

### What changed
- **README / Sphinx** (`index.rst`, `installation.rst`, `estimator.rst`): pure-Python (Numba) wording, drop the compile step, fix install instructions, Python 3.10+, refresh the landing cards (Portfolio, vectorized Backtest, TCN/Transformer).
- **doc/dev 01/02/04**: rewrite overview, architecture and the subpackage map to the layered 2.x (`core`/`data`/…/`strategy`), Numba kernels with golden-value parity, numpy as the lingua franca; fix the policy matrix and public-API surface.
- **doc/dev 03 (ADR)**: tombstone the "Cython extend-only" + `setup.py`/`cibuildwheel` prose and add the dated **E7 Cython→Numba** journal entry.
- **doc/dev 05/06**: 501 tests, pure-Python wheel; full status rewrite.
- **doc/dev 07 (roadmap)**: drop the fully-shipped fynance 2.0 section (per the roadmap's own "done = removed" rule); keep the open R&D axis (renumbered to §1).
- **doc/dev README**: correct the tracking note — only the plan trees are gitignored, the roadmap is tracked.

Polars references were verified as **current** (still a dependency, used by the data adapters) and left in place.

### Test plan
- `cd doc && make html SPHINXOPTS="-W --keep-going"` → build succeeded (exit 0).
- Docs-only change; no code touched.