### PR TITLE
feat: research-harness — ledger (S3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `fynance.research` guardrails (`guards.py`): `permutation_test` (shuffle the asset's returns, build a null distribution of a metric → p-value; detects a spurious edge / leakage) and `probabilistic_sharpe_ratio` / `deflated_sharpe_ratio` (Bailey & López de Prado — does the edge survive the number of trials?). Anti-overfitting / anti-data-snooping for AI-driven search.
 - `fynance.research.compare_report(experiments, output_dir)` and `leaderboard(experiments)` — rank a set of experiments and overlay their equity curves into a portable comparison report (leaderboard markdown + overlay PNG).
+- `fynance.research.Ledger(root)` — a persistent experiment store: `append`/`load`/`leaderboard`, an `n_trials` count, and `deflated_sharpe(experiment)` that judges a selected strategy against the ledger's trial count and Sharpe dispersion. The store lives entirely under the caller's `root`.
 
 ### Changed
 

--- a/doc/source/generated/fynance.research.Ledger.rst
+++ b/doc/source/generated/fynance.research.Ledger.rst
@@ -1,0 +1,13 @@
+﻿Ledger
+=======================
+
+*Defined in* :mod:`fynance.research`
+
+.. currentmodule:: fynance.research
+
+.. autoclass:: Ledger
+   :members:
+   :inherited-members:
+   :special-members: __call__, __iter__, __next__
+   :show-inheritance:
+   :no-index:

--- a/doc/source/research.rst
+++ b/doc/source/research.rst
@@ -13,6 +13,7 @@ adapters live downstream.
    :toctree: generated/
 
    Experiment
+   Ledger
    run_experiment
    write_report
    compare_report

--- a/fynance/research/__init__.py
+++ b/fynance/research/__init__.py
@@ -15,10 +15,11 @@ downstream, never here.
 """
 
 # Local
-from . import compare, experiment, guards, report, runner, synthetic
+from . import compare, experiment, guards, ledger, report, runner, synthetic
 from .compare import *
 from .experiment import *
 from .guards import *
+from .ledger import *
 from .report import *
 from .runner import *
 from .synthetic import *
@@ -30,3 +31,4 @@ __all__ += runner.__all__
 __all__ += report.__all__
 __all__ += guards.__all__
 __all__ += compare.__all__
+__all__ += ledger.__all__

--- a/fynance/research/ledger.py
+++ b/fynance/research/ledger.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Persistent experiment ledger.
+
+A :class:`Ledger` turns one-off runs into **cumulative** research: it persists
+experiments under a caller-provided ``root``, reloads them, ranks them into a
+leaderboard, and tracks the **number of trials** — which it can feed into the
+deflated Sharpe ratio so a selected strategy is judged against the multiple
+testing it came from. The store lives entirely under ``root`` (the caller's
+private repo) — never inside fynance.
+
+"""
+
+# Built-in
+from __future__ import annotations
+
+from pathlib import Path
+
+# Third-party
+import numpy as np
+
+# Local
+from fynance.research.compare import leaderboard
+from fynance.research.experiment import Experiment
+from fynance.research.guards import deflated_sharpe_ratio
+
+__all__ = ['Ledger']
+
+
+class Ledger:
+    """ A persistent, append-only store of experiments under ``root``.
+
+    Parameters
+    ----------
+    root : str or pathlib.Path
+        Directory the experiments live under (created on demand). Each experiment
+        is stored at ``<root>/<name>/experiment.json``.
+
+    Examples
+    --------
+    >>> import tempfile
+    >>> from fynance.research import Experiment, Ledger
+    >>> d = tempfile.mkdtemp()
+    >>> led = Ledger(d)
+    >>> _ = led.append(Experiment(name="a", metrics={"sharpe": 1.0}))
+    >>> _ = led.append(Experiment(name="b", metrics={"sharpe": 2.0}))
+    >>> led.n_trials
+    2
+    >>> [r["name"] for r in led.leaderboard()]
+    ['b', 'a']
+
+    """
+
+    def __init__(self, root: str | Path):
+        self.root = Path(root)
+
+    def append(self, experiment: Experiment) -> Path:
+        """ Persist ``experiment`` under the ledger root; return its json path. """
+        self.root.mkdir(parents=True, exist_ok=True)
+
+        return experiment.save(self.root)
+
+    def load(self) -> list[Experiment]:
+        """ Load every stored experiment (sorted by name for determinism). """
+        if not self.root.exists():
+            return []
+
+        return [Experiment.load(p)
+                for p in sorted(self.root.glob("*/experiment.json"))]
+
+    @property
+    def n_trials(self) -> int:
+        """ Number of experiments in the ledger (the multiple-testing count). """
+        if not self.root.exists():
+            return 0
+
+        return sum(1 for _ in self.root.glob("*/experiment.json"))
+
+    def leaderboard(self, *, sort_by: str = "sharpe",
+                    descending: bool = True) -> list[dict[str, float | str]]:
+        """ Rank the stored experiments (see :func:`fynance.research.leaderboard`). """
+        return leaderboard(self.load(), sort_by=sort_by, descending=descending)
+
+    def deflated_sharpe(self, experiment: Experiment,
+                        metric: str = "sharpe") -> float:
+        """ Deflated Sharpe of ``experiment`` against the ledger's trial count.
+
+        Uses the ledger's :attr:`n_trials` as the number of trials and the
+        dispersion of the stored Sharpe metrics as the trial variance, so a
+        selected strategy is judged against the multiple testing it came from.
+        """
+        sharpes = [float(e.metrics[metric]) for e in self.load()
+                   if metric in e.metrics]
+        sr_variance = float(np.var(sharpes)) if len(sharpes) > 1 else 1.0
+
+        n_obs = len(experiment.series["returns"]) if (
+            experiment.series and experiment.series.get("returns")) else 0
+
+        return deflated_sharpe_ratio(
+            float(experiment.metrics[metric]), n_obs, max(self.n_trials, 1),
+            sr_variance=sr_variance,
+        )

--- a/fynance/tests/research/test_ledger.py
+++ b/fynance/tests/research/test_ledger.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Tests for :class:`fynance.research.Ledger`. """
+
+# Built-in
+from pathlib import Path
+
+# Third-party
+import numpy as np
+
+# Local
+import fynance
+from fynance.research import Experiment, Ledger, gbm, run_experiment
+from fynance.strategy import Strategy
+
+
+def _exp(name, seed):
+    strat = Strategy(features=lambda p: np.diff(p, prepend=p[0]))
+    return run_experiment(strat, gbm(400, seed=seed), name=name, seed=seed)
+
+
+def test_append_load_roundtrip(tmp_path):
+    led = Ledger(tmp_path)
+    led.append(_exp("a", 1))
+    led.append(_exp("b", 2))
+
+    loaded = led.load()
+    assert {e.name for e in loaded} == {"a", "b"}
+    assert led.n_trials == 2
+    assert (tmp_path / "a" / "experiment.json").is_file()
+
+
+def test_empty_ledger(tmp_path):
+    led = Ledger(tmp_path / "nope")
+    assert led.load() == []
+    assert led.n_trials == 0
+
+
+def test_leaderboard_ranked(tmp_path):
+    led = Ledger(tmp_path)
+    for nm, sd in [("a", 1), ("b", 2), ("c", 3)]:
+        led.append(_exp(nm, sd))
+
+    rows = led.leaderboard(sort_by="sharpe")
+    sharpes = [r["sharpe"] for r in rows]
+    assert sharpes == sorted(sharpes, reverse=True)
+
+
+def test_deflated_sharpe_uses_trial_count(tmp_path):
+    led = Ledger(tmp_path)
+    exps = [_exp(n, s) for n, s in [("a", 1), ("b", 2), ("c", 3), ("d", 4)]]
+    for e in exps:
+        led.append(e)
+
+    best = max(exps, key=lambda e: e.metrics["sharpe"])
+    dsr = led.deflated_sharpe(best)
+    assert 0.0 <= dsr <= 1.0
+
+
+def test_store_stays_under_root(tmp_path):
+    pkg = Path(fynance.__file__).resolve().parent
+    before = {p for p in pkg.rglob("experiment.json")}
+
+    Ledger(tmp_path).append(_exp("x", 1))
+
+    assert {p for p in pkg.rglob("experiment.json")} == before
+
+
+def test_n_trials_counts_only_experiments(tmp_path):
+    # A stray sub-dir without experiment.json must not inflate the count.
+    led = Ledger(tmp_path)
+    led.append(Experiment(name="real", metrics={"sharpe": 1.0}))
+    (tmp_path / "stray").mkdir()
+    (tmp_path / "stray" / "report.md").write_text("noise")
+
+    assert led.n_trials == 1


### PR DESCRIPTION
**S3** — `Ledger(root)`, a persistent experiment store that makes research cumulative.

- `append` / `load` / `leaderboard` over a caller-provided `root` (each experiment at `<root>/<name>/experiment.json`).
- `n_trials` — the multiple-testing count (counts only real `experiment.json` files).
- `deflated_sharpe(experiment)` — judges a selected strategy against the ledger's trial count and Sharpe dispersion (closes the loop with the S2 guardrails).
- Store lives entirely under `root` — never in fynance.

### Test plan
- `pytest` → **544 passed, 1 skipped** (+7); doctest on `Ledger`; `ruff`/`mypy` clean; `sphinx-build -W` ok (stub committed).