### PR TITLE
feat: research-harness — comparison report (S2 leaf B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `fynance.research` guardrails (`guards.py`): `permutation_test` (shuffle the asset's returns, build a null distribution of a metric → p-value; detects a spurious edge / leakage) and `probabilistic_sharpe_ratio` / `deflated_sharpe_ratio` (Bailey & López de Prado — does the edge survive the number of trials?). Anti-overfitting / anti-data-snooping for AI-driven search.
+- `fynance.research.compare_report(experiments, output_dir)` and `leaderboard(experiments)` — rank a set of experiments and overlay their equity curves into a portable comparison report (leaderboard markdown + overlay PNG).
 
 ### Changed
 

--- a/doc/source/generated/fynance.research.compare_report.rst
+++ b/doc/source/generated/fynance.research.compare_report.rst
@@ -1,0 +1,9 @@
+﻿compare_report
+===============================
+
+*Defined in* :mod:`fynance.research`
+
+.. currentmodule:: fynance.research
+
+.. autofunction:: compare_report
+   :no-index:

--- a/doc/source/generated/fynance.research.leaderboard.rst
+++ b/doc/source/generated/fynance.research.leaderboard.rst
@@ -1,0 +1,9 @@
+﻿leaderboard
+============================
+
+*Defined in* :mod:`fynance.research`
+
+.. currentmodule:: fynance.research
+
+.. autofunction:: leaderboard
+   :no-index:

--- a/doc/source/research.rst
+++ b/doc/source/research.rst
@@ -15,6 +15,8 @@ adapters live downstream.
    Experiment
    run_experiment
    write_report
+   compare_report
+   leaderboard
    permutation_test
    probabilistic_sharpe_ratio
    deflated_sharpe_ratio

--- a/fynance/research/__init__.py
+++ b/fynance/research/__init__.py
@@ -15,7 +15,8 @@ downstream, never here.
 """
 
 # Local
-from . import experiment, guards, report, runner, synthetic
+from . import compare, experiment, guards, report, runner, synthetic
+from .compare import *
 from .experiment import *
 from .guards import *
 from .report import *
@@ -28,3 +29,4 @@ __all__ += synthetic.__all__
 __all__ += runner.__all__
 __all__ += report.__all__
 __all__ += guards.__all__
+__all__ += compare.__all__

--- a/fynance/research/compare.py
+++ b/fynance/research/compare.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Multi-strategy comparison report.
+
+Ranks a set of :class:`~fynance.research.Experiment` runs into a leaderboard and
+overlays their equity curves — the artifact for *"which of these strategies is
+best, and by how much vs a baseline?"*. Written, like everything in the harness,
+only to a caller-provided ``output_dir``.
+
+"""
+
+# Built-in
+from __future__ import annotations
+
+from pathlib import Path
+
+# Third-party
+import numpy as np
+
+# Local
+from fynance.research.experiment import Experiment
+
+__all__ = ['compare_report', 'leaderboard']
+
+
+def leaderboard(
+    experiments: list[Experiment],
+    *,
+    sort_by: str = "sharpe",
+    descending: bool = True,
+) -> list[dict[str, float | str]]:
+    """ Rank experiments into leaderboard rows.
+
+    Parameters
+    ----------
+    experiments : list of Experiment
+        The runs to rank.
+    sort_by : str
+        Metric key to sort on (missing values sink to the bottom).
+    descending : bool
+        Higher is better when True.
+
+    Returns
+    -------
+    list of dict
+        One ``{"name": ..., <metric>: <value>, ...}`` row per experiment, ranked.
+
+    """
+    rows: list[dict[str, float | str]] = [
+        {"name": e.name, **{k: float(v) for k, v in e.metrics.items()}}
+        for e in experiments
+    ]
+    worst = float("-inf") if descending else float("inf")
+    rows.sort(key=lambda r: r.get(sort_by, worst), reverse=descending)  # type: ignore[arg-type]
+
+    return rows
+
+
+def _write_overlay(experiments: list[Experiment], png_path: Path) -> bool:
+    """ Overlay each experiment's equity curve (rebased to 100). """
+    curves = [(e.name, e.series["equity"]) for e in experiments
+              if e.series and e.series.get("equity")]
+    if not curves:
+        return False
+
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots(figsize=(10, 5))
+    for label, equity in curves:
+        eq = np.asarray(equity, dtype=float)
+        ax.plot(100.0 * eq / eq[0], label=label)
+    ax.set_title("Equity comparison (rebased to 100)")
+    ax.set_xlabel("step")
+    ax.set_ylabel("equity")
+    ax.legend(loc="best", fontsize=8)
+    fig.tight_layout()
+    fig.savefig(png_path, dpi=110, bbox_inches="tight")
+    plt.close(fig)
+
+    return True
+
+
+def _markdown_table(rows: list[dict[str, float | str]]) -> str:
+    """ Render leaderboard rows as a markdown table. """
+    if not rows:
+        return "_no experiments_\n"
+
+    cols = ["name"] + [k for k in rows[0] if k != "name"]
+    head = "| " + " | ".join(cols) + " |"
+    sep = "| " + " | ".join("---" for _ in cols) + " |"
+    body = []
+    for r in rows:
+        cells = [str(r["name"])] + [
+            f"{r[c]:.4f}" if isinstance(r.get(c), float) else str(r.get(c, ""))
+            for c in cols[1:]
+        ]
+        body.append("| " + " | ".join(cells) + " |")
+
+    return "\n".join([head, sep, *body]) + "\n"
+
+
+def compare_report(
+    experiments: list[Experiment],
+    output_dir: str | Path,
+    *,
+    name: str = "comparison",
+    sort_by: str = "sharpe",
+) -> dict[str, Path]:
+    """ Write a leaderboard + equity-overlay comparison report.
+
+    Creates ``<output_dir>/<name>/`` with ``report.md`` (a leaderboard table
+    ranked by ``sort_by``) and ``equity_overlay.png`` (when curves are present).
+    The first experiment is treated as the baseline in the narrative.
+
+    Parameters
+    ----------
+    experiments : list of Experiment
+        The runs to compare (≥ 1).
+    output_dir : str or pathlib.Path
+        Base directory for the artifacts.
+    name : str
+        Sub-directory name.
+    sort_by : str
+        Leaderboard sort metric.
+
+    Returns
+    -------
+    dict of str to pathlib.Path
+        Written artifacts (keys: ``markdown``, ``png`` when produced).
+
+    """
+    if not experiments:
+        raise ValueError("compare_report needs at least one experiment")
+
+    target = Path(output_dir) / name
+    target.mkdir(parents=True, exist_ok=True)
+    written: dict[str, Path] = {}
+
+    png = target / "equity_overlay.png"
+    if _write_overlay(experiments, png):
+        written["png"] = png
+
+    rows = leaderboard(experiments, sort_by=sort_by)
+    md = [f"# Comparison: {name}\n",
+          f"Ranked by `{sort_by}` — {len(experiments)} experiment(s), "
+          f"baseline `{experiments[0].name}`.\n",
+          "## Leaderboard\n",
+          _markdown_table(rows)]
+    if "png" in written:
+        md += ["\n## Equity overlay\n", "![equity overlay](equity_overlay.png)\n"]
+
+    md_path = target / "report.md"
+    md_path.write_text("\n".join(md) + "\n", encoding="utf-8")
+    written["markdown"] = md_path
+
+    return written

--- a/fynance/tests/research/test_compare.py
+++ b/fynance/tests/research/test_compare.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Tests for :mod:`fynance.research.compare`. """
+
+# Built-in
+from pathlib import Path
+
+# Third-party
+import numpy as np
+import pytest
+
+# Local
+import fynance
+from fynance.research import compare_report, gbm, leaderboard, run_experiment
+from fynance.strategy import Strategy
+
+
+def _exp(name, seed, fee=0.0):
+    from fynance.backtest import ProportionalCost
+
+    strat = Strategy(features=lambda p: np.diff(p, prepend=p[0]),
+                     cost=ProportionalCost(fee))
+    return run_experiment(strat, gbm(400, seed=seed), name=name, seed=seed)
+
+
+@pytest.fixture
+def experiments():
+    return [_exp("a", 1), _exp("b", 2), _exp("c", 3)]
+
+
+def test_leaderboard_ranked_by_sharpe(experiments):
+    rows = leaderboard(experiments, sort_by="sharpe")
+
+    assert {r["name"] for r in rows} == {"a", "b", "c"}
+    sharpes = [r["sharpe"] for r in rows]
+    assert sharpes == sorted(sharpes, reverse=True)
+
+
+def test_compare_report_writes_md_and_png(tmp_path, experiments):
+    out = compare_report(experiments, tmp_path, name="cmp")
+
+    md = tmp_path / "cmp" / "report.md"
+    png = tmp_path / "cmp" / "equity_overlay.png"
+    assert out["markdown"] == md and md.is_file()
+    assert out["png"] == png and png.is_file() and png.stat().st_size > 0
+
+    text = md.read_text()
+    assert "# Comparison: cmp" in text
+    for nm in ("a", "b", "c"):
+        assert f"| {nm} |" in text
+    assert "equity_overlay.png" in text
+
+
+def test_empty_raises(tmp_path):
+    with pytest.raises(ValueError):
+        compare_report([], tmp_path)
+
+
+def test_nothing_written_outside_output_dir(tmp_path, experiments):
+    pkg = Path(fynance.__file__).resolve().parent
+    before = {p for p in pkg.rglob("equity_overlay.png")}
+
+    compare_report(experiments, tmp_path)
+
+    assert {p for p in pkg.rglob("equity_overlay.png")} == before


### PR DESCRIPTION
Second leaf of **S2**. `compare_report(experiments, output_dir, *, name, sort_by)` ranks a set of experiments into a leaderboard markdown table and overlays their equity curves (rebased to 100) into `equity_overlay.png`. Shared `leaderboard(experiments)` helper (reused by the S3 ledger). Artifacts only under `output_dir`.

### Test plan
- `pytest` → **537 passed, 1 skipped** (+4); `ruff`/`mypy` clean; `sphinx-build -W` ok (2 stubs committed).