### PR TITLE
feat: research-harness — Experiment object (leaf 01)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `fynance.research` — new data-agnostic research-harness subpackage. First piece: `Experiment`, a serializable record (spec + generated code + seed + metrics + curves + provenance) with `to_dict`/`from_dict`/`save`/`load`. Artifacts are written only to a caller-provided `output_dir` (fynance never stores results itself).
+
 ### Changed
 
 ### Fixed

--- a/doc/source/generated/fynance.research.Experiment.rst
+++ b/doc/source/generated/fynance.research.Experiment.rst
@@ -1,0 +1,13 @@
+﻿Experiment
+===========================
+
+*Defined in* :mod:`fynance.research`
+
+.. currentmodule:: fynance.research
+
+.. autoclass:: Experiment
+   :members:
+   :inherited-members:
+   :special-members: __call__, __iter__, __next__
+   :show-inheritance:
+   :no-index:

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -95,3 +95,4 @@
    models
    plot
    strategy
+   research

--- a/doc/source/research.rst
+++ b/doc/source/research.rst
@@ -1,0 +1,15 @@
+------------------------------------
+ Research (:mod:`fynance.research`)
+------------------------------------
+
+A data-agnostic harness for running strategy experiments and emitting portable
+result artifacts. fynance never stores results itself — artifacts are written to
+a caller-provided ``output_dir``. Built and tested on synthetic data; real-data
+adapters live downstream.
+
+.. currentmodule:: fynance.research
+
+.. autosummary::
+   :toctree: generated/
+
+   Experiment

--- a/fynance/__init__.py
+++ b/fynance/__init__.py
@@ -64,6 +64,10 @@ __all__ = ['__version__']
 
 import sys as _sys
 
+# Research harness — kept namespaced (``fynance.research.*``), not flattened into
+# the top-level surface, and not eagerly heavy (its report writer imports
+# matplotlib lazily).
+from . import research
 from .backtest import *
 from .core import *
 from .data import *

--- a/fynance/research/__init__.py
+++ b/fynance/research/__init__.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Research harness (:mod:`fynance.research`).
+
+A **data-agnostic** layer for running strategy experiments and emitting portable
+result artifacts. fynance is *the tool*: it never stores results itself — every
+artifact is written to a caller-provided ``output_dir`` (a downstream private
+research repo points that wherever it wants). Built and tested on the synthetic
+generators in :mod:`fynance.research.synthetic`; real-data adapters live
+downstream, never here.
+
+.. currentmodule:: fynance.research
+
+"""
+
+# Local
+from . import experiment
+from .experiment import *
+
+__all__: list[str] = []
+__all__ += experiment.__all__

--- a/fynance/research/experiment.py
+++ b/fynance/research/experiment.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" The :class:`Experiment` record.
+
+A serializable description of one strategy experiment — enough to reproduce it
+and to render a report — with **no run logic** (that lives in
+:mod:`fynance.research.runner`). This is the portable artifact a downstream
+(private) research repo stores; ``fynance`` itself never persists results except
+to a caller-provided ``output_dir``.
+
+"""
+
+# Built-in
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+__all__ = ['Experiment']
+
+
+def _utc_now() -> str:
+    """ Current UTC timestamp as an ISO-8601 string. """
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _fynance_version() -> str:
+    """ Resolve the installed fynance version lazily (avoids import cycles). """
+    from fynance import __version__
+
+    return __version__
+
+
+@dataclass
+class Experiment:
+    """ Serializable record of a single strategy experiment.
+
+    Parameters
+    ----------
+    name : str
+        Short slug identifying the experiment (also the output sub-directory).
+    spec : dict, optional
+        Everything needed to reproduce the run: strategy description, params,
+        walk-forward config, cost config and the data spec (e.g.
+        ``{"kind": "synthetic-gbm", "seed": 7, "n": 1000}``).
+    code : str, optional
+        The generated strategy source, stored verbatim for audit/reproduction.
+    seed : int
+        Master seed driving every stochastic step.
+    metrics : dict of str to float, optional
+        Summary metrics (``sharpe``/``sortino``/…); empty until a run fills it.
+    series : dict of str to list of float, optional
+        JSON-friendly curves (e.g. ``equity``/``returns``) for the report.
+    created_at : str
+        ISO-8601 UTC creation time (set automatically).
+    fynance_version : str
+        Version of fynance that produced the experiment (set automatically).
+
+    Examples
+    --------
+    >>> from fynance.research import Experiment
+    >>> e = Experiment(name="demo", seed=7, metrics={"sharpe": 1.5})
+    >>> e2 = Experiment.from_dict(e.to_dict())
+    >>> e2.name, e2.seed, e2.metrics["sharpe"]
+    ('demo', 7, 1.5)
+
+    """
+
+    name: str
+    spec: dict[str, Any] = field(default_factory=dict)
+    code: str | None = None
+    seed: int = 0
+    metrics: dict[str, float] = field(default_factory=dict)
+    series: dict[str, list[float]] | None = None
+    created_at: str = field(default_factory=_utc_now)
+    fynance_version: str = field(default_factory=_fynance_version)
+
+    def to_dict(self) -> dict[str, Any]:
+        """ Return a JSON-serializable dict of the experiment. """
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Experiment:
+        """ Rebuild an :class:`Experiment` from a :meth:`to_dict` mapping. """
+        return cls(**data)
+
+    def save(self, output_dir: str | Path, *, name: str | None = None) -> Path:
+        """ Write ``<output_dir>/<name>/experiment.json`` and return its path.
+
+        Always writes under the caller-provided ``output_dir`` — never inside
+        the package. Parent directories are created as needed.
+
+        Parameters
+        ----------
+        output_dir : str or pathlib.Path
+            Base directory the artifact is written under.
+        name : str, optional
+            Sub-directory name; defaults to :attr:`name`.
+
+        Returns
+        -------
+        pathlib.Path
+            Path to the written ``experiment.json``.
+
+        """
+        sub = name if name is not None else self.name
+        target = Path(output_dir) / sub
+        target.mkdir(parents=True, exist_ok=True)
+        path = target / "experiment.json"
+        path.write_text(json.dumps(self.to_dict(), indent=2), encoding="utf-8")
+
+        return path
+
+    @classmethod
+    def load(cls, path: str | Path) -> Experiment:
+        """ Load an :class:`Experiment` from an ``experiment.json`` file. """
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
+
+        return cls.from_dict(data)

