### PR TITLE
Release v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `fynance.research` — new data-agnostic research-harness subpackage. First piece: `Experiment`, a serializable record (spec + generated code + seed + metrics + curves + provenance) with `to_dict`/`from_dict`/`save`/`load`. Artifacts are written only to a caller-provided `output_dir` (fynance never stores results itself).
+
 ### Changed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fynance.research` — new data-agnostic research-harness subpackage. First piece: `Experiment`, a serializable record (spec + generated code + seed + metrics + curves + provenance) with `to_dict`/`from_dict`/`save`/`load`. Artifacts are written only to a caller-provided `output_dir` (fynance never stores results itself).
 - `fynance.research` synthetic generators `gbm` and `regime_switching` — seeded price paths so the harness is testable with zero real data (and usable as a null test).
 - `fynance.research.run_experiment(strategy, data, *, name, walk_forward, costs, seed, output_dir, ...)` — runs a seeded, cost-aware, walk-forward (or single) backtest through the existing maillons and returns a populated `Experiment`; saves it under `output_dir` when given. No-lookahead verified by a black-box causality probe.
+- `fynance.research.write_report(experiment, output_dir, *, notebook, execute)` — renders an experiment into portable, remotely-viewable artifacts (markdown + tearsheet PNG + a re-runnable notebook) under `output_dir`. matplotlib/nbformat imported lazily; notebook execution is opt-in and degrades gracefully.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `fynance.research` — new data-agnostic research-harness subpackage. First piece: `Experiment`, a serializable record (spec + generated code + seed + metrics + curves + provenance) with `to_dict`/`from_dict`/`save`/`load`. Artifacts are written only to a caller-provided `output_dir` (fynance never stores results itself).
 - `fynance.research` synthetic generators `gbm` and `regime_switching` — seeded price paths so the harness is testable with zero real data (and usable as a null test).
+- `fynance.research.run_experiment(strategy, data, *, name, walk_forward, costs, seed, output_dir, ...)` — runs a seeded, cost-aware, walk-forward (or single) backtest through the existing maillons and returns a populated `Experiment`; saves it under `output_dir` when given. No-lookahead verified by a black-box causality probe.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [2.2.0] - 2026-06-16
+
+### Breaking Changes
+
+### Added
+
 - `fynance.research` — new data-agnostic research-harness subpackage. First piece: `Experiment`, a serializable record (spec + generated code + seed + metrics + curves + provenance) with `to_dict`/`from_dict`/`save`/`load`. Artifacts are written only to a caller-provided `output_dir` (fynance never stores results itself).
 - `fynance.research` synthetic generators `gbm` and `regime_switching` — seeded price paths so the harness is testable with zero real data (and usable as a null test).
 - `fynance.research.run_experiment(strategy, data, *, name, walk_forward, costs, seed, output_dir, ...)` — runs a seeded, cost-aware, walk-forward (or single) backtest through the existing maillons and returns a populated `Experiment`; saves it under `output_dir` when given. No-lookahead verified by a black-box causality probe.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `fynance.research` — new data-agnostic research-harness subpackage. First piece: `Experiment`, a serializable record (spec + generated code + seed + metrics + curves + provenance) with `to_dict`/`from_dict`/`save`/`load`. Artifacts are written only to a caller-provided `output_dir` (fynance never stores results itself).
+- `fynance.research` synthetic generators `gbm` and `regime_switching` — seeded price paths so the harness is testable with zero real data (and usable as a null test).
 
 ### Changed
 

--- a/badges/interrogate_badge.svg
+++ b/badges/interrogate_badge.svg
@@ -1,5 +1,5 @@
 <svg width="140" height="20" viewBox="0 0 140 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <title>interrogate: 93.6%</title>
+    <title>interrogate: 93.8%</title>
     <g transform="matrix(1,0,0,1,22,0)">
         <g id="backgrounds" transform="matrix(1.32789,0,0,1,-22.3892,0)">
             <rect x="0" y="0" width="71" height="20" style="fill:rgb(85,85,85);"/>
@@ -12,8 +12,8 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
         <text x="590" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="610">interrogate</text>
         <text x="590" y="140" transform="scale(.1)" textLength="610">interrogate</text>
-        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">93.6%</text>
-        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">93.6%</text>
+        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">93.8%</text>
+        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">93.8%</text>
     </g>
     <g id="logo-shadow" serif:id="logo shadow" transform="matrix(0.854876,0,0,0.854876,-6.73514,1.732)">
         <g transform="matrix(0.299012,0,0,0.299012,9.70229,-6.68582)">

--- a/badges/interrogate_badge.svg
+++ b/badges/interrogate_badge.svg
@@ -1,5 +1,5 @@
 <svg width="140" height="20" viewBox="0 0 140 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <title>interrogate: 93.8%</title>
+    <title>interrogate: 93.9%</title>
     <g transform="matrix(1,0,0,1,22,0)">
         <g id="backgrounds" transform="matrix(1.32789,0,0,1,-22.3892,0)">
             <rect x="0" y="0" width="71" height="20" style="fill:rgb(85,85,85);"/>
@@ -12,8 +12,8 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
         <text x="590" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="610">interrogate</text>
         <text x="590" y="140" transform="scale(.1)" textLength="610">interrogate</text>
-        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">93.8%</text>
-        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">93.8%</text>
+        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">93.9%</text>
+        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">93.9%</text>
     </g>
     <g id="logo-shadow" serif:id="logo shadow" transform="matrix(0.854876,0,0,0.854876,-6.73514,1.732)">
         <g transform="matrix(0.299012,0,0,0.299012,9.70229,-6.68582)">

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -33,6 +33,13 @@ so an agent doesn't re-investigate settled ground or assume a known stub is a bu
 - **Backtest / Plot**: vectorized `backtest()` engine → `BacktestResult`,
   `ProportionalCost`; reporting via `fynance.plot` (`tearsheet`, composable
   figures, lazy matplotlib so `import fynance` stays matplotlib-free).
