### PR TITLE
feat: research-harness — run_experiment (leaf 03)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `fynance.research` — new data-agnostic research-harness subpackage. First piece: `Experiment`, a serializable record (spec + generated code + seed + metrics + curves + provenance) with `to_dict`/`from_dict`/`save`/`load`. Artifacts are written only to a caller-provided `output_dir` (fynance never stores results itself).
 - `fynance.research` synthetic generators `gbm` and `regime_switching` — seeded price paths so the harness is testable with zero real data (and usable as a null test).
+- `fynance.research.run_experiment(strategy, data, *, name, walk_forward, costs, seed, output_dir, ...)` — runs a seeded, cost-aware, walk-forward (or single) backtest through the existing maillons and returns a populated `Experiment`; saves it under `output_dir` when given. No-lookahead verified by a black-box causality probe.
 
 ### Changed
 

--- a/doc/source/generated/fynance.research.run_experiment.rst
+++ b/doc/source/generated/fynance.research.run_experiment.rst
@@ -1,0 +1,9 @@
+﻿run_experiment
+===============================
+
+*Defined in* :mod:`fynance.research`
+
+.. currentmodule:: fynance.research
+
+.. autofunction:: run_experiment
+   :no-index:

--- a/doc/source/research.rst
+++ b/doc/source/research.rst
@@ -13,5 +13,6 @@ adapters live downstream.
    :toctree: generated/
 
    Experiment
+   run_experiment
    gbm
    regime_switching

--- a/fynance/research/__init__.py
+++ b/fynance/research/__init__.py
@@ -15,10 +15,12 @@ downstream, never here.
 """
 
 # Local
-from . import experiment, synthetic
+from . import experiment, runner, synthetic
 from .experiment import *
+from .runner import *
 from .synthetic import *
 
 __all__: list[str] = []
 __all__ += experiment.__all__
 __all__ += synthetic.__all__
+__all__ += runner.__all__

--- a/fynance/research/runner.py
+++ b/fynance/research/runner.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" The experiment runner.
+
+:func:`run_experiment` takes a strategy and a price series, runs a walk-forward
+(or single), cost-aware, seeded backtest through the existing maillons, and
+returns a populated :class:`~fynance.research.Experiment`. Results are written
+only to a caller-provided ``output_dir`` — fynance never persists them itself.
+
+"""
+
+# Built-in
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+# Third-party
+import numpy as np
+from numpy.typing import NDArray
+
+# Local
+from fynance.core import PriceSeries
+from fynance.research.experiment import Experiment
+
+__all__ = ['run_experiment']
+
+
+def _to_array(data: Any) -> NDArray[np.float64]:
+    """ Coerce a PriceSeries / array-like to a 1-D float64 array. """
+    if isinstance(data, PriceSeries):
+        return data.to_numpy()
+
+    return np.asarray(data, dtype=np.float64).reshape(-1)
+
+
+def _seed_everything(seed: int) -> None:
+    """ Seed numpy (and torch if present) for reproducibility. """
+    np.random.seed(seed)
+    try:  # torch is optional at call time
+        import torch
+
+        torch.manual_seed(seed)
+    except ImportError:
+        pass
+
+
+def run_experiment(
+    strategy: Any,
+    data: Any,
+    *,
+    name: str,
+    y: NDArray | None = None,
+    walk_forward: dict[str, Any] | None = None,
+    costs: Any = None,
+    period: int = 252,
+    seed: int = 0,
+    code: str | None = None,
+    output_dir: str | Path | None = None,
+) -> Experiment:
+    """ Run a strategy experiment and return a populated :class:`Experiment`.
+
+    Parameters
+    ----------
+    strategy : fynance.strategy.Strategy
+        The composed strategy (features -> model -> signal -> cost).
+    data : PriceSeries or array-like
+        Price series the strategy runs on (coerced to float64).
+    name : str
+        Experiment slug (also the output sub-directory).
+    y : array-like, optional
+        Supervised target for a model-based strategy run via ``walk_forward``.
+        Defaults to zeros (ignored by rule-based strategies).
+    walk_forward : dict, optional
+        Window params for :meth:`Strategy.run_walk_forward`
+        (``train``/``test``/``step``/``purge``). ``None`` runs a single pass.
+    costs : CostModel, optional
+        Overrides the strategy's own cost model for this run when given.
+    period : int
+        Annualization factor for the metrics.
+    seed : int
+        Master seed (numpy + torch).
+    code : str, optional
+        Generated strategy source, stored verbatim on the experiment.
+    output_dir : str or pathlib.Path, optional
+        When given, the experiment is saved under ``<output_dir>/<name>/``.
+
+    Returns
+    -------
+    Experiment
+        Populated with ``spec``, ``metrics`` and ``series``.
+
+    """
+    _seed_everything(seed)
+
+    if costs is not None:
+        strategy.cost = costs
+
+    prices = _to_array(data)
+    n = prices.shape[0]
+
+    if walk_forward is not None:
+        target = np.zeros(n) if y is None else np.asarray(y, dtype=np.float64)
+        result = strategy.run_walk_forward(data, target, **walk_forward)
+
+    else:
+        result = strategy.run(data, y)
+
+    metrics = result.summary(period=period)
+
+    spec: dict[str, Any] = {
+        "data": {"kind": getattr(data, "name", None) or type(data).__name__,
+                 "n": int(n)},
+        "walk_forward": walk_forward,
+        "cost": type(strategy.cost).__name__ if strategy.cost is not None else None,
+        "period": period,
+        "seed": seed,
+    }
+
+    series = {
+        "equity": np.asarray(result.equity, dtype=float).tolist(),
+        "returns": np.asarray(result.returns, dtype=float).tolist(),
+    }
+
+    experiment = Experiment(
+        name=name,
+        spec=spec,
+        code=code,
+        seed=seed,
+        metrics={k: float(v) for k, v in metrics.items()},
+        series=series,
+    )
+
+    if output_dir is not None:
+        experiment.save(output_dir, name=name)
+
+    return experiment