--- a/fynance/tests/research/test_experiment.py
+++ b/fynance/tests/research/test_experiment.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Tests for :class:`fynance.research.Experiment`. """
+
+# Built-in
+import json
+from pathlib import Path
+
+# Third-party
+import pytest
+
+# Local
+import fynance
+from fynance.research import Experiment
+
+
+@pytest.fixture
+def populated():
+    """ A fully-populated experiment. """
+    return Experiment(
+        name="demo",
+        spec={"kind": "synthetic-gbm", "seed": 7, "n": 5},
+        code="def strat(p): return p",
+        seed=7,
+        metrics={"sharpe": 1.5, "max_drawdown": -0.1},
+        series={"equity": [100.0, 101.0, 99.5, 102.0]},
+    )
+
+
+def test_to_from_dict_round_trip(populated):
+    restored = Experiment.from_dict(populated.to_dict())
+
+    assert restored.to_dict() == populated.to_dict()
+    assert restored.metrics["sharpe"] == 1.5
+    assert restored.series["equity"][0] == 100.0
+
+
+def test_to_dict_is_json_serializable(populated):
+    # Must round-trip through real JSON without custom encoders.
+    text = json.dumps(populated.to_dict())
+    assert Experiment.from_dict(json.loads(text)).name == "demo"
+
+
+def test_save_and_load(tmp_path, populated):
+    path = populated.save(tmp_path)
+
+    assert path == tmp_path / "demo" / "experiment.json"
+    assert path.is_file()
+
+    loaded = Experiment.load(path)
+    assert loaded.to_dict() == populated.to_dict()
+
+
+def test_save_custom_name(tmp_path, populated):
+    path = populated.save(tmp_path, name="run-42")
+
+    assert path == tmp_path / "run-42" / "experiment.json"
+    assert path.is_file()
+
+
+def test_save_never_writes_inside_package(tmp_path, populated):
+    pkg_root = Path(fynance.__file__).resolve().parent
+    before = {p for p in pkg_root.rglob("experiment.json")}
+
+    populated.save(tmp_path)
+
+    after = {p for p in pkg_root.rglob("experiment.json")}
+    assert before == after  # nothing new written under the package
+
+
+def test_version_and_timestamp_autoset():
+    e = Experiment(name="x")
+
+    assert e.fynance_version == fynance.__version__
+    assert e.created_at  # non-empty ISO timestamp


### PR DESCRIPTION
First leaf of the **research-harness** epic (S1). Adds the new `fynance.research` subpackage with the `Experiment` artifact.

- `Experiment` dataclass: `name`, `spec`, `code`, `seed`, `metrics`, `series`, `created_at`, `fynance_version`.
- `to_dict`/`from_dict` (JSON-safe round-trip), `save(output_dir, name=)` / `load(path)`.
- **fynance never stores results itself** — `save()` only writes under a caller-provided `output_dir` (tested). Kept namespaced (`fynance.research.*`); `import fynance` stays matplotlib-free.

### Test plan
- `pytest` → **508 passed** (+7); doctest on `Experiment`; `ruff`/`mypy` clean; `sphinx-build -W` ok (generated stub committed).