+- **Research harness** (`fynance.research`, S1): `Experiment` (serializable
+  spec + code + seed + metrics + curves), `run_experiment` (seeded, cost-aware,
+  walk-forward; no-lookahead probe), `write_report` (portable markdown + tearsheet
+  PNG + notebook), and `gbm`/`regime_switching` synthetic generators. **Data-agnostic
+  and result-free**: artifacts only go to a caller-provided `output_dir`; real data
+  + result storage live in a separate private repo. Driven by the user-level
+  `/run-strategy` skill. Guardrails (S2) and ledger (S3) are pending.
 - **Numerical kernels on Numba `@njit`** — no Cython anywhere; the build is
   pure-Python (no `setup.py`, no compile step). Every kernel has a golden-value
   parity test (1e-9/1e-10) captured from the former Cython.
@@ -50,6 +57,9 @@ so an agent doesn't re-investigate settled ground or assume a known stub is a bu
   normalization on real out-of-sample data, market-regime conditioning, and
   multi-series OHLCV indicators — see the roadmap (§1). Most items are blocked on
   having a real dataset / orchestration rather than on missing code.
+- **Research harness** (roadmap §2): S1 shipped (above); **S2 guardrails**
+  (shuffle/permutation test, deflated Sharpe, trials counter) and **S3 ledger**
+  (save/load/compare → leaderboard) are next.
 
 ## Known gaps / sharp edges (by design or deferred)
 

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -19,6 +19,31 @@ shipped, `03-decisions.md` for *why*. Keep it short and true.
 
 ---
 
+## 2. Research harness — outillage R&D piloté par l'IA  ⭐ active
+
+Faire de fynance le **substrat** qu'un agent (Claude Code) pilote pour tester des
+stratégies et produire des **artefacts de résultats portables**. fynance =
+**l'outil seulement** : les expériences sur vraie data et leurs **résultats sont
+stockés dans un repo privé séparé** qui dépend de fynance — *jamais* dans fynance.
+Data-agnostique : construit et testé sur un **générateur synthétique** (la vraie
+data est injectée en aval). Plan détaillé : `doc/dev/plans/research-harness/`.
+
+- [ ] **S1 harnais** — `fynance.research` : `Experiment` (spec + code généré +
+  résultats + seed, sérialisable), `run_experiment(strategy, data, *,
+  walk_forward, costs, seed, output_dir)`, générateur synthétique (GBM/régimes,
+  sert aussi de **test null**), writer de rapport (notebook + markdown/PNG vers un
+  `output_dir` configurable), skill `/run-strategy` encodant la boucle
+  write → validate → backtest → report → publish → résume.
+- [ ] **S2 garde-fous** — shuffle/permutation test, intégration purged walk-forward,
+  **deflated Sharpe + compteur d'essais** (anti-overfitting), rapport de
+  comparaison multi-stratégies vs baseline.
+- [ ] **S3 ledger** — save/load/compare des expériences (parquet/json) →
+  leaderboard cumulatif.
+
+> Les adaptateurs de vraie data (dccd…) et le stockage des résultats vivent dans
+> le **repo privé** de recherche, pas ici. Un explorateur Streamlit au-dessus du
+> ledger reste optionnel et plus tardif.
+
 ## 1. R&D — Loss, architecture, données
 
 Objectif : identifier empiriquement la meilleure combinaison loss / architecture / features

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -28,12 +28,6 @@ stockés dans un repo privé séparé** qui dépend de fynance — *jamais* dans
 Data-agnostique : construit et testé sur un **générateur synthétique** (la vraie
 data est injectée en aval). Plan détaillé : `doc/dev/plans/research-harness/`.
 
-- [ ] **S1 harnais** — `fynance.research` : `Experiment` (spec + code généré +
-  résultats + seed, sérialisable), `run_experiment(strategy, data, *,
-  walk_forward, costs, seed, output_dir)`, générateur synthétique (GBM/régimes,
-  sert aussi de **test null**), writer de rapport (notebook + markdown/PNG vers un
-  `output_dir` configurable), skill `/run-strategy` encodant la boucle
-  write → validate → backtest → report → publish → résume.
 - [ ] **S2 garde-fous** — shuffle/permutation test, intégration purged walk-forward,
   **deflated Sharpe + compteur d'essais** (anti-overfitting), rapport de
   comparaison multi-stratégies vs baseline.

--- a/doc/source/generated/fynance.research.Experiment.rst
+++ b/doc/source/generated/fynance.research.Experiment.rst
@@ -1,0 +1,13 @@
+﻿Experiment
+===========================
+
+*Defined in* :mod:`fynance.research`
+
+.. currentmodule:: fynance.research
+
+.. autoclass:: Experiment
+   :members:
+   :inherited-members:
+   :special-members: __call__, __iter__, __next__
+   :show-inheritance:
+   :no-index:

--- a/doc/source/generated/fynance.research.gbm.rst
+++ b/doc/source/generated/fynance.research.gbm.rst
@@ -1,0 +1,9 @@
+﻿gbm
+====================
+
+*Defined in* :mod:`fynance.research`
+
+.. currentmodule:: fynance.research
+
+.. autofunction:: gbm
+   :no-index:

--- a/doc/source/generated/fynance.research.regime_switching.rst
+++ b/doc/source/generated/fynance.research.regime_switching.rst
@@ -1,0 +1,9 @@
+﻿regime_switching
+=================================
+
+*Defined in* :mod:`fynance.research`
+
+.. currentmodule:: fynance.research
+
+.. autofunction:: regime_switching
+   :no-index:

