### PR TITLE
docs: surface fynance.research across docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ Calmar, Omega, directional, hybrid), and robust-training utilities.
 **Strategy** `fynance.strategy` — optional orchestrator composing the maillons
 end-to-end, with single-run and walk-forward evaluation.
 
+**Research** `fynance.research` — data-agnostic experiment harness: `Experiment`
+(serializable run record), `run_experiment` (seeded, cost-aware, walk-forward),
+`write_report` (portable markdown + tearsheet PNG + notebook) and synthetic data
+generators (`gbm`, `regime_switching`). Results are written only to a
+caller-provided `output_dir` — fynance never stores them itself.
+
 ## Quick start
 
 ```python

--- a/doc/dev/01-overview.md
+++ b/doc/dev/01-overview.md
@@ -23,6 +23,9 @@ analysis and backtesting**. Since 2.0 it is a **layered backtesting tool**
   PyTorch losses (Sharpe/Sortino/Calmar/Omega/directional/hybrid).
 - **Backtest / Plot / Strategy** — vectorized engine + cost models →
   `BacktestResult`; `tearsheet` reporting; optional `Strategy` orchestrator.
+- **Research** — data-agnostic experiment harness (`Experiment`,
+  `run_experiment`, `write_report`, synthetic generators) emitting portable result
+  artifacts to a caller-provided `output_dir`; fynance never stores results itself.
 
 The throughline is **strict temporal causality**: every rolling feature and every
 training window is computed from the past only — no lookahead. This is the
@@ -60,6 +63,8 @@ fynance/
   backtest/    # vectorized engine + cost + result; legacy live-viz plot stack
   plot/        # composable matplotlib figures + tearsheet (lazy import)
   strategy/    # optional Strategy orchestrator + walk-forward run
+  research/    # data-agnostic experiment harness: Experiment, run_experiment,
+               #   write_report, synthetic generators (results -> output_dir only)
   estimator/   # ARMA/GARCH parameter estimation (Numba)
   tests/       # mirrors the package; pytest + doctests
 doc/

--- a/doc/dev/02-architecture.md
+++ b/doc/dev/02-architecture.md
@@ -6,6 +6,9 @@ or models out. The structure is by *concern*, wired through `typing.Protocol`
 seams, with a shared causal-windowing pattern running through it.
 
 ```
+research            experiment harness: run_experiment → Experiment → write_report
+   │  drives           (data-agnostic; artifacts -> caller's output_dir only)
+   ▼
 strategy            optional orchestrator (compose the maillons end-to-end)
    │  composes
    ▼
@@ -47,6 +50,10 @@ stability policy per package.)
   kept for `RollMultiLayerPerceptron` but off the eager public surface.
 - **`plot/` · `strategy/`** — composable matplotlib figures + `tearsheet` (lazy
   import); the optional `Strategy` orchestrator + `run_walk_forward`.
+- **`research/`** — data-agnostic experiment harness: `experiment.py`
+  (`Experiment`), `runner.py` (`run_experiment`), `report.py` (`write_report`,
+  lazy matplotlib/nbformat), `synthetic.py` (`gbm`/`regime_switching`). Writes
+  artifacts only to a caller-provided `output_dir`; no real-data dependency.
 - **`estimator/`** — Numba ARMA/GARCH parameter estimation. **Authoritative** —
   parameter logic lives here / in `econometric_models`, not duplicated.
 

--- a/doc/dev/04-subpackages.md
+++ b/doc/dev/04-subpackages.md
@@ -16,6 +16,7 @@ modernisation).
 | `estimator` / `models.econometric_models` | **Single Numba implementation** — do not duplicate parameter logic | One source for ARMA/GARCH estimation |
 | `signal` / `models` | **Modernise freely** (PyTorch) | The active R&D surface |
 | `backtest` / `plot` / `strategy` | **Improve freely** | Engine/reporting/orchestration, no frozen contract |
+| `research` | **Extend freely — but stay data-agnostic & result-free** | The AI-driven R&D harness; must never depend on real data or store results (→ `output_dir` only) |
 
 ## Public API surface (what callers import)
 
@@ -43,6 +44,10 @@ modernisation).
   `run_walk_forward`. (The legacy live-viz objects `PlotBackTest`/
   `DynaPlotBackTest`/`display_perf` remain as lazy submodules, off the eager
   surface.)
+- **`research`** (namespaced as `fynance.research.*`, not flattened) — `Experiment`,
+  `run_experiment`, `write_report`, `gbm`/`regime_switching`. Driven by the
+  user-level `/run-strategy` skill. Artifacts go only to a caller-provided
+  `output_dir`.
 
 ## Known sharp edges (by design)
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -72,6 +72,13 @@
       Econometric models, neural networks (MLP, RNN, GRU, LSTM,
       attention, TCN, Transformer) and walk-forward training.
 
+   .. grid-item-card:: :octicon:`beaker;1.2em;sd-mr-1` Research
+      :link: research
+      :link-type: doc
+
+      Data-agnostic experiment harness: run, report and reproduce
+      strategies, emitting portable result artifacts.
+
 .. toctree::
    :hidden:
    :caption: Getting Started


### PR DESCRIPTION
Adds the new `fynance.research` subpackage (shipped in v2.2.0) to the docs that didn't yet mention it: README subpackage list, the dev brief (01/02/04), and a landing-page card. Keeps the *data-agnostic, result-free* invariant visible. Docs-only; `sphinx-build -W` green.