### PR TITLE
feat: research-harness — guardrails (S2 leaf A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `fynance.research` guardrails (`guards.py`): `permutation_test` (shuffle the asset's returns, build a null distribution of a metric → p-value; detects a spurious edge / leakage) and `probabilistic_sharpe_ratio` / `deflated_sharpe_ratio` (Bailey & López de Prado — does the edge survive the number of trials?). Anti-overfitting / anti-data-snooping for AI-driven search.
+
 ### Changed
 
 ### Fixed

--- a/doc/source/generated/fynance.research.deflated_sharpe_ratio.rst
+++ b/doc/source/generated/fynance.research.deflated_sharpe_ratio.rst
@@ -1,0 +1,9 @@
+﻿deflated_sharpe_ratio
+======================================
+
+*Defined in* :mod:`fynance.research`
+
+.. currentmodule:: fynance.research
+
+.. autofunction:: deflated_sharpe_ratio
+   :no-index:

--- a/doc/source/generated/fynance.research.permutation_test.rst
+++ b/doc/source/generated/fynance.research.permutation_test.rst
@@ -1,0 +1,9 @@
+﻿permutation_test
+=================================
+
+*Defined in* :mod:`fynance.research`
+
+.. currentmodule:: fynance.research
+
+.. autofunction:: permutation_test
+   :no-index:

--- a/doc/source/generated/fynance.research.probabilistic_sharpe_ratio.rst
+++ b/doc/source/generated/fynance.research.probabilistic_sharpe_ratio.rst
@@ -1,0 +1,9 @@
+﻿probabilistic_sharpe_ratio
+===========================================
+
+*Defined in* :mod:`fynance.research`
+
+.. currentmodule:: fynance.research
+
+.. autofunction:: probabilistic_sharpe_ratio
+   :no-index:

--- a/doc/source/research.rst
+++ b/doc/source/research.rst
@@ -15,5 +15,8 @@ adapters live downstream.
    Experiment
    run_experiment
    write_report
+   permutation_test
+   probabilistic_sharpe_ratio
+   deflated_sharpe_ratio
    gbm
    regime_switching

--- a/fynance/research/__init__.py
+++ b/fynance/research/__init__.py
@@ -15,8 +15,9 @@ downstream, never here.
 """
 
 # Local
-from . import experiment, report, runner, synthetic
+from . import experiment, guards, report, runner, synthetic
 from .experiment import *
+from .guards import *
 from .report import *
 from .runner import *
 from .synthetic import *
@@ -26,3 +27,4 @@ __all__ += experiment.__all__
 __all__ += synthetic.__all__
 __all__ += runner.__all__
 __all__ += report.__all__
+__all__ += guards.__all__

--- a/fynance/research/guards.py
+++ b/fynance/research/guards.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Statistical guardrails against spurious results.
+
+When an agent searches over many strategies, the danger is **overfitting and
+data-snooping**: a good in-sample Sharpe may be luck or leakage. These guards make
+honest evaluation cheap — a permutation test (is the edge real?) and the
+probabilistic / deflated Sharpe ratio (does it survive the number of trials?).
+
+All functions are data-agnostic and operate on the existing maillons / plain
+metrics; nothing here reads real data or stores results.
+
+"""
+
+# Built-in
+from __future__ import annotations
+
+from typing import Any
+
+# Third-party
+import numpy as np
+from numpy.typing import NDArray
+from scipy.stats import norm
+
+# Local
+from fynance.core import PriceSeries
+
+__all__ = [
+    'permutation_test',
+    'probabilistic_sharpe_ratio',
+    'deflated_sharpe_ratio',
+]
+
+# Euler-Mascheroni constant (for the expected maximum of N Gaussians).
+_EULER = 0.5772156649015329
+
+
+def _to_array(data: Any) -> NDArray[np.float64]:
+    """ Coerce a PriceSeries / array-like to a 1-D float64 array. """
+    if isinstance(data, PriceSeries):
+        return data.to_numpy()
+
+    return np.asarray(data, dtype=np.float64).reshape(-1)
+
+
+def permutation_test(
+    strategy: Any,
+    data: Any,
+    *,
+    metric: str = "sharpe",
+    n_permutations: int = 200,
+    seed: int = 0,
+) -> dict[str, float]:
+    """ Permutation test for a spurious edge.
+
+    Runs the strategy on the real series, then on ``n_permutations`` shuffles of
+    the asset's returns (which destroys any temporal structure). If the strategy
+    scores as well on shuffled data as on the real data, its edge is not real.
+
+    Parameters
+    ----------
+    strategy : fynance.strategy.Strategy
+        The strategy to evaluate.
+    data : PriceSeries or array-like
+        Price series.
+    metric : str
+        Metric key from the run summary (default ``"sharpe"``).
+    n_permutations : int
+        Number of shuffles forming the null distribution.
+    seed : int
+        Seed for the shuffles and the runs.
+
+    Returns
+    -------
+    dict
+        ``observed``, ``p_value``, ``null_mean``, ``null_std``. The p-value is the
+        (smoothed) fraction of shuffles scoring at least the observed metric.
+
+    """
+    # Imported here to avoid a runner <-> guards import cycle at module load.
+    from fynance.research.runner import run_experiment
+
+    prices = _to_array(data)
+    log_ret = np.diff(np.log(prices))
+    s0 = float(prices[0])
+
+    observed = run_experiment(strategy, prices, name="observed",
+                              seed=seed).metrics[metric]
+
+    rng = np.random.default_rng(seed)
+    null = np.empty(n_permutations, dtype=np.float64)
+    for i in range(n_permutations):
+        shuffled = rng.permutation(log_ret)
+        path = s0 * np.exp(np.concatenate([[0.0], np.cumsum(shuffled)]))
+        null[i] = run_experiment(strategy, path, name="perm",
+                                 seed=seed).metrics[metric]
+
+    # Smoothed p-value (never exactly 0): (#{null >= observed} + 1) / (n + 1).
+    p_value = float((np.sum(null >= observed) + 1) / (n_permutations + 1))
+
+    return {
+        "observed": float(observed),
+        "p_value": p_value,
+        "null_mean": float(null.mean()),
+        "null_std": float(null.std()),
+    }
+
+
+def probabilistic_sharpe_ratio(
+    sr: float,
+    n_obs: int,
+    *,
+    sr_benchmark: float = 0.0,
+    skew: float = 0.0,
+    kurt: float = 3.0,
+) -> float:
+    """ Probabilistic Sharpe ratio (PSR).
+
+    The probability that the true Sharpe exceeds ``sr_benchmark`` given the
+    estimate ``sr`` from ``n_obs`` observations, correcting for the returns'
+    skewness and kurtosis (Bailey & López de Prado).
+
+    Parameters
+    ----------
+    sr : float
+        Observed (non-annualized) Sharpe ratio.
+    n_obs : int
+        Number of return observations.
+    sr_benchmark : float
+        Benchmark Sharpe to beat.
+    skew : float
+        Skewness of the returns.
+    kurt : float
+        Kurtosis of the returns (3 for a normal distribution).
+
+    Returns
+    -------
+    float
+        PSR in ``[0, 1]``.
+
+    """
+    if n_obs <= 1:
+        return float("nan")
+
+    denom = np.sqrt(1.0 - skew * sr + (kurt - 1.0) / 4.0 * sr**2)
+    z = (sr - sr_benchmark) * np.sqrt(n_obs - 1) / denom
+
+    return float(norm.cdf(z))
+
+
+def deflated_sharpe_ratio(
+    sr: float,
+    n_obs: int,
+    n_trials: int,
+    *,
+    skew: float = 0.0,
+    kurt: float = 3.0,
+    sr_variance: float = 1.0,
+) -> float:
+    """ Deflated Sharpe ratio (DSR).
+
+    The PSR against a benchmark set to the **expected maximum** Sharpe of
+    ``n_trials`` independent strategies — i.e. the probability the edge survives
+    the multiple testing implied by trying ``n_trials`` strategies.
+
+    Parameters
+    ----------
+    sr : float
+        Observed (non-annualized) Sharpe ratio of the selected strategy.
+    n_obs : int
+        Number of return observations.
+    n_trials : int
+        Number of strategy configurations tried.
+    skew, kurt : float
+        Skewness / kurtosis of the selected strategy's returns.
+    sr_variance : float
+        Variance of the Sharpe estimates **across the trials**.
+
+    Returns
+    -------
+    float
+        DSR in ``[0, 1]``. Low values flag a likely overfit selection.
+
+    """
+    n = max(int(n_trials), 1)
+    if n == 1:
+        sr_star = 0.0
+    else:
+        # Expected max of N i.i.d. standard normals, scaled by the SR dispersion.
+        gauss_max = ((1 - _EULER) * norm.ppf(1 - 1.0 / n)
+                     + _EULER * norm.ppf(1 - 1.0 / (n * np.e)))
+        sr_star = float(np.sqrt(sr_variance) * gauss_max)
+
+    return probabilistic_sharpe_ratio(
+        sr, n_obs, sr_benchmark=sr_star, skew=skew, kurt=kurt
+    )

--- a/fynance/tests/research/test_guards.py
+++ b/fynance/tests/research/test_guards.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Tests for :mod:`fynance.research.guards`. """
+
+# Third-party
+import numpy as np
+import pytest
+
+# Local
+from fynance.research import (
+    deflated_sharpe_ratio,
+    gbm,
+    permutation_test,
+    probabilistic_sharpe_ratio,
+)
+from fynance.research.guards import _to_array  # noqa: F401 — coverage of helper
+from fynance.strategy import Strategy
+
+
+def momentum() -> Strategy:
+    """ Causal sign-of-recent-change momentum. """
+    return Strategy(features=lambda p: np.diff(p, prepend=p[0]))
+
+
+# -- probabilistic / deflated Sharpe (deterministic) -----------------------
+
+def test_psr_bounds_and_midpoint():
+    assert probabilistic_sharpe_ratio(0.0, 100) == pytest.approx(0.5)
+    val = probabilistic_sharpe_ratio(0.2, 250)
+    assert 0.0 <= val <= 1.0
+
+
+def test_psr_monotonic_in_sharpe_and_n():
+    assert (probabilistic_sharpe_ratio(0.3, 250)
+            > probabilistic_sharpe_ratio(0.1, 250))
+    assert (probabilistic_sharpe_ratio(0.2, 1000)
+            > probabilistic_sharpe_ratio(0.2, 100))
+
+
+def test_dsr_equals_psr_at_one_trial():
+    sr, n = 0.25, 500
+    assert deflated_sharpe_ratio(sr, n, 1) == pytest.approx(
+        probabilistic_sharpe_ratio(sr, n, sr_benchmark=0.0)
+    )
+
+
+def test_dsr_decreases_with_more_trials():
+    sr, n = 0.25, 500
+    few = deflated_sharpe_ratio(sr, n, 1)
+    many = deflated_sharpe_ratio(sr, n, 100)
+    assert many < few
+    assert 0.0 <= many <= 1.0
+
+
+# -- permutation test ------------------------------------------------------
+
+def test_permutation_structure_and_determinism():
+    out1 = permutation_test(momentum(), gbm(300, seed=1), n_permutations=30, seed=4)
+    out2 = permutation_test(momentum(), gbm(300, seed=1), n_permutations=30, seed=4)
+
+    assert set(out1) == {"observed", "p_value", "null_mean", "null_std"}
+    assert 0.0 < out1["p_value"] <= 1.0
+    assert out1 == out2  # fully reproducible
+
+
+def test_permutation_detects_autocorrelation_edge():
+    # AR(1) returns with positive autocorrelation -> momentum has a real edge;
+    # shuffling destroys the autocorrelation, so the edge should be significant.
+    rng = np.random.default_rng(0)
+    n = 1200
+    r = np.zeros(n)
+    for t in range(1, n):
+        r[t] = 0.35 * r[t - 1] + 0.01 * rng.standard_normal()
+    prices = 100.0 * np.exp(np.cumsum(r))
+
+    out = permutation_test(momentum(), prices, n_permutations=200, seed=0)
+
+    assert out["observed"] > out["null_mean"]
+    assert out["p_value"] < 0.10


### PR DESCRIPTION
First leaf of **S2** (guardrails) — statistical robustness for AI-driven search.

- `permutation_test(strategy, data, *, metric, n_permutations, seed)` — shuffles the asset's returns, builds a null distribution of the metric, returns `{observed, p_value, null_mean, null_std}`. Catches a **spurious edge / leakage**.
- `probabilistic_sharpe_ratio(sr, n_obs, *, sr_benchmark, skew, kurt)` and `deflated_sharpe_ratio(sr, n_obs, n_trials, ...)` (Bailey & López de Prado) — does the edge survive the **number of trials**?

Verified: AR(1) autocorrelation edge → p=0.005 (caught); GBM null → not significant; DSR strictly decreases with trials and equals PSR at one trial.

### Test plan
- `pytest` → **533 passed, 1 skipped** (+6); `ruff`/`mypy` clean; `sphinx-build -W` ok (3 stubs committed).