### PR TITLE
chore: release v2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [2.1.2] - 2026-06-16
+
+### Breaking Changes
+
+### Added
+
+### Changed
+
 - `import fynance` no longer eagerly imports matplotlib/seaborn (lazy in the rolling-NN live-viz path); the legacy `backtest` plot objects (`PlotBackTest`/`DynaPlotBackTest`/`display_perf`) are no longer on the eager public surface (still importable as submodules). Plotting/reporting is `fynance.plot`.
+- Documentation and packaging metadata refreshed for the pure-Python (Numba) 2.x reality: dropped the stale `Cython` PyPI classifier and "Python and Cython" project description, fixed the install instructions (no compile step), and rewrote the developer brief / Sphinx pages to the layered architecture.
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fynance"
-version = "2.1.1"
-description = "Python and Cython scripts of machine learning, econometrics and statistical features for financial analysis"
+version = "2.1.2"
+description = "Pure-Python (Numba-accelerated) machine learning, econometrics and statistical tools for financial analysis and backtesting"
 readme = "README.md"
 license = { text = "MIT" }
 authors = [{ name = "Arthur Bernard", email = "arthur.bernard.92@gmail.com" }]
@@ -17,7 +17,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python",
-    "Programming Language :: Cython",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -95,7 +94,7 @@ ignore = ["E501"]
 [tool.ruff.lint.per-file-ignores]
 "fynance/**/__init__.py" = ["F401", "F403", "F405"]
 "fynance/__init__.py" = ["F401", "F403", "F405"]
-# Dual Cython/Python files use star imports to pull Cython symbols
+# Aggregator modules use star imports to re-export their split kernels
 "fynance/metrics/returns.py" = ["F403", "F405"]
 "fynance/metrics/ratios.py" = ["F403", "F405"]
 "fynance/metrics/drawdown.py" = ["F403", "F405"]
@@ -109,7 +108,7 @@ ignore = ["E501"]
 [tool.mypy]
 python_version = "3.10"
 ignore_missing_imports = true
-# numpy / Cython kernels pervasively return Any; we still declare
+# numpy / Numba kernels pervasively return Any; we still declare
 # concrete return annotations but don't fail the build on their Any-returns
 warn_return_any = false
 warn_unused_configs = true


### PR DESCRIPTION
Freezes `[Unreleased]` → `[2.1.2]` and bumps the version. This patch ships the post-2.1.1 audit fixes plus the docs/metadata cleanup.

## [2.1.2]

### Changed
- `import fynance` no longer eagerly imports matplotlib/seaborn (lazy in the rolling-NN live-viz path); the legacy `backtest` plot objects (`PlotBackTest`/`DynaPlotBackTest`/`display_perf`) are off the eager public surface (still importable as submodules). Plotting/reporting is `fynance.plot`.
- Documentation and packaging metadata refreshed for the pure-Python (Numba) 2.x reality: dropped the stale `Cython` PyPI classifier and "Python and Cython" project description, fixed the install instructions (no compile step), and rewrote the developer brief / Sphinx pages to the layered architecture.

### Fixed
- `ARMAX_GARCH`: the external-regressor coefficients (`psi`) and MA coefficients (`theta`) were swapped between the public wrapper and the kernel, so `psi` was applied to past residuals instead of the exogenous regressor `x` (a long-standing bug, preserved verbatim through the Cython→numba port). Fixed; `ARMA_GARCH` was unaffected.

### Removed
- Dead private helpers `_roll_annual_return_py` / `_roll_annual_volatility_py` from `fynance.features._metrics_helpers`.

## Test plan
- CI green on `develop` (501 tests across 3.10–3.13, ruff, mypy, Sphinx `-W`).
- Version sources agree: `pyproject.toml` → `2.1.2`.