--- a/doc/source/generated/fynance.research.run_experiment.rst
+++ b/doc/source/generated/fynance.research.run_experiment.rst
@@ -1,0 +1,9 @@
+﻿run_experiment
+===============================
+
+*Defined in* :mod:`fynance.research`
+
+.. currentmodule:: fynance.research
+
+.. autofunction:: run_experiment
+   :no-index:

--- a/doc/source/generated/fynance.research.write_report.rst
+++ b/doc/source/generated/fynance.research.write_report.rst
@@ -1,0 +1,9 @@
+﻿write_report
+=============================
+
+*Defined in* :mod:`fynance.research`
+
+.. currentmodule:: fynance.research
+
+.. autofunction:: write_report
+   :no-index:

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -95,3 +95,4 @@
    models
    plot
    strategy
+   research

--- a/doc/source/research.rst
+++ b/doc/source/research.rst
@@ -13,5 +13,6 @@ adapters live downstream.
    :toctree: generated/
 
    Experiment
+   run_experiment
    gbm
    regime_switching

--- a/doc/source/research.rst
+++ b/doc/source/research.rst
@@ -14,5 +14,6 @@ adapters live downstream.
 
    Experiment
    run_experiment
+   write_report
    gbm
    regime_switching

--- a/doc/source/research.rst
+++ b/doc/source/research.rst
@@ -13,3 +13,5 @@ adapters live downstream.
    :toctree: generated/
 
    Experiment
+   gbm
+   regime_switching

--- a/doc/source/research.rst
+++ b/doc/source/research.rst
@@ -1,0 +1,15 @@
+------------------------------------
+ Research (:mod:`fynance.research`)
+------------------------------------
+
+A data-agnostic harness for running strategy experiments and emitting portable
+result artifacts. fynance never stores results itself — artifacts are written to
+a caller-provided ``output_dir``. Built and tested on synthetic data; real-data
+adapters live downstream.
+
+.. currentmodule:: fynance.research
+
+.. autosummary::
+   :toctree: generated/
+
+   Experiment

--- a/fynance/__init__.py
+++ b/fynance/__init__.py
@@ -64,6 +64,10 @@ __all__ = ['__version__']
 
 import sys as _sys
 
+# Research harness — kept namespaced (``fynance.research.*``), not flattened into
+# the top-level surface, and not eagerly heavy (its report writer imports
+# matplotlib lazily).
+from . import research
 from .backtest import *
 from .core import *
 from .data import *

--- a/fynance/research/__init__.py
+++ b/fynance/research/__init__.py
@@ -15,8 +15,10 @@ downstream, never here.
 """
 
 # Local
-from . import experiment
+from . import experiment, synthetic
 from .experiment import *
+from .synthetic import *
 
 __all__: list[str] = []
 __all__ += experiment.__all__
+__all__ += synthetic.__all__

--- a/fynance/research/__init__.py
+++ b/fynance/research/__init__.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Research harness (:mod:`fynance.research`).
+
+A **data-agnostic** layer for running strategy experiments and emitting portable
+result artifacts. fynance is *the tool*: it never stores results itself — every
+artifact is written to a caller-provided ``output_dir`` (a downstream private
+research repo points that wherever it wants). Built and tested on the synthetic
+generators in :mod:`fynance.research.synthetic`; real-data adapters live
+downstream, never here.
+
+.. currentmodule:: fynance.research
+
+"""
+
+# Local
+from . import experiment
+from .experiment import *
+
+__all__: list[str] = []
+__all__ += experiment.__all__

--- a/fynance/research/__init__.py
+++ b/fynance/research/__init__.py
@@ -15,8 +15,9 @@ downstream, never here.
 """
 
 # Local
-from . import experiment, runner, synthetic
+from . import experiment, report, runner, synthetic
 from .experiment import *
+from .report import *
 from .runner import *
 from .synthetic import *
 
@@ -24,3 +25,4 @@ __all__: list[str] = []
 __all__ += experiment.__all__
 __all__ += synthetic.__all__
 __all__ += runner.__all__
+__all__ += report.__all__

--- a/fynance/research/__init__.py
+++ b/fynance/research/__init__.py
@@ -15,10 +15,12 @@ downstream, never here.
 """
 
 # Local
-from . import experiment, synthetic
+from . import experiment, runner, synthetic
 from .experiment import *
+from .runner import *
 from .synthetic import *
 
 __all__: list[str] = []
 __all__ += experiment.__all__
 __all__ += synthetic.__all__
+__all__ += runner.__all__

