### PR TITLE
Release v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [2.3.0] - 2026-06-17
+
+### Breaking Changes
+
+### Added
+
 - `fynance.research` guardrails (`guards.py`): `permutation_test` (shuffle the asset's returns, build a null distribution of a metric → p-value; detects a spurious edge / leakage) and `probabilistic_sharpe_ratio` / `deflated_sharpe_ratio` (Bailey & López de Prado — does the edge survive the number of trials?). Anti-overfitting / anti-data-snooping for AI-driven search.
 - `fynance.research.compare_report(experiments, output_dir)` and `leaderboard(experiments)` — rank a set of experiments and overlay their equity curves into a portable comparison report (leaderboard markdown + overlay PNG).
 - `fynance.research.Ledger(root)` — a persistent experiment store: `append`/`load`/`leaderboard`, an `n_trials` count, and `deflated_sharpe(experiment)` that judges a selected strategy against the ledger's trial count and Sharpe dispersion. The store lives entirely under the caller's `root`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `fynance.research` guardrails (`guards.py`): `permutation_test` (shuffle the asset's returns, build a null distribution of a metric → p-value; detects a spurious edge / leakage) and `probabilistic_sharpe_ratio` / `deflated_sharpe_ratio` (Bailey & López de Prado — does the edge survive the number of trials?). Anti-overfitting / anti-data-snooping for AI-driven search.
 - `fynance.research.compare_report(experiments, output_dir)` and `leaderboard(experiments)` — rank a set of experiments and overlay their equity curves into a portable comparison report (leaderboard markdown + overlay PNG).
+- `fynance.research.Ledger(root)` — a persistent experiment store: `append`/`load`/`leaderboard`, an `n_trials` count, and `deflated_sharpe(experiment)` that judges a selected strategy against the ledger's trial count and Sharpe dispersion. The store lives entirely under the caller's `root`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `fynance.research` guardrails (`guards.py`): `permutation_test` (shuffle the asset's returns, build a null distribution of a metric → p-value; detects a spurious edge / leakage) and `probabilistic_sharpe_ratio` / `deflated_sharpe_ratio` (Bailey & López de Prado — does the edge survive the number of trials?). Anti-overfitting / anti-data-snooping for AI-driven search.
+- `fynance.research.compare_report(experiments, output_dir)` and `leaderboard(experiments)` — rank a set of experiments and overlay their equity curves into a portable comparison report (leaderboard markdown + overlay PNG).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `fynance.research` guardrails (`guards.py`): `permutation_test` (shuffle the asset's returns, build a null distribution of a metric → p-value; detects a spurious edge / leakage) and `probabilistic_sharpe_ratio` / `deflated_sharpe_ratio` (Bailey & López de Prado — does the edge survive the number of trials?). Anti-overfitting / anti-data-snooping for AI-driven search.
+
 ### Changed
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ Calmar, Omega, directional, hybrid), and robust-training utilities.
 **Strategy** `fynance.strategy` — optional orchestrator composing the maillons
 end-to-end, with single-run and walk-forward evaluation.
 
+**Research** `fynance.research` — data-agnostic experiment harness: `Experiment`
+(serializable run record), `run_experiment` (seeded, cost-aware, walk-forward),
+`write_report` (portable markdown + tearsheet PNG + notebook) and synthetic data
+generators (`gbm`, `regime_switching`). Results are written only to a
+caller-provided `output_dir` — fynance never stores them itself.
+
 ## Quick start
 
 ```python

--- a/badges/interrogate_badge.svg
+++ b/badges/interrogate_badge.svg
@@ -1,5 +1,5 @@
 <svg width="140" height="20" viewBox="0 0 140 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <title>interrogate: 93.9%</title>
+    <title>interrogate: 94.0%</title>
     <g transform="matrix(1,0,0,1,22,0)">
         <g id="backgrounds" transform="matrix(1.32789,0,0,1,-22.3892,0)">
             <rect x="0" y="0" width="71" height="20" style="fill:rgb(85,85,85);"/>
@@ -12,8 +12,8 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
         <text x="590" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="610">interrogate</text>
         <text x="590" y="140" transform="scale(.1)" textLength="610">interrogate</text>
-        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">93.9%</text>
-        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">93.9%</text>
+        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">94.0%</text>
+        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">94.0%</text>
     </g>
     <g id="logo-shadow" serif:id="logo shadow" transform="matrix(0.854876,0,0,0.854876,-6.73514,1.732)">
         <g transform="matrix(0.299012,0,0,0.299012,9.70229,-6.68582)">

--- a/badges/interrogate_badge.svg
+++ b/badges/interrogate_badge.svg
@@ -1,5 +1,5 @@
 <svg width="140" height="20" viewBox="0 0 140 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <title>interrogate: 94.0%</title>
+    <title>interrogate: 94.1%</title>
     <g transform="matrix(1,0,0,1,22,0)">
         <g id="backgrounds" transform="matrix(1.32789,0,0,1,-22.3892,0)">
             <rect x="0" y="0" width="71" height="20" style="fill:rgb(85,85,85);"/>
@@ -12,8 +12,8 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
         <text x="590" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="610">interrogate</text>
         <text x="590" y="140" transform="scale(.1)" textLength="610">interrogate</text>
-        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">94.0%</text>
-        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">94.0%</text>
+        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">94.1%</text>
+        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">94.1%</text>
     </g>
     <g id="logo-shadow" serif:id="logo shadow" transform="matrix(0.854876,0,0,0.854876,-6.73514,1.732)">
         <g transform="matrix(0.299012,0,0,0.299012,9.70229,-6.68582)">

--- a/doc/dev/01-overview.md
+++ b/doc/dev/01-overview.md
@@ -23,6 +23,9 @@ analysis and backtesting**. Since 2.0 it is a **layered backtesting tool**
   PyTorch losses (Sharpe/Sortino/Calmar/Omega/directional/hybrid).
 - **Backtest / Plot / Strategy** — vectorized engine + cost models →
   `BacktestResult`; `tearsheet` reporting; optional `Strategy` orchestrator.
+- **Research** — data-agnostic experiment harness (`Experiment`,
+  `run_experiment`, `write_report`, synthetic generators) emitting portable result
+  artifacts to a caller-provided `output_dir`; fynance never stores results itself.
 
 The throughline is **strict temporal causality**: every rolling feature and every
 training window is computed from the past only — no lookahead. This is the
@@ -60,6 +63,8 @@ fynance/
   backtest/    # vectorized engine + cost + result; legacy live-viz plot stack
   plot/        # composable matplotlib figures + tearsheet (lazy import)
   strategy/    # optional Strategy orchestrator + walk-forward run
+  research/    # data-agnostic experiment harness: Experiment, run_experiment,
+               #   write_report, synthetic generators (results -> output_dir only)
   estimator/   # ARMA/GARCH parameter estimation (Numba)
   tests/       # mirrors the package; pytest + doctests
 doc/

--- a/doc/dev/02-architecture.md
+++ b/doc/dev/02-architecture.md
@@ -6,6 +6,9 @@ or models out. The structure is by *concern*, wired through `typing.Protocol`
 seams, with a shared causal-windowing pattern running through it.
 
 ```
+research            experiment harness: run_experiment → Experiment → write_report
+   │  drives           (data-agnostic; artifacts -> caller's output_dir only)
+   ▼
 strategy            optional orchestrator (compose the maillons end-to-end)
    │  composes
    ▼
@@ -47,6 +50,10 @@ stability policy per package.)
   kept for `RollMultiLayerPerceptron` but off the eager public surface.
 - **`plot/` · `strategy/`** — composable matplotlib figures + `tearsheet` (lazy
   import); the optional `Strategy` orchestrator + `run_walk_forward`.
+- **`research/`** — data-agnostic experiment harness: `experiment.py`
+  (`Experiment`), `runner.py` (`run_experiment`), `report.py` (`write_report`,
+  lazy matplotlib/nbformat), `synthetic.py` (`gbm`/`regime_switching`). Writes
+  artifacts only to a caller-provided `output_dir`; no real-data dependency.
 - **`estimator/`** — Numba ARMA/GARCH parameter estimation. **Authoritative** —
   parameter logic lives here / in `econometric_models`, not duplicated.
 

--- a/doc/dev/04-subpackages.md
+++ b/doc/dev/04-subpackages.md
@@ -16,6 +16,7 @@ modernisation).
 | `estimator` / `models.econometric_models` | **Single Numba implementation** — do not duplicate parameter logic | One source for ARMA/GARCH estimation |
 | `signal` / `models` | **Modernise freely** (PyTorch) | The active R&D surface |
 | `backtest` / `plot` / `strategy` | **Improve freely** | Engine/reporting/orchestration, no frozen contract |
+| `research` | **Extend freely — but stay data-agnostic & result-free** | The AI-driven R&D harness; must never depend on real data or store results (→ `output_dir` only) |
 
 ## Public API surface (what callers import)
 
@@ -43,6 +44,10 @@ modernisation).
   `run_walk_forward`. (The legacy live-viz objects `PlotBackTest`/
   `DynaPlotBackTest`/`display_perf` remain as lazy submodules, off the eager
   surface.)
+- **`research`** (namespaced as `fynance.research.*`, not flattened) — `Experiment`,
+  `run_experiment`, `write_report`, `gbm`/`regime_switching`. Driven by the
+  user-level `/run-strategy` skill. Artifacts go only to a caller-provided
+  `output_dir`.
 
 ## Known sharp edges (by design)
 

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -33,13 +33,16 @@ so an agent doesn't re-investigate settled ground or assume a known stub is a bu
 - **Backtest / Plot**: vectorized `backtest()` engine → `BacktestResult`,
   `ProportionalCost`; reporting via `fynance.plot` (`tearsheet`, composable
   figures, lazy matplotlib so `import fynance` stays matplotlib-free).
-- **Research harness** (`fynance.research`, S1): `Experiment` (serializable
-  spec + code + seed + metrics + curves), `run_experiment` (seeded, cost-aware,
-  walk-forward; no-lookahead probe), `write_report` (portable markdown + tearsheet
-  PNG + notebook), and `gbm`/`regime_switching` synthetic generators. **Data-agnostic
-  and result-free**: artifacts only go to a caller-provided `output_dir`; real data
-  + result storage live in a separate private repo. Driven by the user-level
-  `/run-strategy` skill. Guardrails (S2) and ledger (S3) are pending.
+- **Research harness** (`fynance.research`, S1–S3 complete): `Experiment`
+  (serializable spec + code + seed + metrics + curves), `run_experiment` (seeded,
+  cost-aware, walk-forward; no-lookahead probe), `write_report` (portable markdown +
+  tearsheet PNG + notebook), `gbm`/`regime_switching` synthetic generators,
+  **guardrails** (`permutation_test`, `probabilistic_sharpe_ratio`,
+  `deflated_sharpe_ratio`), comparison report (`compare_report`/`leaderboard`) and a
+  persistent `Ledger` (append/load/leaderboard, `n_trials`, deflated-Sharpe vs
+  trials). **Data-agnostic and result-free**: artifacts only go to a caller-provided
+  `output_dir`; real data + result storage live in a separate private repo. Driven
+  by the user-level `/run-strategy` skill.
 - **Numerical kernels on Numba `@njit`** — no Cython anywhere; the build is
   pure-Python (no `setup.py`, no compile step). Every kernel has a golden-value
   parity test (1e-9/1e-10) captured from the former Cython.
@@ -57,9 +60,9 @@ so an agent doesn't re-investigate settled ground or assume a known stub is a bu
   normalization on real out-of-sample data, market-regime conditioning, and
   multi-series OHLCV indicators — see the roadmap (§1). Most items are blocked on
   having a real dataset / orchestration rather than on missing code.
-- **Research harness** (roadmap §2): S1 shipped (above); **S2 guardrails**
-  (shuffle/permutation test, deflated Sharpe, trials counter) and **S3 ledger**
-  (save/load/compare → leaderboard) are next.
+- **Research harness** (roadmap §2): S1–S3 shipped (above). Optional next: a
+  Streamlit explorer over the ledger; real-data adapters + result storage live in
+  the separate private research repo, not here.
 
 ## Known gaps / sharp edges (by design or deferred)
 

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -19,24 +19,18 @@ shipped, `03-decisions.md` for *why*. Keep it short and true.
 
 ---
 
-## 2. Research harness — outillage R&D piloté par l'IA  ⭐ active
+## 2. Research harness — extensions optionnelles
 
-Faire de fynance le **substrat** qu'un agent (Claude Code) pilote pour tester des
-stratégies et produire des **artefacts de résultats portables**. fynance =
-**l'outil seulement** : les expériences sur vraie data et leurs **résultats sont
-stockés dans un repo privé séparé** qui dépend de fynance — *jamais* dans fynance.
-Data-agnostique : construit et testé sur un **générateur synthétique** (la vraie
-data est injectée en aval). Plan détaillé : `doc/dev/plans/research-harness/`.
+Le harnais R&D `fynance.research` est **livré** (S1–S3) : `Experiment`,
+`run_experiment`, `write_report`, générateurs synthétiques, garde-fous
+(`permutation_test`, `deflated_sharpe_ratio`) et `Ledger`/`leaderboard` — piloté
+par la skill `/run-strategy`. Voir `CHANGELOG.md`. Data-agnostique et sans
+stockage de résultats (tout vers un `output_dir`). Restent optionnels :
 
-- [ ] **S2 garde-fous** — shuffle/permutation test, intégration purged walk-forward,
-  **deflated Sharpe + compteur d'essais** (anti-overfitting), rapport de
-  comparaison multi-stratégies vs baseline.
-- [ ] **S3 ledger** — save/load/compare des expériences (parquet/json) →
-  leaderboard cumulatif.
-
-> Les adaptateurs de vraie data (dccd…) et le stockage des résultats vivent dans
-> le **repo privé** de recherche, pas ici. Un explorateur Streamlit au-dessus du
-> ledger reste optionnel et plus tardif.
+- [ ] Explorateur **Streamlit** au-dessus du ledger (parcourir/filtrer/comparer les
+  runs persistés) — interactif, plus tardif.
+- [ ] (**hors fynance**) adaptateurs de vraie data (dccd…) + stockage des
+  résultats : dans le **repo privé** de recherche qui dépend de fynance.
 
 ## 1. R&D — Loss, architecture, données
 

--- a/doc/source/generated/fynance.research.Ledger.rst
+++ b/doc/source/generated/fynance.research.Ledger.rst
@@ -1,0 +1,13 @@
+﻿Ledger
+=======================
+
+*Defined in* :mod:`fynance.research`
+
+.. currentmodule:: fynance.research
+
+.. autoclass:: Ledger
+   :members:
+   :inherited-members:
+   :special-members: __call__, __iter__, __next__
+   :show-inheritance:
+   :no-index:

--- a/doc/source/generated/fynance.research.compare_report.rst
+++ b/doc/source/generated/fynance.research.compare_report.rst
@@ -1,0 +1,9 @@
+﻿compare_report
+===============================
+
+*Defined in* :mod:`fynance.research`
+
+.. currentmodule:: fynance.research
+
+.. autofunction:: compare_report
+   :no-index:

--- a/doc/source/generated/fynance.research.deflated_sharpe_ratio.rst
+++ b/doc/source/generated/fynance.research.deflated_sharpe_ratio.rst
@@ -1,0 +1,9 @@
+﻿deflated_sharpe_ratio
+======================================
+
+*Defined in* :mod:`fynance.research`
+
+.. currentmodule:: fynance.research
+
+.. autofunction:: deflated_sharpe_ratio
+   :no-index:

--- a/doc/source/generated/fynance.research.leaderboard.rst
+++ b/doc/source/generated/fynance.research.leaderboard.rst
@@ -1,0 +1,9 @@
+﻿leaderboard
+============================
+
+*Defined in* :mod:`fynance.research`
+
+.. currentmodule:: fynance.research
+
+.. autofunction:: leaderboard
+   :no-index:

--- a/doc/source/generated/fynance.research.permutation_test.rst
+++ b/doc/source/generated/fynance.research.permutation_test.rst
@@ -1,0 +1,9 @@
+﻿permutation_test
+=================================
+
+*Defined in* :mod:`fynance.research`
+
+.. currentmodule:: fynance.research
+
+.. autofunction:: permutation_test
+   :no-index:

--- a/doc/source/generated/fynance.research.probabilistic_sharpe_ratio.rst
+++ b/doc/source/generated/fynance.research.probabilistic_sharpe_ratio.rst
@@ -1,0 +1,9 @@
+﻿probabilistic_sharpe_ratio
+===========================================
+
+*Defined in* :mod:`fynance.research`
+
+.. currentmodule:: fynance.research
+
+.. autofunction:: probabilistic_sharpe_ratio
+   :no-index:

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -72,6 +72,13 @@
       Econometric models, neural networks (MLP, RNN, GRU, LSTM,
       attention, TCN, Transformer) and walk-forward training.
 
+   .. grid-item-card:: :octicon:`beaker;1.2em;sd-mr-1` Research
+      :link: research
+      :link-type: doc
+
+      Data-agnostic experiment harness: run, report and reproduce
+      strategies, emitting portable result artifacts.
+
 .. toctree::
    :hidden:
    :caption: Getting Started

--- a/doc/source/research.rst
+++ b/doc/source/research.rst
@@ -15,5 +15,8 @@ adapters live downstream.
    Experiment
    run_experiment
    write_report
+   permutation_test
+   probabilistic_sharpe_ratio
+   deflated_sharpe_ratio
    gbm
    regime_switching

--- a/doc/source/research.rst
+++ b/doc/source/research.rst
@@ -15,6 +15,8 @@ adapters live downstream.
    Experiment
    run_experiment
    write_report
+   compare_report
+   leaderboard
    permutation_test
    probabilistic_sharpe_ratio
    deflated_sharpe_ratio

--- a/doc/source/research.rst
+++ b/doc/source/research.rst
@@ -13,6 +13,7 @@ adapters live downstream.
    :toctree: generated/
 
    Experiment
+   Ledger
    run_experiment
    write_report
    compare_report

--- a/fynance/research/__init__.py
+++ b/fynance/research/__init__.py
@@ -15,10 +15,11 @@ downstream, never here.
 """
 
 # Local
-from . import compare, experiment, guards, report, runner, synthetic
+from . import compare, experiment, guards, ledger, report, runner, synthetic
 from .compare import *
 from .experiment import *
 from .guards import *
+from .ledger import *
 from .report import *
 from .runner import *
 from .synthetic import *
@@ -30,3 +31,4 @@ __all__ += runner.__all__
 __all__ += report.__all__
 __all__ += guards.__all__
 __all__ += compare.__all__
+__all__ += ledger.__all__

--- a/fynance/research/__init__.py
+++ b/fynance/research/__init__.py
@@ -15,8 +15,9 @@ downstream, never here.
 """
 
 # Local
-from . import experiment, report, runner, synthetic
+from . import experiment, guards, report, runner, synthetic
 from .experiment import *
+from .guards import *
 from .report import *
 from .runner import *
 from .synthetic import *
@@ -26,3 +27,4 @@ __all__ += experiment.__all__
 __all__ += synthetic.__all__
 __all__ += runner.__all__
 __all__ += report.__all__
+__all__ += guards.__all__

--- a/fynance/research/__init__.py
+++ b/fynance/research/__init__.py
@@ -15,7 +15,8 @@ downstream, never here.
 """
 
 # Local
-from . import experiment, guards, report, runner, synthetic
+from . import compare, experiment, guards, report, runner, synthetic
+from .compare import *
 from .experiment import *
 from .guards import *
 from .report import *
@@ -28,3 +29,4 @@ __all__ += synthetic.__all__
 __all__ += runner.__all__
 __all__ += report.__all__
 __all__ += guards.__all__
+__all__ += compare.__all__

--- a/fynance/research/compare.py
+++ b/fynance/research/compare.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Multi-strategy comparison report.
+
+Ranks a set of :class:`~fynance.research.Experiment` runs into a leaderboard and
+overlays their equity curves — the artifact for *"which of these strategies is
+best, and by how much vs a baseline?"*. Written, like everything in the harness,
+only to a caller-provided ``output_dir``.
+
+"""
+
+# Built-in
+from __future__ import annotations
+
+from pathlib import Path
+
+# Third-party
+import numpy as np
+
+# Local
+from fynance.research.experiment import Experiment
+
+__all__ = ['compare_report', 'leaderboard']
+
+
+def leaderboard(
+    experiments: list[Experiment],
+    *,
+    sort_by: str = "sharpe",
+    descending: bool = True,
+) -> list[dict[str, float | str]]:
+    """ Rank experiments into leaderboard rows.
+
+    Parameters
+    ----------
+    experiments : list of Experiment
+        The runs to rank.
+    sort_by : str
+        Metric key to sort on (missing values sink to the bottom).
+    descending : bool
+        Higher is better when True.
+
+    Returns
+    -------
+    list of dict
+        One ``{"name": ..., <metric>: <value>, ...}`` row per experiment, ranked.
+
+    """
+    rows: list[dict[str, float | str]] = [
+        {"name": e.name, **{k: float(v) for k, v in e.metrics.items()}}
+        for e in experiments
+    ]
+    worst = float("-inf") if descending else float("inf")
+    rows.sort(key=lambda r: r.get(sort_by, worst), reverse=descending)  # type: ignore[arg-type]
+
+    return rows
+
+
+def _write_overlay(experiments: list[Experiment], png_path: Path) -> bool:
+    """ Overlay each experiment's equity curve (rebased to 100). """
+    curves = [(e.name, e.series["equity"]) for e in experiments
+              if e.series and e.series.get("equity")]
+    if not curves:
+        return False
+
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots(figsize=(10, 5))
+    for label, equity in curves:
+        eq = np.asarray(equity, dtype=float)
+        ax.plot(100.0 * eq / eq[0], label=label)
+    ax.set_title("Equity comparison (rebased to 100)")
+    ax.set_xlabel("step")
+    ax.set_ylabel("equity")
+    ax.legend(loc="best", fontsize=8)
+    fig.tight_layout()
+    fig.savefig(png_path, dpi=110, bbox_inches="tight")
+    plt.close(fig)
+
+    return True
+
+
+def _markdown_table(rows: list[dict[str, float | str]]) -> str:
+    """ Render leaderboard rows as a markdown table. """
+    if not rows:
+        return "_no experiments_\n"
+
+    cols = ["name"] + [k for k in rows[0] if k != "name"]
+    head = "| " + " | ".join(cols) + " |"
+    sep = "| " + " | ".join("---" for _ in cols) + " |"
+    body = []
+    for r in rows:
+        cells = [str(r["name"])] + [
+            f"{r[c]:.4f}" if isinstance(r.get(c), float) else str(r.get(c, ""))
+            for c in cols[1:]
+        ]
+        body.append("| " + " | ".join(cells) + " |")
+
+    return "\n".join([head, sep, *body]) + "\n"
+
+
+def compare_report(
+    experiments: list[Experiment],
+    output_dir: str | Path,
+    *,
+    name: str = "comparison",
+    sort_by: str = "sharpe",
+) -> dict[str, Path]:
+    """ Write a leaderboard + equity-overlay comparison report.
+
+    Creates ``<output_dir>/<name>/`` with ``report.md`` (a leaderboard table
+    ranked by ``sort_by``) and ``equity_overlay.png`` (when curves are present).
+    The first experiment is treated as the baseline in the narrative.
+
+    Parameters
+    ----------
+    experiments : list of Experiment
+        The runs to compare (≥ 1).
+    output_dir : str or pathlib.Path
+        Base directory for the artifacts.
+    name : str
+        Sub-directory name.
+    sort_by : str
+        Leaderboard sort metric.
+
+    Returns
+    -------
+    dict of str to pathlib.Path
+        Written artifacts (keys: ``markdown``, ``png`` when produced).
+
+    """
+    if not experiments:
+        raise ValueError("compare_report needs at least one experiment")
+
+    target = Path(output_dir) / name
+    target.mkdir(parents=True, exist_ok=True)
+    written: dict[str, Path] = {}
+
+    png = target / "equity_overlay.png"
+    if _write_overlay(experiments, png):
+        written["png"] = png
+
+    rows = leaderboard(experiments, sort_by=sort_by)
+    md = [f"# Comparison: {name}\n",
+          f"Ranked by `{sort_by}` — {len(experiments)} experiment(s), "
+          f"baseline `{experiments[0].name}`.\n",
+          "## Leaderboard\n",
+          _markdown_table(rows)]
+    if "png" in written:
+        md += ["\n## Equity overlay\n", "![equity overlay](equity_overlay.png)\n"]
+
+    md_path = target / "report.md"
+    md_path.write_text("\n".join(md) + "\n", encoding="utf-8")
+    written["markdown"] = md_path
+
+    return written

--- a/fynance/research/guards.py
+++ b/fynance/research/guards.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Statistical guardrails against spurious results.
+
+When an agent searches over many strategies, the danger is **overfitting and
+data-snooping**: a good in-sample Sharpe may be luck or leakage. These guards make
+honest evaluation cheap — a permutation test (is the edge real?) and the
+probabilistic / deflated Sharpe ratio (does it survive the number of trials?).
+
+All functions are data-agnostic and operate on the existing maillons / plain
+metrics; nothing here reads real data or stores results.
+
+"""
+
+# Built-in
+from __future__ import annotations
+
+from typing import Any
+
+# Third-party
+import numpy as np
+from numpy.typing import NDArray
+from scipy.stats import norm
+
+# Local
+from fynance.core import PriceSeries
+
+__all__ = [
+    'permutation_test',
+    'probabilistic_sharpe_ratio',
+    'deflated_sharpe_ratio',
+]
+
+# Euler-Mascheroni constant (for the expected maximum of N Gaussians).
+_EULER = 0.5772156649015329
+
+
+def _to_array(data: Any) -> NDArray[np.float64]:
+    """ Coerce a PriceSeries / array-like to a 1-D float64 array. """
+    if isinstance(data, PriceSeries):
+        return data.to_numpy()
+
+    return np.asarray(data, dtype=np.float64).reshape(-1)
+
+
+def permutation_test(
+    strategy: Any,
+    data: Any,
+    *,
+    metric: str = "sharpe",
+    n_permutations: int = 200,
+    seed: int = 0,
+) -> dict[str, float]:
+    """ Permutation test for a spurious edge.
+
+    Runs the strategy on the real series, then on ``n_permutations`` shuffles of
+    the asset's returns (which destroys any temporal structure). If the strategy
+    scores as well on shuffled data as on the real data, its edge is not real.
+
+    Parameters
+    ----------
+    strategy : fynance.strategy.Strategy
+        The strategy to evaluate.
+    data : PriceSeries or array-like
+        Price series.
+    metric : str
+        Metric key from the run summary (default ``"sharpe"``).
+    n_permutations : int
+        Number of shuffles forming the null distribution.
+    seed : int
+        Seed for the shuffles and the runs.
+
+    Returns
+    -------
+    dict
+        ``observed``, ``p_value``, ``null_mean``, ``null_std``. The p-value is the
+        (smoothed) fraction of shuffles scoring at least the observed metric.
+
+    """
+    # Imported here to avoid a runner <-> guards import cycle at module load.
+    from fynance.research.runner import run_experiment
+
+    prices = _to_array(data)
+    log_ret = np.diff(np.log(prices))
+    s0 = float(prices[0])
+
+    observed = run_experiment(strategy, prices, name="observed",
+                              seed=seed).metrics[metric]
+
+    rng = np.random.default_rng(seed)
+    null = np.empty(n_permutations, dtype=np.float64)
+    for i in range(n_permutations):
+        shuffled = rng.permutation(log_ret)
+        path = s0 * np.exp(np.concatenate([[0.0], np.cumsum(shuffled)]))
+        null[i] = run_experiment(strategy, path, name="perm",
+                                 seed=seed).metrics[metric]
+
+    # Smoothed p-value (never exactly 0): (#{null >= observed} + 1) / (n + 1).
+    p_value = float((np.sum(null >= observed) + 1) / (n_permutations + 1))
+
+    return {
+        "observed": float(observed),
+        "p_value": p_value,
+        "null_mean": float(null.mean()),
+        "null_std": float(null.std()),
+    }
+
+
+def probabilistic_sharpe_ratio(
+    sr: float,
+    n_obs: int,
+    *,
+    sr_benchmark: float = 0.0,
+    skew: float = 0.0,
+    kurt: float = 3.0,
+) -> float:
+    """ Probabilistic Sharpe ratio (PSR).
+
+    The probability that the true Sharpe exceeds ``sr_benchmark`` given the
+    estimate ``sr`` from ``n_obs`` observations, correcting for the returns'
+    skewness and kurtosis (Bailey & López de Prado).
+
+    Parameters
+    ----------
+    sr : float
+        Observed (non-annualized) Sharpe ratio.
+    n_obs : int
+        Number of return observations.
+    sr_benchmark : float
+        Benchmark Sharpe to beat.
+    skew : float
+        Skewness of the returns.
+    kurt : float
+        Kurtosis of the returns (3 for a normal distribution).
+
+    Returns
+    -------
+    float
+        PSR in ``[0, 1]``.
+
+    """
+    if n_obs <= 1:
+        return float("nan")
+
+    denom = np.sqrt(1.0 - skew * sr + (kurt - 1.0) / 4.0 * sr**2)
+    z = (sr - sr_benchmark) * np.sqrt(n_obs - 1) / denom
+
+    return float(norm.cdf(z))
+
+
+def deflated_sharpe_ratio(
+    sr: float,
+    n_obs: int,
+    n_trials: int,
+    *,
+    skew: float = 0.0,
+    kurt: float = 3.0,
+    sr_variance: float = 1.0,
+) -> float:
+    """ Deflated Sharpe ratio (DSR).
+
+    The PSR against a benchmark set to the **expected maximum** Sharpe of
+    ``n_trials`` independent strategies — i.e. the probability the edge survives
+    the multiple testing implied by trying ``n_trials`` strategies.
+
+    Parameters
+    ----------
+    sr : float
+        Observed (non-annualized) Sharpe ratio of the selected strategy.
+    n_obs : int
+        Number of return observations.
+    n_trials : int
+        Number of strategy configurations tried.
+    skew, kurt : float
+        Skewness / kurtosis of the selected strategy's returns.
+    sr_variance : float
+        Variance of the Sharpe estimates **across the trials**.
+
+    Returns
+    -------
+    float
+        DSR in ``[0, 1]``. Low values flag a likely overfit selection.
+
+    """
+    n = max(int(n_trials), 1)
+    if n == 1:
+        sr_star = 0.0
+    else:
+        # Expected max of N i.i.d. standard normals, scaled by the SR dispersion.
+        gauss_max = ((1 - _EULER) * norm.ppf(1 - 1.0 / n)
+                     + _EULER * norm.ppf(1 - 1.0 / (n * np.e)))
+        sr_star = float(np.sqrt(sr_variance) * gauss_max)
+
+    return probabilistic_sharpe_ratio(
+        sr, n_obs, sr_benchmark=sr_star, skew=skew, kurt=kurt
+    )

--- a/fynance/research/ledger.py
+++ b/fynance/research/ledger.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Persistent experiment ledger.
+
+A :class:`Ledger` turns one-off runs into **cumulative** research: it persists
+experiments under a caller-provided ``root``, reloads them, ranks them into a
+leaderboard, and tracks the **number of trials** — which it can feed into the
+deflated Sharpe ratio so a selected strategy is judged against the multiple
+testing it came from. The store lives entirely under ``root`` (the caller's
+private repo) — never inside fynance.
+
+"""
+
+# Built-in
+from __future__ import annotations
+
+from pathlib import Path
+
+# Third-party
+import numpy as np
+
+# Local
+from fynance.research.compare import leaderboard
+from fynance.research.experiment import Experiment
+from fynance.research.guards import deflated_sharpe_ratio
+
+__all__ = ['Ledger']
+
+
+class Ledger:
+    """ A persistent, append-only store of experiments under ``root``.
+
+    Parameters
+    ----------
+    root : str or pathlib.Path
+        Directory the experiments live under (created on demand). Each experiment
+        is stored at ``<root>/<name>/experiment.json``.
+
+    Examples
+    --------
+    >>> import tempfile
+    >>> from fynance.research import Experiment, Ledger
+    >>> d = tempfile.mkdtemp()
+    >>> led = Ledger(d)
+    >>> _ = led.append(Experiment(name="a", metrics={"sharpe": 1.0}))
+    >>> _ = led.append(Experiment(name="b", metrics={"sharpe": 2.0}))
+    >>> led.n_trials
+    2
+    >>> [r["name"] for r in led.leaderboard()]
+    ['b', 'a']
+
+    """
+
+    def __init__(self, root: str | Path):
+        self.root = Path(root)
+
+    def append(self, experiment: Experiment) -> Path:
+        """ Persist ``experiment`` under the ledger root; return its json path. """
+        self.root.mkdir(parents=True, exist_ok=True)
+
+        return experiment.save(self.root)
+
+    def load(self) -> list[Experiment]:
+        """ Load every stored experiment (sorted by name for determinism). """
+        if not self.root.exists():
+            return []
+
+        return [Experiment.load(p)
+                for p in sorted(self.root.glob("*/experiment.json"))]
+
+    @property
+    def n_trials(self) -> int:
+        """ Number of experiments in the ledger (the multiple-testing count). """
+        if not self.root.exists():
+            return 0
+
+        return sum(1 for _ in self.root.glob("*/experiment.json"))
+
+    def leaderboard(self, *, sort_by: str = "sharpe",
+                    descending: bool = True) -> list[dict[str, float | str]]:
+        """ Rank the stored experiments (see :func:`fynance.research.leaderboard`). """
+        return leaderboard(self.load(), sort_by=sort_by, descending=descending)
+
+    def deflated_sharpe(self, experiment: Experiment,
+                        metric: str = "sharpe") -> float:
+        """ Deflated Sharpe of ``experiment`` against the ledger's trial count.
+
+        Uses the ledger's :attr:`n_trials` as the number of trials and the
+        dispersion of the stored Sharpe metrics as the trial variance, so a
+        selected strategy is judged against the multiple testing it came from.
+        """
+        sharpes = [float(e.metrics[metric]) for e in self.load()
+                   if metric in e.metrics]
+        sr_variance = float(np.var(sharpes)) if len(sharpes) > 1 else 1.0
+
+        n_obs = len(experiment.series["returns"]) if (
+            experiment.series and experiment.series.get("returns")) else 0
+
+        return deflated_sharpe_ratio(
+            float(experiment.metrics[metric]), n_obs, max(self.n_trials, 1),
+            sr_variance=sr_variance,
+        )

--- a/fynance/tests/research/test_compare.py
+++ b/fynance/tests/research/test_compare.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Tests for :mod:`fynance.research.compare`. """
+
+# Built-in
+from pathlib import Path
+
+# Third-party
+import numpy as np
+import pytest
+
+# Local
+import fynance
+from fynance.research import compare_report, gbm, leaderboard, run_experiment
+from fynance.strategy import Strategy
+
+
+def _exp(name, seed, fee=0.0):
+    from fynance.backtest import ProportionalCost
+
+    strat = Strategy(features=lambda p: np.diff(p, prepend=p[0]),
+                     cost=ProportionalCost(fee))
+    return run_experiment(strat, gbm(400, seed=seed), name=name, seed=seed)
+
+
+@pytest.fixture
+def experiments():
+    return [_exp("a", 1), _exp("b", 2), _exp("c", 3)]
+
+
+def test_leaderboard_ranked_by_sharpe(experiments):
+    rows = leaderboard(experiments, sort_by="sharpe")
+
+    assert {r["name"] for r in rows} == {"a", "b", "c"}
+    sharpes = [r["sharpe"] for r in rows]
+    assert sharpes == sorted(sharpes, reverse=True)
+
+
+def test_compare_report_writes_md_and_png(tmp_path, experiments):
+    out = compare_report(experiments, tmp_path, name="cmp")
+
+    md = tmp_path / "cmp" / "report.md"
+    png = tmp_path / "cmp" / "equity_overlay.png"
+    assert out["markdown"] == md and md.is_file()
+    assert out["png"] == png and png.is_file() and png.stat().st_size > 0
+
+    text = md.read_text()
+    assert "# Comparison: cmp" in text
+    for nm in ("a", "b", "c"):
+        assert f"| {nm} |" in text
+    assert "equity_overlay.png" in text
+
+
+def test_empty_raises(tmp_path):
+    with pytest.raises(ValueError):
+        compare_report([], tmp_path)
+
+
+def test_nothing_written_outside_output_dir(tmp_path, experiments):
+    pkg = Path(fynance.__file__).resolve().parent
+    before = {p for p in pkg.rglob("equity_overlay.png")}
+
+    compare_report(experiments, tmp_path)
+
+    assert {p for p in pkg.rglob("equity_overlay.png")} == before

--- a/fynance/tests/research/test_guards.py
+++ b/fynance/tests/research/test_guards.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Tests for :mod:`fynance.research.guards`. """
+
+# Third-party
+import numpy as np
+import pytest
+
+# Local
+from fynance.research import (
+    deflated_sharpe_ratio,
+    gbm,
+    permutation_test,
+    probabilistic_sharpe_ratio,
+)
+from fynance.research.guards import _to_array  # noqa: F401 — coverage of helper
+from fynance.strategy import Strategy
+
+
+def momentum() -> Strategy:
+    """ Causal sign-of-recent-change momentum. """
+    return Strategy(features=lambda p: np.diff(p, prepend=p[0]))
+
+
+# -- probabilistic / deflated Sharpe (deterministic) -----------------------
+
+def test_psr_bounds_and_midpoint():
+    assert probabilistic_sharpe_ratio(0.0, 100) == pytest.approx(0.5)
+    val = probabilistic_sharpe_ratio(0.2, 250)
+    assert 0.0 <= val <= 1.0
+
+
+def test_psr_monotonic_in_sharpe_and_n():
+    assert (probabilistic_sharpe_ratio(0.3, 250)
+            > probabilistic_sharpe_ratio(0.1, 250))
+    assert (probabilistic_sharpe_ratio(0.2, 1000)
+            > probabilistic_sharpe_ratio(0.2, 100))
+
+
+def test_dsr_equals_psr_at_one_trial():
+    sr, n = 0.25, 500
+    assert deflated_sharpe_ratio(sr, n, 1) == pytest.approx(
+        probabilistic_sharpe_ratio(sr, n, sr_benchmark=0.0)
+    )
+
+
+def test_dsr_decreases_with_more_trials():
+    sr, n = 0.25, 500
+    few = deflated_sharpe_ratio(sr, n, 1)
+    many = deflated_sharpe_ratio(sr, n, 100)
+    assert many < few
+    assert 0.0 <= many <= 1.0
+
+
+# -- permutation test ------------------------------------------------------
+
+def test_permutation_structure_and_determinism():
+    out1 = permutation_test(momentum(), gbm(300, seed=1), n_permutations=30, seed=4)
+    out2 = permutation_test(momentum(), gbm(300, seed=1), n_permutations=30, seed=4)
+
+    assert set(out1) == {"observed", "p_value", "null_mean", "null_std"}
+    assert 0.0 < out1["p_value"] <= 1.0
+    assert out1 == out2  # fully reproducible
+
+
+def test_permutation_detects_autocorrelation_edge():
+    # AR(1) returns with positive autocorrelation -> momentum has a real edge;
+    # shuffling destroys the autocorrelation, so the edge should be significant.
+    rng = np.random.default_rng(0)
+    n = 1200
+    r = np.zeros(n)
+    for t in range(1, n):
+        r[t] = 0.35 * r[t - 1] + 0.01 * rng.standard_normal()
+    prices = 100.0 * np.exp(np.cumsum(r))
+
+    out = permutation_test(momentum(), prices, n_permutations=200, seed=0)
+
+    assert out["observed"] > out["null_mean"]
+    assert out["p_value"] < 0.10

--- a/fynance/tests/research/test_ledger.py
+++ b/fynance/tests/research/test_ledger.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Tests for :class:`fynance.research.Ledger`. """
+
+# Built-in
+from pathlib import Path
+
+# Third-party
+import numpy as np
+
+# Local
+import fynance
+from fynance.research import Experiment, Ledger, gbm, run_experiment
+from fynance.strategy import Strategy
+
+
+def _exp(name, seed):
+    strat = Strategy(features=lambda p: np.diff(p, prepend=p[0]))
+    return run_experiment(strat, gbm(400, seed=seed), name=name, seed=seed)
+
+
+def test_append_load_roundtrip(tmp_path):
+    led = Ledger(tmp_path)
+    led.append(_exp("a", 1))
+    led.append(_exp("b", 2))
+
+    loaded = led.load()
+    assert {e.name for e in loaded} == {"a", "b"}
+    assert led.n_trials == 2
+    assert (tmp_path / "a" / "experiment.json").is_file()
+
+
+def test_empty_ledger(tmp_path):
+    led = Ledger(tmp_path / "nope")
+    assert led.load() == []
+    assert led.n_trials == 0
+
+
+def test_leaderboard_ranked(tmp_path):
+    led = Ledger(tmp_path)
+    for nm, sd in [("a", 1), ("b", 2), ("c", 3)]:
+        led.append(_exp(nm, sd))
+
+    rows = led.leaderboard(sort_by="sharpe")
+    sharpes = [r["sharpe"] for r in rows]
+    assert sharpes == sorted(sharpes, reverse=True)
+
+
+def test_deflated_sharpe_uses_trial_count(tmp_path):
+    led = Ledger(tmp_path)
+    exps = [_exp(n, s) for n, s in [("a", 1), ("b", 2), ("c", 3), ("d", 4)]]
+    for e in exps:
+        led.append(e)
+
+    best = max(exps, key=lambda e: e.metrics["sharpe"])
+    dsr = led.deflated_sharpe(best)
+    assert 0.0 <= dsr <= 1.0
+
+
+def test_store_stays_under_root(tmp_path):
+    pkg = Path(fynance.__file__).resolve().parent
+    before = {p for p in pkg.rglob("experiment.json")}
+
+    Ledger(tmp_path).append(_exp("x", 1))
+
+    assert {p for p in pkg.rglob("experiment.json")} == before
+
+
+def test_n_trials_counts_only_experiments(tmp_path):
+    # A stray sub-dir without experiment.json must not inflate the count.
+    led = Ledger(tmp_path)
+    led.append(Experiment(name="real", metrics={"sharpe": 1.0}))
+    (tmp_path / "stray").mkdir()
+    (tmp_path / "stray" / "report.md").write_text("noise")
+
+    assert led.n_trials == 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fynance"
-version = "2.2.0"
+version = "2.3.0"
 description = "Pure-Python (Numba-accelerated) machine learning, econometrics and statistical tools for financial analysis and backtesting"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Promotes `develop` (v2.3.0) to `master`. Merge after CI, then tag.

## [2.3.0]
### Added
- Research-harness guardrails: `permutation_test`, `probabilistic_sharpe_ratio`, `deflated_sharpe_ratio`.
- `compare_report` / `leaderboard` — multi-strategy comparison report.
- `Ledger(root)` — persistent experiment store (S3).