### PR TITLE
feat: research-harness — synthetic generators (leaf 02)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `fynance.research` — new data-agnostic research-harness subpackage. First piece: `Experiment`, a serializable record (spec + generated code + seed + metrics + curves + provenance) with `to_dict`/`from_dict`/`save`/`load`. Artifacts are written only to a caller-provided `output_dir` (fynance never stores results itself).
+- `fynance.research` synthetic generators `gbm` and `regime_switching` — seeded price paths so the harness is testable with zero real data (and usable as a null test).
 
 ### Changed
 

--- a/doc/source/generated/fynance.research.gbm.rst
+++ b/doc/source/generated/fynance.research.gbm.rst
@@ -1,0 +1,9 @@
+﻿gbm
+====================
+
+*Defined in* :mod:`fynance.research`
+
+.. currentmodule:: fynance.research
+
+.. autofunction:: gbm
+   :no-index:

--- a/doc/source/generated/fynance.research.regime_switching.rst
+++ b/doc/source/generated/fynance.research.regime_switching.rst
@@ -1,0 +1,9 @@
+﻿regime_switching
+=================================
+
+*Defined in* :mod:`fynance.research`
+
+.. currentmodule:: fynance.research
+
+.. autofunction:: regime_switching
+   :no-index:

--- a/doc/source/research.rst
+++ b/doc/source/research.rst
@@ -13,3 +13,5 @@ adapters live downstream.
    :toctree: generated/
 
    Experiment
+   gbm
+   regime_switching

--- a/fynance/research/__init__.py
+++ b/fynance/research/__init__.py
@@ -15,8 +15,10 @@ downstream, never here.
 """
 
 # Local
-from . import experiment
+from . import experiment, synthetic
 from .experiment import *
+from .synthetic import *
 
 __all__: list[str] = []
 __all__ += experiment.__all__
+__all__ += synthetic.__all__

--- a/fynance/research/synthetic.py
+++ b/fynance/research/synthetic.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Synthetic price generators.
+
+Seeded synthetic price paths so the whole research harness is testable with
+**zero real data**. They also serve as a **null test**: a strategy should show
+~no skill on data with no real edge, which is a quick sanity check on the
+guardrails. Real-data adapters live downstream (a private research repo), never
+here.
+
+"""
+
+# Built-in
+from __future__ import annotations
+
+# Third-party
+import numpy as np
+from numpy.typing import NDArray
+
+# Local
+from fynance.core import PriceSeries
+
+__all__ = ['gbm', 'regime_switching']
+
+
+def gbm(
+    n: int,
+    *,
+    mu: float = 0.0,
+    sigma: float = 0.01,
+    s0: float = 100.0,
+    seed: int | None = None,
+) -> PriceSeries:
+    """ Geometric Brownian motion price path.
+
+    Log-returns are drawn i.i.d. ``Normal(mu, sigma)``, so the path's mean
+    log-return is ``mu`` and its volatility ``sigma``.
+
+    Parameters
+    ----------
+    n : int
+        Number of observations (path length).
+    mu : float
+        Mean per-step log-return.
+    sigma : float
+        Per-step log-return volatility.
+    s0 : float
+        Initial price.
+    seed : int, optional
+        Seed for reproducibility. ``None`` is nondeterministic.
+
+    Returns
+    -------
+    fynance.core.PriceSeries
+        Price path of length ``n``.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from fynance.research import gbm
+    >>> a, b = gbm(5, seed=7), gbm(5, seed=7)
+    >>> bool(np.allclose(a.to_numpy(), b.to_numpy()))
+    True
+    >>> int(a.to_numpy().size)
+    5
+
+    """
+    rng = np.random.default_rng(seed)
+    log_ret = mu + sigma * rng.standard_normal(max(n - 1, 0))
+    path = np.concatenate([[0.0], np.cumsum(log_ret)])
+
+    return PriceSeries(s0 * np.exp(path), name="synthetic-gbm")
+
+
+def regime_switching(
+    n: int,
+    *,
+    regimes: tuple[tuple[float, float], ...] = ((0.0, 0.01), (0.0, 0.03)),
+    p_switch: float = 0.02,
+    s0: float = 100.0,
+    seed: int | None = None,
+) -> PriceSeries:
+    """ Markov regime-switching price path.
+
+    At each step the active regime switches (to a uniformly-drawn regime) with
+    probability ``p_switch``; log-returns are then drawn from the active
+    regime's ``(mu, sigma)``. The varying volatility makes it a natural input
+    for :func:`fynance.detect_regimes`.
+
+    Parameters
+    ----------
+    n : int
+        Number of observations (path length).
+    regimes : tuple of (float, float)
+        ``(mu, sigma)`` per regime.
+    p_switch : float
+        Per-step probability of switching regime.
+    s0 : float
+        Initial price.
+    seed : int, optional
+        Seed for reproducibility. ``None`` is nondeterministic.
+
+    Returns
+    -------
+    fynance.core.PriceSeries
+        Price path of length ``n``.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from fynance.research import regime_switching
+    >>> a, b = regime_switching(5, seed=3), regime_switching(5, seed=3)
+    >>> bool(np.allclose(a.to_numpy(), b.to_numpy()))
+    True
+
+    """
+    rng = np.random.default_rng(seed)
+    mus = np.array([r[0] for r in regimes], dtype=np.float64)
+    sigmas = np.array([r[1] for r in regimes], dtype=np.float64)
+    k = mus.size
+
+    steps = max(n - 1, 0)
+    states: NDArray[np.int_] = np.empty(steps, dtype=np.int_)
+    state = 0
+    for t in range(steps):
+        if rng.random() < p_switch:
+            state = int(rng.integers(0, k))
+        states[t] = state
+
+    log_ret = mus[states] + sigmas[states] * rng.standard_normal(steps)
+    path = np.concatenate([[0.0], np.cumsum(log_ret)])
+
+    return PriceSeries(s0 * np.exp(path), name="synthetic-regime")