--- a/fynance/research/experiment.py
+++ b/fynance/research/experiment.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" The :class:`Experiment` record.
+
+A serializable description of one strategy experiment — enough to reproduce it
+and to render a report — with **no run logic** (that lives in
+:mod:`fynance.research.runner`). This is the portable artifact a downstream
+(private) research repo stores; ``fynance`` itself never persists results except
+to a caller-provided ``output_dir``.
+
+"""
+
+# Built-in
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+__all__ = ['Experiment']
+
+
+def _utc_now() -> str:
+    """ Current UTC timestamp as an ISO-8601 string. """
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _fynance_version() -> str:
+    """ Resolve the installed fynance version lazily (avoids import cycles). """
+    from fynance import __version__
+
+    return __version__
+
+
+@dataclass
+class Experiment:
+    """ Serializable record of a single strategy experiment.
+
+    Parameters
+    ----------
+    name : str
+        Short slug identifying the experiment (also the output sub-directory).
+    spec : dict, optional
+        Everything needed to reproduce the run: strategy description, params,
+        walk-forward config, cost config and the data spec (e.g.
+        ``{"kind": "synthetic-gbm", "seed": 7, "n": 1000}``).
+    code : str, optional
+        The generated strategy source, stored verbatim for audit/reproduction.
+    seed : int
+        Master seed driving every stochastic step.
+    metrics : dict of str to float, optional
+        Summary metrics (``sharpe``/``sortino``/…); empty until a run fills it.
+    series : dict of str to list of float, optional
+        JSON-friendly curves (e.g. ``equity``/``returns``) for the report.
+    created_at : str
+        ISO-8601 UTC creation time (set automatically).
+    fynance_version : str
+        Version of fynance that produced the experiment (set automatically).
+
+    Examples
+    --------
+    >>> from fynance.research import Experiment
+    >>> e = Experiment(name="demo", seed=7, metrics={"sharpe": 1.5})
+    >>> e2 = Experiment.from_dict(e.to_dict())
+    >>> e2.name, e2.seed, e2.metrics["sharpe"]
+    ('demo', 7, 1.5)
+
+    """
+
+    name: str
+    spec: dict[str, Any] = field(default_factory=dict)
+    code: str | None = None
+    seed: int = 0
+    metrics: dict[str, float] = field(default_factory=dict)
+    series: dict[str, list[float]] | None = None
+    created_at: str = field(default_factory=_utc_now)
+    fynance_version: str = field(default_factory=_fynance_version)
+
+    def to_dict(self) -> dict[str, Any]:
+        """ Return a JSON-serializable dict of the experiment. """
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Experiment:
+        """ Rebuild an :class:`Experiment` from a :meth:`to_dict` mapping. """
+        return cls(**data)
+
+    def save(self, output_dir: str | Path, *, name: str | None = None) -> Path:
+        """ Write ``<output_dir>/<name>/experiment.json`` and return its path.
+
+        Always writes under the caller-provided ``output_dir`` — never inside
+        the package. Parent directories are created as needed.
+
+        Parameters
+        ----------
+        output_dir : str or pathlib.Path
+            Base directory the artifact is written under.
+        name : str, optional
+            Sub-directory name; defaults to :attr:`name`.
+
+        Returns
+        -------
+        pathlib.Path
+            Path to the written ``experiment.json``.
+
+        """
+        sub = name if name is not None else self.name
+        target = Path(output_dir) / sub
+        target.mkdir(parents=True, exist_ok=True)
+        path = target / "experiment.json"
+        path.write_text(json.dumps(self.to_dict(), indent=2), encoding="utf-8")
+
+        return path
+
+    @classmethod
+    def load(cls, path: str | Path) -> Experiment:
+        """ Load an :class:`Experiment` from an ``experiment.json`` file. """
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
+
+        return cls.from_dict(data)

--- a/fynance/research/report.py
+++ b/fynance/research/report.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Portable report writer.
+
+Renders an :class:`~fynance.research.Experiment` into remotely-viewable
+artifacts under a caller-provided ``output_dir``: a markdown summary with an
+embedded tearsheet PNG (viewable on GitHub from a phone) and a re-runnable
+notebook. matplotlib and nbformat are imported lazily so ``import fynance`` stays
+matplotlib-free and the package does not hard-require Jupyter.
+
+"""
+
+# Built-in
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+# Third-party
+import numpy as np
+
+# Local
+from fynance.research.experiment import Experiment
+
+__all__ = ['write_report']
+
+
+def _metrics_table(metrics: dict[str, float]) -> str:
+    """ Render a metrics dict as a markdown table. """
+    if not metrics:
+        return "_no metrics_\n"
+
+    lines = ["| metric | value |", "| --- | --- |"]
+    lines += [f"| {k} | {v:.4f} |" for k, v in metrics.items()]
+
+    return "\n".join(lines) + "\n"
+
+
+def _write_png(experiment: Experiment, png_path: Path, period: int) -> bool:
+    """ Render the tearsheet from the equity curve to ``png_path``.
+
+    Returns True if written, False if there is no equity curve to plot.
+    """
+    if not experiment.series or not experiment.series.get("equity"):
+        return False
+
+    import matplotlib
+
+    matplotlib.use("Agg")  # headless
+    import matplotlib.pyplot as plt
+
+    from fynance.plot import tearsheet
+
+    equity = np.asarray(experiment.series["equity"], dtype=float)
+    fig = tearsheet(equity, period=period)
+    fig.savefig(png_path, dpi=110, bbox_inches="tight")
+    plt.close(fig)
+
+    return True
+
+
+def _build_notebook(experiment: Experiment, target: Path, period: int,
+                    execute: bool) -> Path | None:
+    """ Write a re-runnable notebook reconstructing the report. Returns its path
+    or None when nbformat is unavailable. """
+    try:
+        import nbformat
+        from nbformat.v4 import new_code_cell, new_markdown_cell, new_notebook
+    except ImportError:
+        warnings.warn("nbformat not installed — skipping notebook generation.",
+                      stacklevel=2)
+        return None
+
+    nb = new_notebook()
+    nb.cells = [
+        new_markdown_cell(f"# Experiment: {experiment.name}\n\n"
+                          f"Reconstructed from `experiment.json` "
+                          f"(fynance {experiment.fynance_version})."),
+        new_code_cell(
+            "import json\n"
+            "import numpy as np\n"
+            "from fynance.plot import tearsheet\n"
+            "\n"
+            "exp = json.load(open('experiment.json'))\n"
+            "equity = np.asarray(exp['series']['equity'], dtype=float)\n"
+            f"fig = tearsheet(equity, period={period})\n"
+            "fig"
+        ),
+    ]
+
+    nb_path = target / "report.ipynb"
+
+    if execute:
+        try:
+            from nbclient import NotebookClient
+
+            NotebookClient(nb, resources={"metadata": {"path": str(target)}}).execute()
+        except Exception as exc:  # noqa: BLE001 — degrade gracefully (no kernel, etc.)
+            warnings.warn(f"notebook execution skipped: {exc!r}", stacklevel=2)
+
+    nbformat.write(nb, nb_path)
+
+    return nb_path
+
+
+def write_report(
+    experiment: Experiment,
+    output_dir: str | Path,
+    *,
+    notebook: bool = True,
+    execute: bool = False,
+) -> dict[str, Path]:
+    """ Write a portable report for ``experiment`` under ``output_dir``.
+
+    Creates ``<output_dir>/<experiment.name>/`` with ``report.md`` and a
+    ``tearsheet.png`` (when an equity curve is present), plus ``report.ipynb``
+    when ``notebook`` is True. Nothing is ever written outside ``output_dir``.
+
+    Parameters
+    ----------
+    experiment : Experiment
+        The experiment to render.
+    output_dir : str or pathlib.Path
+        Base directory for the artifacts.
+    notebook : bool
+        Also emit a re-runnable ``report.ipynb`` (needs ``nbformat``).
+    execute : bool
+        Execute the notebook before writing it (needs ``nbclient`` + a kernel);
+        degrades to an unexecuted notebook with a warning if unavailable.
+
+    Returns
+    -------
+    dict of str to pathlib.Path
+        The written artifacts (keys: ``markdown``, ``png``, ``notebook`` —
+        present only when actually written).
+
+    """
+    period = int(experiment.spec.get("period", 252)) if experiment.spec else 252
+    target = Path(output_dir) / experiment.name
+    target.mkdir(parents=True, exist_ok=True)
+
+    written: dict[str, Path] = {}
+
+    png_path = target / "tearsheet.png"
+    if _write_png(experiment, png_path, period):
+        written["png"] = png_path
+
+    md = [f"# Experiment: {experiment.name}\n",
+          f"- fynance: `{experiment.fynance_version}`",
+          f"- created: `{experiment.created_at}`",
+          f"- seed: `{experiment.seed}`",
+          f"- data: `{experiment.spec.get('data')}`" if experiment.spec else "",
+          f"- walk_forward: `{experiment.spec.get('walk_forward')}`"
+          if experiment.spec else "",
+          "\n## Metrics\n",
+          _metrics_table(experiment.metrics)]
+    if "png" in written:
+        md += ["\n## Tearsheet\n", "![tearsheet](tearsheet.png)\n"]
+
+    md_path = target / "report.md"
+    md_path.write_text("\n".join(line for line in md if line != "") + "\n",
+                       encoding="utf-8")
+    written["markdown"] = md_path
+
+    if notebook:
+        nb_path = _build_notebook(experiment, target, period, execute)
+        if nb_path is not None:
+            written["notebook"] = nb_path
+
+    return written

