### PR TITLE
docs: mark research-harness S2+S3 done

### DIFF
--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -33,13 +33,16 @@ so an agent doesn't re-investigate settled ground or assume a known stub is a bu
 - **Backtest / Plot**: vectorized `backtest()` engine → `BacktestResult`,
   `ProportionalCost`; reporting via `fynance.plot` (`tearsheet`, composable
   figures, lazy matplotlib so `import fynance` stays matplotlib-free).
-- **Research harness** (`fynance.research`, S1): `Experiment` (serializable
-  spec + code + seed + metrics + curves), `run_experiment` (seeded, cost-aware,
-  walk-forward; no-lookahead probe), `write_report` (portable markdown + tearsheet
-  PNG + notebook), and `gbm`/`regime_switching` synthetic generators. **Data-agnostic
-  and result-free**: artifacts only go to a caller-provided `output_dir`; real data
-  + result storage live in a separate private repo. Driven by the user-level
-  `/run-strategy` skill. Guardrails (S2) and ledger (S3) are pending.
+- **Research harness** (`fynance.research`, S1–S3 complete): `Experiment`
+  (serializable spec + code + seed + metrics + curves), `run_experiment` (seeded,
+  cost-aware, walk-forward; no-lookahead probe), `write_report` (portable markdown +
+  tearsheet PNG + notebook), `gbm`/`regime_switching` synthetic generators,
+  **guardrails** (`permutation_test`, `probabilistic_sharpe_ratio`,
+  `deflated_sharpe_ratio`), comparison report (`compare_report`/`leaderboard`) and a
+  persistent `Ledger` (append/load/leaderboard, `n_trials`, deflated-Sharpe vs
+  trials). **Data-agnostic and result-free**: artifacts only go to a caller-provided
+  `output_dir`; real data + result storage live in a separate private repo. Driven
+  by the user-level `/run-strategy` skill.
 - **Numerical kernels on Numba `@njit`** — no Cython anywhere; the build is
   pure-Python (no `setup.py`, no compile step). Every kernel has a golden-value
   parity test (1e-9/1e-10) captured from the former Cython.
@@ -57,9 +60,9 @@ so an agent doesn't re-investigate settled ground or assume a known stub is a bu
   normalization on real out-of-sample data, market-regime conditioning, and
   multi-series OHLCV indicators — see the roadmap (§1). Most items are blocked on
   having a real dataset / orchestration rather than on missing code.
-- **Research harness** (roadmap §2): S1 shipped (above); **S2 guardrails**
-  (shuffle/permutation test, deflated Sharpe, trials counter) and **S3 ledger**
-  (save/load/compare → leaderboard) are next.
+- **Research harness** (roadmap §2): S1–S3 shipped (above). Optional next: a
+  Streamlit explorer over the ledger; real-data adapters + result storage live in
+  the separate private research repo, not here.
 
 ## Known gaps / sharp edges (by design or deferred)
 

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -19,24 +19,18 @@ shipped, `03-decisions.md` for *why*. Keep it short and true.
 
 ---
 
-## 2. Research harness — outillage R&D piloté par l'IA  ⭐ active
+## 2. Research harness — extensions optionnelles
 
-Faire de fynance le **substrat** qu'un agent (Claude Code) pilote pour tester des
-stratégies et produire des **artefacts de résultats portables**. fynance =
-**l'outil seulement** : les expériences sur vraie data et leurs **résultats sont
-stockés dans un repo privé séparé** qui dépend de fynance — *jamais* dans fynance.
-Data-agnostique : construit et testé sur un **générateur synthétique** (la vraie
-data est injectée en aval). Plan détaillé : `doc/dev/plans/research-harness/`.
+Le harnais R&D `fynance.research` est **livré** (S1–S3) : `Experiment`,
+`run_experiment`, `write_report`, générateurs synthétiques, garde-fous
+(`permutation_test`, `deflated_sharpe_ratio`) et `Ledger`/`leaderboard` — piloté
+par la skill `/run-strategy`. Voir `CHANGELOG.md`. Data-agnostique et sans
+stockage de résultats (tout vers un `output_dir`). Restent optionnels :
 
-- [ ] **S2 garde-fous** — shuffle/permutation test, intégration purged walk-forward,
-  **deflated Sharpe + compteur d'essais** (anti-overfitting), rapport de
-  comparaison multi-stratégies vs baseline.
-- [ ] **S3 ledger** — save/load/compare des expériences (parquet/json) →
-  leaderboard cumulatif.
-
-> Les adaptateurs de vraie data (dccd…) et le stockage des résultats vivent dans
-> le **repo privé** de recherche, pas ici. Un explorateur Streamlit au-dessus du
-> ledger reste optionnel et plus tardif.
+- [ ] Explorateur **Streamlit** au-dessus du ledger (parcourir/filtrer/comparer les
+  runs persistés) — interactif, plus tardif.
+- [ ] (**hors fynance**) adaptateurs de vraie data (dccd…) + stockage des
+  résultats : dans le **repo privé** de recherche qui dépend de fynance.
 
 ## 1. R&D — Loss, architecture, données
 


### PR DESCRIPTION
Closes out **S2** (guardrails: `permutation_test`, `probabilistic_sharpe_ratio`, `deflated_sharpe_ratio`, `compare_report`/`leaderboard`) and **S3** (`Ledger`), shipped across #144–#146. Slims roadmap §2 to the optional remainder (Streamlit ledger explorer; real-data + result storage live in the private repo) and marks the harness complete in `06-status.md`. Docs-only. After merge → release (minor, 2.3.0).