--- a/fynance/tests/research/test_run_experiment.py
+++ b/fynance/tests/research/test_run_experiment.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Tests for :func:`fynance.research.run_experiment`. """
+
+# Built-in
+from pathlib import Path
+
+# Third-party
+import numpy as np
+
+# Local
+import fynance
+from fynance.backtest import ProportionalCost
+from fynance.research import Experiment, gbm, run_experiment
+from fynance.strategy import Strategy
+
+
+def momentum() -> Strategy:
+    """ A simple causal rule-based momentum strategy. """
+    return Strategy(
+        features=lambda p: np.diff(p, prepend=p[0]),
+        cost=ProportionalCost(0.0005),
+    )
+
+
+def test_returns_populated_experiment(tmp_path):
+    exp = run_experiment(momentum(), gbm(500, seed=7), name="m1",
+                         output_dir=tmp_path)
+
+    assert isinstance(exp, Experiment)
+    assert exp.metrics and all(np.isfinite(list(exp.metrics.values())))
+    assert exp.series["equity"] and exp.series["returns"]
+    assert (tmp_path / "m1" / "experiment.json").is_file()
+    # Round-trips through disk.
+    assert Experiment.load(tmp_path / "m1" / "experiment.json").metrics == exp.metrics
+
+
+def test_reproducible_same_seed():
+    a = run_experiment(momentum(), gbm(500, seed=7), name="a")
+    b = run_experiment(momentum(), gbm(500, seed=7), name="b")
+
+    assert a.metrics == b.metrics
+
+
+def test_output_dir_none_writes_nothing():
+    pkg = Path(fynance.__file__).resolve().parent
+    before = set(pkg.rglob("experiment.json"))
+
+    exp = run_experiment(momentum(), gbm(200, seed=1), name="x")
+
+    assert isinstance(exp, Experiment)
+    assert set(pkg.rglob("experiment.json")) == before
+
+
+def test_priceseries_and_ndarray_equivalent():
+    ps = gbm(300, seed=5)
+    a = run_experiment(momentum(), ps, name="ps")
+    b = run_experiment(momentum(), ps.to_numpy(), name="np")
+
+    assert a.metrics == b.metrics
+
+
+def test_costs_override_changes_result():
+    data = gbm(400, seed=3)
+    free = run_experiment(Strategy(features=lambda p: np.diff(p, prepend=p[0])),
+                          data, name="free", costs=ProportionalCost(0.0))
+    pricey = run_experiment(Strategy(features=lambda p: np.diff(p, prepend=p[0])),
+                            data, name="pricey", costs=ProportionalCost(0.01))
+
+    assert free.metrics != pricey.metrics
+
+
+def test_no_lookahead_walk_forward():
+    # Perturbing the tail must not change the out-of-sample returns on the
+    # earlier (unperturbed) prefix — a black-box causality probe.
+    data = gbm(600, seed=7).to_numpy()
+    wf = {"train": 100, "test": 50}
+
+    base = run_experiment(momentum(), data, name="base", walk_forward=wf)
+
+    pert = data.copy()
+    cut = int(len(data) * 0.7)
+    rng = np.random.default_rng(0)
+    bumps = 1.0 + rng.standard_normal(len(data) - cut) * 0.05
+    pert[cut:] = pert[cut - 1] * np.cumprod(bumps)
+
+    pert_exp = run_experiment(momentum(), pert, name="pert", walk_forward=wf)
+
+    k = len(base.series["returns"]) // 3
+    assert np.allclose(base.series["returns"][:k], pert_exp.series["returns"][:k])


### PR DESCRIPTION
Third leaf of the **research-harness** epic (S1) — the core entry point.

`run_experiment(strategy, data, *, name, y=None, walk_forward=None, costs=None, period=252, seed=0, code=None, output_dir=None) -> Experiment`

- Seeds numpy/torch, runs `Strategy.run_walk_forward` (or `run`) — never re-implements the backtest — computes metrics via `BacktestResult.summary`, captures the equity/returns curves and a reproducible `spec`.
- **Data-agnostic** (PriceSeries/ndarray); saves only under a caller-provided `output_dir` (verified nothing is written in the package when `output_dir=None`).
- `costs=` overrides the strategy's cost for the run.
- **No-lookahead** proven by a black-box probe: perturbing the tail leaves earlier out-of-sample returns unchanged.

### Test plan
- `pytest` → **523 passed** (+6); `ruff`/`mypy` clean; `sphinx-build -W` ok (stub committed).