### PR TITLE
feat: research-harness — report writer (leaf 04)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fynance.research` — new data-agnostic research-harness subpackage. First piece: `Experiment`, a serializable record (spec + generated code + seed + metrics + curves + provenance) with `to_dict`/`from_dict`/`save`/`load`. Artifacts are written only to a caller-provided `output_dir` (fynance never stores results itself).
 - `fynance.research` synthetic generators `gbm` and `regime_switching` — seeded price paths so the harness is testable with zero real data (and usable as a null test).
 - `fynance.research.run_experiment(strategy, data, *, name, walk_forward, costs, seed, output_dir, ...)` — runs a seeded, cost-aware, walk-forward (or single) backtest through the existing maillons and returns a populated `Experiment`; saves it under `output_dir` when given. No-lookahead verified by a black-box causality probe.
+- `fynance.research.write_report(experiment, output_dir, *, notebook, execute)` — renders an experiment into portable, remotely-viewable artifacts (markdown + tearsheet PNG + a re-runnable notebook) under `output_dir`. matplotlib/nbformat imported lazily; notebook execution is opt-in and degrades gracefully.
 
 ### Changed
 

--- a/doc/source/generated/fynance.research.write_report.rst
+++ b/doc/source/generated/fynance.research.write_report.rst
@@ -1,0 +1,9 @@
+﻿write_report
+=============================
+
+*Defined in* :mod:`fynance.research`
+
+.. currentmodule:: fynance.research
+
+.. autofunction:: write_report
+   :no-index:

--- a/doc/source/research.rst
+++ b/doc/source/research.rst
@@ -14,5 +14,6 @@ adapters live downstream.
 
    Experiment
    run_experiment
+   write_report
    gbm
    regime_switching

--- a/fynance/research/__init__.py
+++ b/fynance/research/__init__.py
@@ -15,8 +15,9 @@ downstream, never here.
 """
 
 # Local
-from . import experiment, runner, synthetic
+from . import experiment, report, runner, synthetic
 from .experiment import *
+from .report import *
 from .runner import *
 from .synthetic import *
 
@@ -24,3 +25,4 @@ __all__: list[str] = []
 __all__ += experiment.__all__
 __all__ += synthetic.__all__
 __all__ += runner.__all__
+__all__ += report.__all__

--- a/fynance/research/report.py
+++ b/fynance/research/report.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Portable report writer.
+
+Renders an :class:`~fynance.research.Experiment` into remotely-viewable
+artifacts under a caller-provided ``output_dir``: a markdown summary with an
+embedded tearsheet PNG (viewable on GitHub from a phone) and a re-runnable
+notebook. matplotlib and nbformat are imported lazily so ``import fynance`` stays
+matplotlib-free and the package does not hard-require Jupyter.
+
+"""
+
+# Built-in
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+# Third-party
+import numpy as np
+
+# Local
+from fynance.research.experiment import Experiment
+
+__all__ = ['write_report']
+
+
+def _metrics_table(metrics: dict[str, float]) -> str:
+    """ Render a metrics dict as a markdown table. """
+    if not metrics:
+        return "_no metrics_\n"
+
+    lines = ["| metric | value |", "| --- | --- |"]
+    lines += [f"| {k} | {v:.4f} |" for k, v in metrics.items()]
+
+    return "\n".join(lines) + "\n"
+
+
+def _write_png(experiment: Experiment, png_path: Path, period: int) -> bool:
+    """ Render the tearsheet from the equity curve to ``png_path``.
+
+    Returns True if written, False if there is no equity curve to plot.
+    """
+    if not experiment.series or not experiment.series.get("equity"):
+        return False
+
+    import matplotlib
+
+    matplotlib.use("Agg")  # headless
+    import matplotlib.pyplot as plt
+
+    from fynance.plot import tearsheet
+
+    equity = np.asarray(experiment.series["equity"], dtype=float)
+    fig = tearsheet(equity, period=period)
+    fig.savefig(png_path, dpi=110, bbox_inches="tight")
+    plt.close(fig)
+
+    return True
+
+
+def _build_notebook(experiment: Experiment, target: Path, period: int,
+                    execute: bool) -> Path | None:
+    """ Write a re-runnable notebook reconstructing the report. Returns its path
+    or None when nbformat is unavailable. """
+    try:
+        import nbformat
+        from nbformat.v4 import new_code_cell, new_markdown_cell, new_notebook
+    except ImportError:
+        warnings.warn("nbformat not installed — skipping notebook generation.",
+                      stacklevel=2)
+        return None
+
+    nb = new_notebook()
+    nb.cells = [
+        new_markdown_cell(f"# Experiment: {experiment.name}\n\n"
+                          f"Reconstructed from `experiment.json` "
+                          f"(fynance {experiment.fynance_version})."),
+        new_code_cell(
+            "import json\n"
+            "import numpy as np\n"
+            "from fynance.plot import tearsheet\n"
+            "\n"
+            "exp = json.load(open('experiment.json'))\n"
+            "equity = np.asarray(exp['series']['equity'], dtype=float)\n"
+            f"fig = tearsheet(equity, period={period})\n"
+            "fig"
+        ),
+    ]
+
+    nb_path = target / "report.ipynb"
+
+    if execute:
+        try:
+            from nbclient import NotebookClient
+
+            NotebookClient(nb, resources={"metadata": {"path": str(target)}}).execute()
+        except Exception as exc:  # noqa: BLE001 — degrade gracefully (no kernel, etc.)
+            warnings.warn(f"notebook execution skipped: {exc!r}", stacklevel=2)
+
+    nbformat.write(nb, nb_path)
+
+    return nb_path
+
+
+def write_report(
+    experiment: Experiment,
+    output_dir: str | Path,
+    *,
+    notebook: bool = True,
+    execute: bool = False,
+) -> dict[str, Path]:
+    """ Write a portable report for ``experiment`` under ``output_dir``.
+
+    Creates ``<output_dir>/<experiment.name>/`` with ``report.md`` and a
+    ``tearsheet.png`` (when an equity curve is present), plus ``report.ipynb``
+    when ``notebook`` is True. Nothing is ever written outside ``output_dir``.
+
+    Parameters
+    ----------
+    experiment : Experiment
+        The experiment to render.
+    output_dir : str or pathlib.Path
+        Base directory for the artifacts.
+    notebook : bool
+        Also emit a re-runnable ``report.ipynb`` (needs ``nbformat``).
+    execute : bool
+        Execute the notebook before writing it (needs ``nbclient`` + a kernel);
+        degrades to an unexecuted notebook with a warning if unavailable.
+
+    Returns
+    -------
+    dict of str to pathlib.Path
+        The written artifacts (keys: ``markdown``, ``png``, ``notebook`` —
+        present only when actually written).
+
+    """
+    period = int(experiment.spec.get("period", 252)) if experiment.spec else 252
+    target = Path(output_dir) / experiment.name
+    target.mkdir(parents=True, exist_ok=True)
+
+    written: dict[str, Path] = {}
+
+    png_path = target / "tearsheet.png"
+    if _write_png(experiment, png_path, period):
+        written["png"] = png_path
+
+    md = [f"# Experiment: {experiment.name}\n",
+          f"- fynance: `{experiment.fynance_version}`",
+          f"- created: `{experiment.created_at}`",
+          f"- seed: `{experiment.seed}`",
+          f"- data: `{experiment.spec.get('data')}`" if experiment.spec else "",
+          f"- walk_forward: `{experiment.spec.get('walk_forward')}`"
+          if experiment.spec else "",
+          "\n## Metrics\n",
+          _metrics_table(experiment.metrics)]
+    if "png" in written:
+        md += ["\n## Tearsheet\n", "![tearsheet](tearsheet.png)\n"]
+
+    md_path = target / "report.md"
+    md_path.write_text("\n".join(line for line in md if line != "") + "\n",
+                       encoding="utf-8")
+    written["markdown"] = md_path
+
+    if notebook:
+        nb_path = _build_notebook(experiment, target, period, execute)
+        if nb_path is not None:
+            written["notebook"] = nb_path
+
+    return written

--- a/fynance/tests/research/test_report.py
+++ b/fynance/tests/research/test_report.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Tests for :func:`fynance.research.write_report`. """
+
+# Built-in
+import importlib.util
+from pathlib import Path
+
+# Third-party
+import numpy as np
+import pytest
+
+# Local
+import fynance
+from fynance.research import gbm, run_experiment, write_report
+from fynance.strategy import Strategy
+
+_HAS_NBFORMAT = importlib.util.find_spec("nbformat") is not None
+_HAS_KERNEL = importlib.util.find_spec("ipykernel") is not None
+
+
+@pytest.fixture
+def experiment(tmp_path):
+    """ A real experiment from a synthetic run. """
+    strat = Strategy(features=lambda p: np.diff(p, prepend=p[0]))
+    return run_experiment(strat, gbm(400, seed=7), name="demo")
+
+
+def test_writes_markdown_and_png(tmp_path, experiment):
+    out = write_report(experiment, tmp_path, notebook=False)
+
+    md = tmp_path / "demo" / "report.md"
+    png = tmp_path / "demo" / "tearsheet.png"
+    assert out["markdown"] == md and md.is_file()
+    assert out["png"] == png and png.is_file() and png.stat().st_size > 0
+
+    text = md.read_text()
+    assert "# Experiment: demo" in text
+    assert "tearsheet.png" in text
+    # at least one metric value rendered
+    assert "sharpe" in text
+
+
+def test_nothing_written_outside_output_dir(tmp_path, experiment):
+    pkg = Path(fynance.__file__).resolve().parent
+    before = {p for p in pkg.rglob("report.md")}
+
+    write_report(experiment, tmp_path)
+
+    assert {p for p in pkg.rglob("report.md")} == before
+
+
+def test_import_fynance_stays_matplotlib_free():
+    import subprocess
+    import sys
+
+    code = "import fynance, sys; print('matplotlib' in sys.modules)"
+    out = subprocess.check_output([sys.executable, "-c", code], text=True)
+    assert out.strip() == "False"
+
+
+@pytest.mark.skipif(not _HAS_NBFORMAT, reason="nbformat not installed")
+def test_notebook_written(tmp_path, experiment):
+    out = write_report(experiment, tmp_path, notebook=True)
+    nb = tmp_path / "demo" / "report.ipynb"
+
+    assert out["notebook"] == nb and nb.is_file()
+
+    import nbformat
+
+    parsed = nbformat.read(nb, as_version=4)
+    assert any("tearsheet" in c.source for c in parsed.cells)
+
+
+@pytest.mark.skipif(not (_HAS_NBFORMAT and _HAS_KERNEL),
+                    reason="needs nbformat + a jupyter kernel")
+def test_notebook_execution(tmp_path, experiment):
+    # Execute against the saved experiment.json (the notebook reads it relatively).
+    experiment.save(tmp_path, name="demo")
+    out = write_report(experiment, tmp_path, notebook=True, execute=True)
+
+    import nbformat
+
+    parsed = nbformat.read(out["notebook"], as_version=4)
+    code_cells = [c for c in parsed.cells if c.cell_type == "code"]
+    assert any(c.get("outputs") for c in code_cells)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "ruff>=0.4",
     "mypy>=1.8",
     "numpydoc",
+    "nbformat",
 ]
 doc = [
     "sphinx>=7.0",
@@ -52,6 +53,7 @@ doc = [
     "nbsphinx",
     "sphinx-design",
     "sphinx-copybutton",
+    "nbformat",
 ]
 ui = [
     "streamlit>=1.30",


### PR DESCRIPTION
Fourth leaf of the **research-harness** epic (S1).

`write_report(experiment, output_dir, *, notebook=True, execute=False) -> dict[str, Path]`

- Writes `<output_dir>/<name>/`: `report.md` (metadata + metrics table + `![](tearsheet.png)`), `tearsheet.png` (reuses `fynance.plot.tearsheet` on the stored equity curve), and a re-runnable `report.ipynb`.
- **Remotely viewable**: `report.md` + PNG render on GitHub from a phone.
- matplotlib & nbformat imported **lazily** (`import fynance` stays matplotlib-free, verified by a subprocess test); notebook **execution is opt-in** and degrades gracefully without `nbclient`/a kernel.
- Never writes outside `output_dir`. `nbformat` added to `dev`/`doc` extras.

### Test plan
- `pytest` → **527 passed, 1 skipped** (execution test skips without a kernel); `ruff`/`mypy` clean; `sphinx-build -W` ok (stub committed).