--- a/fynance/research/runner.py
+++ b/fynance/research/runner.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" The experiment runner.
+
+:func:`run_experiment` takes a strategy and a price series, runs a walk-forward
+(or single), cost-aware, seeded backtest through the existing maillons, and
+returns a populated :class:`~fynance.research.Experiment`. Results are written
+only to a caller-provided ``output_dir`` — fynance never persists them itself.
+
+"""
+
+# Built-in
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+# Third-party
+import numpy as np
+from numpy.typing import NDArray
+
+# Local
+from fynance.core import PriceSeries
+from fynance.research.experiment import Experiment
+
+__all__ = ['run_experiment']
+
+
+def _to_array(data: Any) -> NDArray[np.float64]:
+    """ Coerce a PriceSeries / array-like to a 1-D float64 array. """
+    if isinstance(data, PriceSeries):
+        return data.to_numpy()
+
+    return np.asarray(data, dtype=np.float64).reshape(-1)
+
+
+def _seed_everything(seed: int) -> None:
+    """ Seed numpy (and torch if present) for reproducibility. """
+    np.random.seed(seed)
+    try:  # torch is optional at call time
+        import torch
+
+        torch.manual_seed(seed)
+    except ImportError:
+        pass
+
+
+def run_experiment(
+    strategy: Any,
+    data: Any,
+    *,
+    name: str,
+    y: NDArray | None = None,
+    walk_forward: dict[str, Any] | None = None,
+    costs: Any = None,
+    period: int = 252,
+    seed: int = 0,
+    code: str | None = None,
+    output_dir: str | Path | None = None,
+) -> Experiment:
+    """ Run a strategy experiment and return a populated :class:`Experiment`.
+
+    Parameters
+    ----------
+    strategy : fynance.strategy.Strategy
+        The composed strategy (features -> model -> signal -> cost).
+    data : PriceSeries or array-like
+        Price series the strategy runs on (coerced to float64).
+    name : str
+        Experiment slug (also the output sub-directory).
+    y : array-like, optional
+        Supervised target for a model-based strategy run via ``walk_forward``.
+        Defaults to zeros (ignored by rule-based strategies).
+    walk_forward : dict, optional
+        Window params for :meth:`Strategy.run_walk_forward`
+        (``train``/``test``/``step``/``purge``). ``None`` runs a single pass.
+    costs : CostModel, optional
+        Overrides the strategy's own cost model for this run when given.
+    period : int
+        Annualization factor for the metrics.
+    seed : int
+        Master seed (numpy + torch).
+    code : str, optional
+        Generated strategy source, stored verbatim on the experiment.
+    output_dir : str or pathlib.Path, optional
+        When given, the experiment is saved under ``<output_dir>/<name>/``.
+
+    Returns
+    -------
+    Experiment
+        Populated with ``spec``, ``metrics`` and ``series``.
+
+    """
+    _seed_everything(seed)
+
+    if costs is not None:
+        strategy.cost = costs
+
+    prices = _to_array(data)
+    n = prices.shape[0]
+
+    if walk_forward is not None:
+        target = np.zeros(n) if y is None else np.asarray(y, dtype=np.float64)
+        result = strategy.run_walk_forward(data, target, **walk_forward)
+
+    else:
+        result = strategy.run(data, y)
+
+    metrics = result.summary(period=period)
+
+    spec: dict[str, Any] = {
+        "data": {"kind": getattr(data, "name", None) or type(data).__name__,
+                 "n": int(n)},
+        "walk_forward": walk_forward,
+        "cost": type(strategy.cost).__name__ if strategy.cost is not None else None,
+        "period": period,
+        "seed": seed,
+    }
+
+    series = {
+        "equity": np.asarray(result.equity, dtype=float).tolist(),
+        "returns": np.asarray(result.returns, dtype=float).tolist(),
+    }
+
+    experiment = Experiment(
+        name=name,
+        spec=spec,
+        code=code,
+        seed=seed,
+        metrics={k: float(v) for k, v in metrics.items()},
+        series=series,
+    )
+
+    if output_dir is not None:
+        experiment.save(output_dir, name=name)
+
+    return experiment

--- a/fynance/research/synthetic.py
+++ b/fynance/research/synthetic.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Synthetic price generators.
+
+Seeded synthetic price paths so the whole research harness is testable with
+**zero real data**. They also serve as a **null test**: a strategy should show
+~no skill on data with no real edge, which is a quick sanity check on the
+guardrails. Real-data adapters live downstream (a private research repo), never
+here.
+
+"""
+
+# Built-in
+from __future__ import annotations
+
+# Third-party
+import numpy as np
+from numpy.typing import NDArray
+
+# Local
+from fynance.core import PriceSeries
+
+__all__ = ['gbm', 'regime_switching']
+
+
+def gbm(
+    n: int,
+    *,
+    mu: float = 0.0,
+    sigma: float = 0.01,
+    s0: float = 100.0,
+    seed: int | None = None,
+) -> PriceSeries:
+    """ Geometric Brownian motion price path.
+
+    Log-returns are drawn i.i.d. ``Normal(mu, sigma)``, so the path's mean
+    log-return is ``mu`` and its volatility ``sigma``.
+
+    Parameters
+    ----------
+    n : int
+        Number of observations (path length).
+    mu : float
+        Mean per-step log-return.
+    sigma : float
+        Per-step log-return volatility.
+    s0 : float
+        Initial price.
+    seed : int, optional
+        Seed for reproducibility. ``None`` is nondeterministic.
+
+    Returns
+    -------
+    fynance.core.PriceSeries
+        Price path of length ``n``.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from fynance.research import gbm
+    >>> a, b = gbm(5, seed=7), gbm(5, seed=7)
+    >>> bool(np.allclose(a.to_numpy(), b.to_numpy()))
+    True
+    >>> int(a.to_numpy().size)
+    5
+
+    """
+    rng = np.random.default_rng(seed)
+    log_ret = mu + sigma * rng.standard_normal(max(n - 1, 0))
+    path = np.concatenate([[0.0], np.cumsum(log_ret)])
+
+    return PriceSeries(s0 * np.exp(path), name="synthetic-gbm")
+
+
+def regime_switching(
+    n: int,
+    *,
+    regimes: tuple[tuple[float, float], ...] = ((0.0, 0.01), (0.0, 0.03)),
+    p_switch: float = 0.02,
+    s0: float = 100.0,
+    seed: int | None = None,
+) -> PriceSeries:
+    """ Markov regime-switching price path.
+
+    At each step the active regime switches (to a uniformly-drawn regime) with
+    probability ``p_switch``; log-returns are then drawn from the active
+    regime's ``(mu, sigma)``. The varying volatility makes it a natural input
+    for :func:`fynance.detect_regimes`.
+
+    Parameters
+    ----------
+    n : int
+        Number of observations (path length).
+    regimes : tuple of (float, float)
+        ``(mu, sigma)`` per regime.
+    p_switch : float
+        Per-step probability of switching regime.
+    s0 : float
+        Initial price.
+    seed : int, optional
+        Seed for reproducibility. ``None`` is nondeterministic.
+
+    Returns
+    -------
+    fynance.core.PriceSeries
+        Price path of length ``n``.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from fynance.research import regime_switching
+    >>> a, b = regime_switching(5, seed=3), regime_switching(5, seed=3)
+    >>> bool(np.allclose(a.to_numpy(), b.to_numpy()))
+    True
+
+    """
+    rng = np.random.default_rng(seed)
+    mus = np.array([r[0] for r in regimes], dtype=np.float64)
+    sigmas = np.array([r[1] for r in regimes], dtype=np.float64)
+    k = mus.size
+
+    steps = max(n - 1, 0)
+    states: NDArray[np.int_] = np.empty(steps, dtype=np.int_)
+    state = 0
+    for t in range(steps):
+        if rng.random() < p_switch:
+            state = int(rng.integers(0, k))
+        states[t] = state
+
+    log_ret = mus[states] + sigmas[states] * rng.standard_normal(steps)
+    path = np.concatenate([[0.0], np.cumsum(log_ret)])
+
+    return PriceSeries(s0 * np.exp(path), name="synthetic-regime")

