### PR TITLE
docs: mark research-harness S1 done

### DIFF
--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -33,6 +33,13 @@ so an agent doesn't re-investigate settled ground or assume a known stub is a bu
 - **Backtest / Plot**: vectorized `backtest()` engine → `BacktestResult`,
   `ProportionalCost`; reporting via `fynance.plot` (`tearsheet`, composable
   figures, lazy matplotlib so `import fynance` stays matplotlib-free).
+- **Research harness** (`fynance.research`, S1): `Experiment` (serializable
+  spec + code + seed + metrics + curves), `run_experiment` (seeded, cost-aware,
+  walk-forward; no-lookahead probe), `write_report` (portable markdown + tearsheet
+  PNG + notebook), and `gbm`/`regime_switching` synthetic generators. **Data-agnostic
+  and result-free**: artifacts only go to a caller-provided `output_dir`; real data
+  + result storage live in a separate private repo. Driven by the user-level
+  `/run-strategy` skill. Guardrails (S2) and ledger (S3) are pending.
 - **Numerical kernels on Numba `@njit`** — no Cython anywhere; the build is
   pure-Python (no `setup.py`, no compile step). Every kernel has a golden-value
   parity test (1e-9/1e-10) captured from the former Cython.
@@ -50,6 +57,9 @@ so an agent doesn't re-investigate settled ground or assume a known stub is a bu
   normalization on real out-of-sample data, market-regime conditioning, and
   multi-series OHLCV indicators — see the roadmap (§1). Most items are blocked on
   having a real dataset / orchestration rather than on missing code.
+- **Research harness** (roadmap §2): S1 shipped (above); **S2 guardrails**
+  (shuffle/permutation test, deflated Sharpe, trials counter) and **S3 ledger**
+  (save/load/compare → leaderboard) are next.
 
 ## Known gaps / sharp edges (by design or deferred)
 

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -28,12 +28,6 @@ stockés dans un repo privé séparé** qui dépend de fynance — *jamais* dans
 Data-agnostique : construit et testé sur un **générateur synthétique** (la vraie
 data est injectée en aval). Plan détaillé : `doc/dev/plans/research-harness/`.
 
-- [ ] **S1 harnais** — `fynance.research` : `Experiment` (spec + code généré +
-  résultats + seed, sérialisable), `run_experiment(strategy, data, *,
-  walk_forward, costs, seed, output_dir)`, générateur synthétique (GBM/régimes,
-  sert aussi de **test null**), writer de rapport (notebook + markdown/PNG vers un
-  `output_dir` configurable), skill `/run-strategy` encodant la boucle
-  write → validate → backtest → report → publish → résume.
 - [ ] **S2 garde-fous** — shuffle/permutation test, intégration purged walk-forward,
   **deflated Sharpe + compteur d'essais** (anti-overfitting), rapport de
   comparaison multi-stratégies vs baseline.


### PR DESCRIPTION
Closes out **S1** of the research-harness epic.

Shipped across #136–#139: `fynance.research` = `Experiment`, `gbm`/`regime_switching`, `run_experiment`, `write_report` — plus the user-level `/run-strategy` skill (outside the repo). Verified end-to-end on synthetic data: artifacts land only under a caller-provided `output_dir`, nothing in the repo.

- Roadmap: remove the S1 line (done = removed); S2/S3 remain.
- `06-status.md`: record the harness under *Done & working*; note S2 (guardrails) / S3 (ledger) as next.

Docs-only. After merge → release (minor — new `fynance.research` public subpackage → 2.2.0).