--- a/fynance/tests/research/test_synthetic.py
+++ b/fynance/tests/research/test_synthetic.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Tests for :mod:`fynance.research.synthetic`. """
+
+# Third-party
+import numpy as np
+import pytest
+
+# Local
+from fynance.core import PriceSeries
+from fynance.features import detect_regimes
+from fynance.research import gbm, regime_switching
+
+
+@pytest.mark.parametrize("gen", [gbm, regime_switching])
+def test_returns_price_series_of_right_length(gen):
+    p = gen(500, seed=1)
+
+    assert isinstance(p, PriceSeries)
+    arr = p.to_numpy()
+    assert arr.shape == (500,)
+    assert arr.dtype == np.float64
+    assert np.all(np.isfinite(arr)) and np.all(arr > 0)
+
+
+@pytest.mark.parametrize("gen", [gbm, regime_switching])
+def test_seed_determinism(gen):
+    assert np.allclose(gen(300, seed=42).to_numpy(), gen(300, seed=42).to_numpy())
+    assert not np.allclose(gen(300, seed=1).to_numpy(), gen(300, seed=2).to_numpy())
+
+
+def test_gbm_statistics():
+    mu, sigma, n = 0.0005, 0.02, 20000
+    p = gbm(n, mu=mu, sigma=sigma, seed=7).to_numpy()
+    log_ret = np.diff(np.log(p))
+
+    assert log_ret.mean() == pytest.approx(mu, abs=5 * sigma / np.sqrt(n))
+    assert log_ret.std() == pytest.approx(sigma, rel=0.1)
+
+
+def test_regime_switching_feeds_detect_regimes():
+    p = regime_switching(
+        3000, regimes=((0.0, 0.005), (0.0, 0.04)), p_switch=0.01, seed=11
+    )
+    labels = detect_regimes(p.to_numpy(), n_regimes=2)
+
+    assert len(np.unique(labels)) >= 2
+
+
+def test_zero_length_edge_cases():
+    # n == 1 -> a single starting price, no returns.
+    assert gbm(1, s0=100.0, seed=0).to_numpy().tolist() == [100.0]
+    assert regime_switching(1, s0=100.0, seed=0).to_numpy().tolist() == [100.0]


### PR DESCRIPTION
Second leaf of the **research-harness** epic (S1). Adds seeded synthetic price generators so the harness is testable with **zero real data**.

- `gbm(n, *, mu, sigma, s0, seed)` — GBM path; mean log-return `mu`, vol `sigma`.
- `regime_switching(n, *, regimes, p_switch, s0, seed)` — Markov regime-switching path; feeds `detect_regimes`.
- Both return a `PriceSeries`, built as `s0*exp(cumsum(log-returns))` (first price exactly `s0`), seeded via `numpy.default_rng` (reproducible). Doubles as a **null test**.

### Test plan
- `pytest` → **517 passed** (+9); doctests on both generators; `ruff`/`mypy` clean; `sphinx-build -W` ok (stubs committed).