--- a/fynance/tests/research/test_experiment.py
+++ b/fynance/tests/research/test_experiment.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Tests for :class:`fynance.research.Experiment`. """
+
+# Built-in
+import json
+from pathlib import Path
+
+# Third-party
+import pytest
+
+# Local
+import fynance
+from fynance.research import Experiment
+
+
+@pytest.fixture
+def populated():
+    """ A fully-populated experiment. """
+    return Experiment(
+        name="demo",
+        spec={"kind": "synthetic-gbm", "seed": 7, "n": 5},
+        code="def strat(p): return p",
+        seed=7,
+        metrics={"sharpe": 1.5, "max_drawdown": -0.1},
+        series={"equity": [100.0, 101.0, 99.5, 102.0]},
+    )
+
+
+def test_to_from_dict_round_trip(populated):
+    restored = Experiment.from_dict(populated.to_dict())
+
+    assert restored.to_dict() == populated.to_dict()
+    assert restored.metrics["sharpe"] == 1.5
+    assert restored.series["equity"][0] == 100.0
+
+
+def test_to_dict_is_json_serializable(populated):
+    # Must round-trip through real JSON without custom encoders.
+    text = json.dumps(populated.to_dict())
+    assert Experiment.from_dict(json.loads(text)).name == "demo"
+
+
+def test_save_and_load(tmp_path, populated):
+    path = populated.save(tmp_path)
+
+    assert path == tmp_path / "demo" / "experiment.json"
+    assert path.is_file()
+
+    loaded = Experiment.load(path)
+    assert loaded.to_dict() == populated.to_dict()
+
+
+def test_save_custom_name(tmp_path, populated):
+    path = populated.save(tmp_path, name="run-42")
+
+    assert path == tmp_path / "run-42" / "experiment.json"
+    assert path.is_file()
+
+
+def test_save_never_writes_inside_package(tmp_path, populated):
+    pkg_root = Path(fynance.__file__).resolve().parent
+    before = {p for p in pkg_root.rglob("experiment.json")}
+
+    populated.save(tmp_path)
+
+    after = {p for p in pkg_root.rglob("experiment.json")}
+    assert before == after  # nothing new written under the package
+
+
+def test_version_and_timestamp_autoset():
+    e = Experiment(name="x")
+
+    assert e.fynance_version == fynance.__version__
+    assert e.created_at  # non-empty ISO timestamp

--- a/fynance/tests/research/test_report.py
+++ b/fynance/tests/research/test_report.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Tests for :func:`fynance.research.write_report`. """
+
+# Built-in
+import importlib.util
+from pathlib import Path
+
+# Third-party
+import numpy as np
+import pytest
+
+# Local
+import fynance
+from fynance.research import gbm, run_experiment, write_report
+from fynance.strategy import Strategy
+
+_HAS_NBFORMAT = importlib.util.find_spec("nbformat") is not None
+_HAS_KERNEL = importlib.util.find_spec("ipykernel") is not None
+
+
+@pytest.fixture
+def experiment(tmp_path):
+    """ A real experiment from a synthetic run. """
+    strat = Strategy(features=lambda p: np.diff(p, prepend=p[0]))
+    return run_experiment(strat, gbm(400, seed=7), name="demo")
+
+
+def test_writes_markdown_and_png(tmp_path, experiment):
+    out = write_report(experiment, tmp_path, notebook=False)
+
+    md = tmp_path / "demo" / "report.md"
+    png = tmp_path / "demo" / "tearsheet.png"
+    assert out["markdown"] == md and md.is_file()
+    assert out["png"] == png and png.is_file() and png.stat().st_size > 0
+
+    text = md.read_text()
+    assert "# Experiment: demo" in text
+    assert "tearsheet.png" in text
+    # at least one metric value rendered
+    assert "sharpe" in text
+
+
+def test_nothing_written_outside_output_dir(tmp_path, experiment):
+    pkg = Path(fynance.__file__).resolve().parent
+    before = {p for p in pkg.rglob("report.md")}
+
+    write_report(experiment, tmp_path)
+
+    assert {p for p in pkg.rglob("report.md")} == before
+
+
+def test_import_fynance_stays_matplotlib_free():
+    import subprocess
+    import sys
+
+    code = "import fynance, sys; print('matplotlib' in sys.modules)"
+    out = subprocess.check_output([sys.executable, "-c", code], text=True)
+    assert out.strip() == "False"
+
+
+@pytest.mark.skipif(not _HAS_NBFORMAT, reason="nbformat not installed")
+def test_notebook_written(tmp_path, experiment):
+    out = write_report(experiment, tmp_path, notebook=True)
+    nb = tmp_path / "demo" / "report.ipynb"
+
+    assert out["notebook"] == nb and nb.is_file()
+
+    import nbformat
+
+    parsed = nbformat.read(nb, as_version=4)
+    assert any("tearsheet" in c.source for c in parsed.cells)
+
+
+@pytest.mark.skipif(not (_HAS_NBFORMAT and _HAS_KERNEL),
+                    reason="needs nbformat + a jupyter kernel")
+def test_notebook_execution(tmp_path, experiment):
+    # Execute against the saved experiment.json (the notebook reads it relatively).
+    experiment.save(tmp_path, name="demo")
+    out = write_report(experiment, tmp_path, notebook=True, execute=True)
+
+    import nbformat
+
+    parsed = nbformat.read(out["notebook"], as_version=4)
+    code_cells = [c for c in parsed.cells if c.cell_type == "code"]
+    assert any(c.get("outputs") for c in code_cells)

