### PR TITLE
chore: release v2.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [2.1.3] - 2026-06-16
+
+### Breaking Changes
+
+### Added
+
+### Changed
+
 - Removed the last stale Cython references from the user-facing surface (package docstring, `estimator`/`econometric_models` docstrings, the API-stability policy now reads "2.x"). Internal parity-test docstrings keep accurate "former Cython" provenance notes.
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fynance"
-version = "2.1.2"
+version = "2.1.3"
 description = "Pure-Python (Numba-accelerated) machine learning, econometrics and statistical tools for financial analysis and backtesting"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Patch release carrying the Read the Docs fix to `master` (RTD `latest` builds from the default branch, `master`, so the live docs only refresh once the config fix lands there).

## [2.1.3]

### Changed
- Removed the last stale Cython references from the user-facing surface (package docstring, `estimator`/`econometric_models` docstrings, API-stability policy → "2.x"). Internal parity-test docstrings keep accurate "former Cython" provenance.

### Fixed
- Read the Docs builds were failing since v2.1.0 — `.readthedocs.yaml` still ran `python setup.py build_ext` (no `setup.py` in the pure-Python build), so the hosted docs were stuck on a pre-2.0 render. Dropped the obsolete step; RTD now builds the current docs.

## Test plan
- CI green on develop (501 tests, ruff, mypy, Sphinx -W).
- `pyproject.toml` → 2.1.3.