### PR TITLE
chore: release v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [2.2.0] - 2026-06-16
+
+### Breaking Changes
+
+### Added
+
 - `fynance.research` — new data-agnostic research-harness subpackage. First piece: `Experiment`, a serializable record (spec + generated code + seed + metrics + curves + provenance) with `to_dict`/`from_dict`/`save`/`load`. Artifacts are written only to a caller-provided `output_dir` (fynance never stores results itself).
 - `fynance.research` synthetic generators `gbm` and `regime_switching` — seeded price paths so the harness is testable with zero real data (and usable as a null test).
 - `fynance.research.run_experiment(strategy, data, *, name, walk_forward, costs, seed, output_dir, ...)` — runs a seeded, cost-aware, walk-forward (or single) backtest through the existing maillons and returns a populated `Experiment`; saves it under `output_dir` when given. No-lookahead verified by a black-box causality probe.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fynance"
-version = "2.1.3"
+version = "2.2.0"
 description = "Pure-Python (Numba-accelerated) machine learning, econometrics and statistical tools for financial analysis and backtesting"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Minor release — new `fynance.research` subpackage (research-harness S1).

## [2.2.0]

### Added
- `fynance.research` — data-agnostic research harness: `Experiment` (serializable spec + code + seed + metrics + curves), `gbm`/`regime_switching` synthetic generators, `run_experiment` (seeded, cost-aware, walk-forward; no-lookahead probe), `write_report` (portable markdown + tearsheet PNG + notebook). Artifacts go only to a caller-provided `output_dir` — fynance never stores results itself. Driven by the user-level `/run-strategy` skill.

## Test plan
- CI green on develop (527 tests + 1 skipped, ruff, mypy, Sphinx -W).
- `pyproject.toml` → 2.2.0.