### PR TITLE
Release v2.1.3

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,27 +1,38 @@
 #!/usr/bin/env bash
-# Enforces Git Flow branch protection.
+# Git Flow reminder (non-blocking).
 # Install: git config core.hooksPath .githooks
+#
+# Reads the refs actually being pushed from stdin (the pre-push protocol:
+# "<local ref> <local sha> <remote ref> <remote sha>"), so it never interferes
+# with tag pushes (e.g. release tags `vX.Y.Z`) — only branch pushes are checked,
+# and only with a warning. The real protection for `master` is GitHub branch
+# protection server-side; this hook is just a local nudge toward the PR flow.
 
-current_branch=$(git symbolic-ref HEAD 2>/dev/null | sed 's|refs/heads/||')
+z40=0000000000000000000000000000000000000000
 
-# Hard block: never push directly to master
-if [ "$current_branch" = "master" ]; then
-    echo ""
-    echo "ERROR: Direct push to 'master' is not allowed."
-    echo "       Open a Pull Request from 'develop' -> 'master'."
-    echo "       See CONTRIBUTING.md for the full Git Flow."
-    echo ""
-    exit 1
-fi
+while read -r local_ref local_sha remote_ref remote_sha; do
+    # Only nudge on branch pushes; skip tags, notes, deletions, etc.
+    case "$remote_ref" in
+        refs/heads/*) ;;
+        *) continue ;;
+    esac
+    [ "$local_sha" = "$z40" ] && continue
 
-# Soft warning: develop should receive PRs, not direct commits
-if [ "$current_branch" = "develop" ]; then
-    echo ""
-    echo "WARNING: You are pushing directly to 'develop'."
-    echo "         Prefer a feat/ branch and a PR, except for merges or initial setup."
-    echo "         (push allowed -- press Ctrl+C within 5s to cancel)"
-    echo ""
-    sleep 5
-fi
+    branch=${remote_ref#refs/heads/}
+    case "$branch" in
+        master)
+            echo ""
+            echo "WARNING: pushing directly to 'master'."
+            echo "         The Git Flow is develop -> master via a release PR (see CONTRIBUTING.md)."
+            echo ""
+            ;;
+        develop)
+            echo ""
+            echo "WARNING: pushing directly to 'develop'."
+            echo "         Prefer a feat/fix/chore/docs branch + PR (see CONTRIBUTING.md)."
+            echo ""
+            ;;
+    esac
+done
 
 exit 0

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,9 +4,6 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.12"
-  jobs:
-    post_install:
-      - python setup.py build_ext --inplace
 
 python:
   install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [2.1.3] - 2026-06-16
+
+### Breaking Changes
+
+### Added
+
+### Changed
+
 - Removed the last stale Cython references from the user-facing surface (package docstring, `estimator`/`econometric_models` docstrings, the API-stability policy now reads "2.x"). Internal parity-test docstrings keep accurate "former Cython" provenance notes.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Removed the last stale Cython references from the user-facing surface (package docstring, `estimator`/`econometric_models` docstrings, the API-stability policy now reads "2.x"). Internal parity-test docstrings keep accurate "former Cython" provenance notes.
+
 ### Fixed
+
+- Read the Docs builds were failing since v2.1.0 — `.readthedocs.yaml` still ran `python setup.py build_ext` (no `setup.py` in the pure-Python build), so the hosted docs were stuck on a pre-2.0 render. Dropped the obsolete build step; RTD now builds the current docs.
 
 ### Deprecated
 

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -72,6 +72,21 @@ Template:
 
 <!-- new entries below, newest first -->
 
+### 2026-06-16 — Fix RTD build + remove the GitHub Pages docs workflow (PR #131)  [accepted]
+- **Choice**: drop the `post_install: python setup.py build_ext --inplace` job
+  from `.readthedocs.yaml`, and delete the master-only `.github/workflows/docs.yml`
+  (Sphinx build + GitHub Pages deploy). Read the Docs remains the single docs host;
+  the required CI `Docs (Sphinx, -W)` gate in `ci.yml` validates the build.
+- **Why**: both still ran `setup.py build_ext`, which has not existed since v2.1.0
+  (pure-Python/Numba) — so **RTD builds and the master Pages workflow had been
+  failing on every build/push**. `docs.yml` also contradicted the RTD-canonical
+  decision below.
+- **Corrects** the 2026-06-14 entry: `.readthedocs.yaml` no longer "compiles the
+  Cython ext", and a GitHub Pages deploy workflow *did* exist (master-only) and is
+  now removed.
+- **Note**: per-version (per-tag) docs are an RTD **dashboard** setting (Admin →
+  Versions / Automation Rules), not something the repo config controls.
+
 ### 2026-06-15 — All Cython ported to Numba; pure-Python build (E7 / 2.1.0)  [tombstone]
 - **Choice**: remove **all** Cython. The `*_cy.pyx`/`.c` kernels — features
   `momentums`/`metrics`/`roll_functions` and the ARMA/GARCH `econometric_models`/

--- a/fynance/__init__.py
+++ b/fynance/__init__.py
@@ -15,15 +15,15 @@ https://fynance.readthedocs.io/en/latest/index.html.
 
 Contents
 --------
-Fynance is a python/cython project that includes several machine learning,
-econometric and statistical subpackages specialy adapted for financial
-analysis, portfolio allocation, and backtest trading strategies.
+Fynance is a pure-Python (Numba-accelerated) project that includes several
+machine learning, econometric and statistical subpackages specially adapted
+for financial analysis, portfolio allocation, and backtest trading strategies.
 
 Subpackages
 -----------
 portfolio       --- Portfolio allocation & sizing
 backtest        --- Backtest strategy tools
-estimator       --- Parameter estimation (Cython ARMA/GARCH)
+estimator       --- Parameter estimation (Numba ARMA/GARCH)
 features        --- Features extraction
 models          --- Econometric and Neural Network models (using PyTorch)
 
@@ -33,12 +33,12 @@ _exceptions --- Fynance exceptions
 tests       --- Run fynance unittests
 _wrappers   --- Fynance wrapper functions
 
-API stability policy (1.x series)
+API stability policy (2.x series)
 ---------------------------------
 The symbols re-exported below from :mod:`fynance.models`,
-:mod:`fynance.portfolio.allocation`, :mod:`fynance.features` and
-:mod:`fynance.estimator` form the **public, stable API** for the 1.x
-release line. Within 1.x:
+:mod:`fynance.portfolio.allocation`, :mod:`fynance.features`,
+:mod:`fynance.metrics` and :mod:`fynance.estimator` form the **public,
+stable API** for the 2.x release line. Within 2.x:
 
 - public function and class signatures are frozen — no removals, no
   backward-incompatible signature changes;
@@ -48,7 +48,7 @@ release line. Within 1.x:
 - :mod:`fynance.backtest` and :mod:`fynance.models` *internal* helpers
   (names prefixed with ``_``) remain free to evolve.
 
-Breaking changes are reserved for the 2.x line and tracked in
+Breaking changes are reserved for the next major line and tracked in
 ``CHANGELOG.md``.
 
 """

--- a/fynance/_wrappers.py
+++ b/fynance/_wrappers.py
@@ -32,8 +32,8 @@ def _check_dtype(X, dtype):
 def wrap_dtype(func):
     """ Check the dtype of the `X` array.
 
-    Convert dtype of X to np.float64 before to pass to cython function and
-    convert to specified dtype at the end.
+    Convert dtype of X to np.float64 before passing it to the numba kernel and
+    convert to the specified dtype at the end.
 
     """
     @wraps(func)

--- a/fynance/estimator/estimator.py
+++ b/fynance/estimator/estimator.py
@@ -31,7 +31,7 @@ def estimation(y, x0, p=0, q=0, Q=0, P=0, cons=True, model='arch'):
        driver never reached a working optimiser. It is kept as a placeholder
        only; calling it raises :class:`NotImplementedError`.
 
-       For ARMA/GARCH parameter estimation use the Cython-backed path exposed
+       For ARMA/GARCH parameter estimation use the Numba-backed path exposed
        through :func:`fynance.models.econometric_models.get_parameters`, which
        is the authoritative implementation (the Python layer must not duplicate
        it — see the estimator stability policy).
@@ -45,7 +45,7 @@ def estimation(y, x0, p=0, q=0, Q=0, P=0, cons=True, model='arch'):
     raise NotImplementedError(
         "fynance.estimator.estimation is experimental and not implemented; "
         "use fynance.models.econometric_models.get_parameters for ARMA/GARCH "
-        "parameter estimation (the Cython-backed, authoritative path)."
+        "parameter estimation (the Numba-backed, authoritative path)."
     )
 
 
@@ -74,10 +74,10 @@ def target_function(params, y, p=0, q=0, Q=0, P=0, cons=True, model='arch'):
 
 
 def _loglikelihood(u, h):
-    """ Normal log-likelihood (matches the former Cython ``loglikelihood_cy``).
+    """ Normal log-likelihood.
 
     Adds a 1e-8 floor to every conditional variance term (not only zeros), as
-    the Cython implementation did; used internally by :func:`target_function`.
+    the original kernel did; used internally by :func:`target_function`.
     """
     h2 = np.square(h) + 1e-8
     L = u.size * np.log(2 * np.pi) + np.sum(np.log(h2)) + np.sum(np.square(u) / h2)

--- a/fynance/features/__init__.py
+++ b/fynance/features/__init__.py
@@ -24,8 +24,7 @@ features.
 
 """
 
-# Cython imports
-# Python imports
+# Submodule imports
 from . import (
     engineering,
     filters,

--- a/fynance/features/_metrics_helpers.py
+++ b/fynance/features/_metrics_helpers.py
@@ -82,7 +82,7 @@ def _roll_drawdown_2d(X, w, raw):
 
 @njit(cache=True)
 def _roll_mdd_1d(X, w, raw):
-    # First w points: expanding drawdown, running max of it (== Cython).
+    # First w points: expanding drawdown, running max of it (parity reference).
     T = X.shape[0]
     mdd = np.empty(T, dtype=np.float64)
     S = 0.0

--- a/fynance/models/econometric_models.py
+++ b/fynance/models/econometric_models.py
@@ -10,7 +10,7 @@
 
 Pure-NumPy implementations of moving-average, autoregressive and
 GARCH-family processes used to simulate or fit return series. Parameter
-estimation is delegated to the Cython routines in
+estimation is delegated to the Numba routines in
 :mod:`fynance.estimator` via :func:`get_parameters`, a single
 maximum-likelihood entry point for all four model types.
 

--- a/fynance/tests/estimator/test_estimator.py
+++ b/fynance/tests/estimator/test_estimator.py
@@ -13,7 +13,7 @@ from fynance.estimator.estimator import estimation, loglikelihood
 
 def test_estimation_raises_not_implemented():
     # estimation() is an experimental, non-functional placeholder; it must
-    # fail loudly and point to the Cython-backed path instead of returning
+    # fail loudly and point to the Numba-backed path instead of returning
     # silently wrong estimates.
     y = np.array([0.1, -0.2, 0.3, 0.0, -0.1])
     with pytest.raises(NotImplementedError, match="get_parameters"):

--- a/fynance/tests/features/test_property.py
+++ b/fynance/tests/features/test_property.py
@@ -5,10 +5,9 @@
 
 Two invariants that the per-function unit tests do not check directly:
 
-1. **Reference parity** — each Cython-backed kernel matches an independent,
+1. **Reference parity** — each Numba kernel matches an independent,
    pure-NumPy reference of the same definition. This is the cross-check that
-   would catch a window off-by-one (cf. the stale ``w + 1`` FIXME in
-   ``momentums_cy.pyx``).
+   would catch a window off-by-one.
 2. **No lookahead** — every kernel is strictly causal: output ``[:t]`` is
    unchanged when the future ``X[t:]`` is perturbed.
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fynance"
-version = "2.1.2"
+version = "2.1.3"
 description = "Pure-Python (Numba-accelerated) machine learning, econometrics and statistical tools for financial analysis and backtesting"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Promotes `develop` (v2.1.3) to `master`. Merge after CI, then tag.

## [2.1.3]

### Changed
- Removed the last stale Cython references from the user-facing surface (package docstring, estimator/econometric docstrings, API-stability policy → "2.x").

### Fixed
- Read the Docs builds were failing since v2.1.0 (`.readthedocs.yaml` ran a non-existent `setup.py build_ext`), so the hosted docs were stuck on a pre-2.0 render. Fixed — this brings the config fix to `master`, which RTD `latest` builds from.