--- a/fynance/tests/research/test_run_experiment.py
+++ b/fynance/tests/research/test_run_experiment.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Tests for :func:`fynance.research.run_experiment`. """
+
+# Built-in
+from pathlib import Path
+
+# Third-party
+import numpy as np
+
+# Local
+import fynance
+from fynance.backtest import ProportionalCost
+from fynance.research import Experiment, gbm, run_experiment
+from fynance.strategy import Strategy
+
+
+def momentum() -> Strategy:
+    """ A simple causal rule-based momentum strategy. """
+    return Strategy(
+        features=lambda p: np.diff(p, prepend=p[0]),
+        cost=ProportionalCost(0.0005),
+    )
+
+
+def test_returns_populated_experiment(tmp_path):
+    exp = run_experiment(momentum(), gbm(500, seed=7), name="m1",
+                         output_dir=tmp_path)
+
+    assert isinstance(exp, Experiment)
+    assert exp.metrics and all(np.isfinite(list(exp.metrics.values())))
+    assert exp.series["equity"] and exp.series["returns"]
+    assert (tmp_path / "m1" / "experiment.json").is_file()
+    # Round-trips through disk.
+    assert Experiment.load(tmp_path / "m1" / "experiment.json").metrics == exp.metrics
+
+
+def test_reproducible_same_seed():
+    a = run_experiment(momentum(), gbm(500, seed=7), name="a")
+    b = run_experiment(momentum(), gbm(500, seed=7), name="b")
+
+    assert a.metrics == b.metrics
+
+
+def test_output_dir_none_writes_nothing():
+    pkg = Path(fynance.__file__).resolve().parent
+    before = set(pkg.rglob("experiment.json"))
+
+    exp = run_experiment(momentum(), gbm(200, seed=1), name="x")
+
+    assert isinstance(exp, Experiment)
+    assert set(pkg.rglob("experiment.json")) == before
+
+
+def test_priceseries_and_ndarray_equivalent():
+    ps = gbm(300, seed=5)
+    a = run_experiment(momentum(), ps, name="ps")
+    b = run_experiment(momentum(), ps.to_numpy(), name="np")
+
+    assert a.metrics == b.metrics
+
+
+def test_costs_override_changes_result():
+    data = gbm(400, seed=3)
+    free = run_experiment(Strategy(features=lambda p: np.diff(p, prepend=p[0])),
+                          data, name="free", costs=ProportionalCost(0.0))
+    pricey = run_experiment(Strategy(features=lambda p: np.diff(p, prepend=p[0])),
+                            data, name="pricey", costs=ProportionalCost(0.01))
+
+    assert free.metrics != pricey.metrics
+
+
+def test_no_lookahead_walk_forward():
+    # Perturbing the tail must not change the out-of-sample returns on the
+    # earlier (unperturbed) prefix — a black-box causality probe.
+    data = gbm(600, seed=7).to_numpy()
+    wf = {"train": 100, "test": 50}
+
+    base = run_experiment(momentum(), data, name="base", walk_forward=wf)
+
+    pert = data.copy()
+    cut = int(len(data) * 0.7)
+    rng = np.random.default_rng(0)
+    bumps = 1.0 + rng.standard_normal(len(data) - cut) * 0.05
+    pert[cut:] = pert[cut - 1] * np.cumprod(bumps)
+
+    pert_exp = run_experiment(momentum(), pert, name="pert", walk_forward=wf)
+
+    k = len(base.series["returns"]) // 3
+    assert np.allclose(base.series["returns"][:k], pert_exp.series["returns"][:k])

--- a/fynance/tests/research/test_synthetic.py
+++ b/fynance/tests/research/test_synthetic.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Tests for :mod:`fynance.research.synthetic`. """
+
+# Third-party
+import numpy as np
+import pytest
+
+# Local
+from fynance.core import PriceSeries
+from fynance.features import detect_regimes
+from fynance.research import gbm, regime_switching
+
+
+@pytest.mark.parametrize("gen", [gbm, regime_switching])
+def test_returns_price_series_of_right_length(gen):
+    p = gen(500, seed=1)
+
+    assert isinstance(p, PriceSeries)
+    arr = p.to_numpy()
+    assert arr.shape == (500,)
+    assert arr.dtype == np.float64
+    assert np.all(np.isfinite(arr)) and np.all(arr > 0)
+
+
+@pytest.mark.parametrize("gen", [gbm, regime_switching])
+def test_seed_determinism(gen):
+    assert np.allclose(gen(300, seed=42).to_numpy(), gen(300, seed=42).to_numpy())
+    assert not np.allclose(gen(300, seed=1).to_numpy(), gen(300, seed=2).to_numpy())
+
+
+def test_gbm_statistics():
+    mu, sigma, n = 0.0005, 0.02, 20000
+    p = gbm(n, mu=mu, sigma=sigma, seed=7).to_numpy()
+    log_ret = np.diff(np.log(p))
+
+    assert log_ret.mean() == pytest.approx(mu, abs=5 * sigma / np.sqrt(n))
+    assert log_ret.std() == pytest.approx(sigma, rel=0.1)
+
+
+def test_regime_switching_feeds_detect_regimes():
+    p = regime_switching(
+        3000, regimes=((0.0, 0.005), (0.0, 0.04)), p_switch=0.01, seed=11
+    )
+    labels = detect_regimes(p.to_numpy(), n_regimes=2)
+
+    assert len(np.unique(labels)) >= 2
+
+
+def test_zero_length_edge_cases():
+    # n == 1 -> a single starting price, no returns.
+    assert gbm(1, s0=100.0, seed=0).to_numpy().tolist() == [100.0]
+    assert regime_switching(1, s0=100.0, seed=0).to_numpy().tolist() == [100.0]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fynance"
-version = "2.1.3"
+version = "2.2.0"
 description = "Pure-Python (Numba-accelerated) machine learning, econometrics and statistical tools for financial analysis and backtesting"
 readme = "README.md"
 license = { text = "MIT" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "ruff>=0.4",
     "mypy>=1.8",
     "numpydoc",
+    "nbformat",
 ]
 doc = [
     "sphinx>=7.0",
@@ -52,6 +53,7 @@ doc = [
     "nbsphinx",
     "sphinx-design",
     "sphinx-copybutton",
+    "nbformat",
 ]
 ui = [
     "streamlit>=1.30",


### PR DESCRIPTION
Promotes `develop` (v2.2.0) to `master`. Merge after CI, then tag.

## [2.2.0]

### Added
- `fynance.research` — data-agnostic research harness: `Experiment`, `gbm`/`regime_switching`, `run_experiment` (seeded, cost-aware, walk-forward; no-lookahead probe), `write_report` (portable markdown + tearsheet PNG + notebook). Results go only to a caller-provided `output_dir`. Driven by the user-level `/run-strategy` skill.