### PR TITLE
feat: harness X/y feature-matrix inputs (I1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Strategy.run` / `Strategy.run_walk_forward` and `fynance.research.run_experiment` accept a precomputed feature matrix `X` (aligned with the price index): when given it replaces `features(prices)` and the walk-forward slices `X[train]`/`X[test]` per window (the rolling-NN refit). Prices are used only for the P&L; `X` carries exogenous / regime / multi-venue inputs the price-only featurizer cannot build. `X`/`y` dtypes are preserved (so a float32 `X` matches a float32 torch model).
+
 ### Changed
 
 ### Fixed

--- a/fynance/research/runner.py
+++ b/fynance/research/runner.py
@@ -51,6 +51,7 @@ def run_experiment(
     data: Any,
     *,
     name: str,
+    X: NDArray | None = None,
     y: NDArray | None = None,
     walk_forward: dict[str, Any] | None = None,
     costs: Any = None,
@@ -69,6 +70,10 @@ def run_experiment(
         Price series the strategy runs on (coerced to float64).
     name : str
         Experiment slug (also the output sub-directory).
+    X : array-like, optional
+        Precomputed feature matrix aligned with ``data`` (rows = time). Passed
+        through to the strategy — the way to feed exogenous / regime / multi-venue
+        features the price-only featurizer cannot build. Must be causal.
     y : array-like, optional
         Supervised target for a model-based strategy run via ``walk_forward``.
         Defaults to zeros (ignored by rule-based strategies).
@@ -101,17 +106,18 @@ def run_experiment(
     n = prices.shape[0]
 
     if walk_forward is not None:
-        target = np.zeros(n) if y is None else np.asarray(y, dtype=np.float64)
-        result = strategy.run_walk_forward(data, target, **walk_forward)
+        target = np.zeros(n) if y is None else np.asarray(y)  # preserve dtype
+        result = strategy.run_walk_forward(data, target, **walk_forward, X=X)
 
     else:
-        result = strategy.run(data, y)
+        result = strategy.run(data, y, X=X)
 
     metrics = result.summary(period=period)
 
     spec: dict[str, Any] = {
         "data": {"kind": getattr(data, "name", None) or type(data).__name__,
                  "n": int(n)},
+        "features": None if X is None else {"X_shape": list(np.asarray(X).shape)},
         "walk_forward": walk_forward,
         "cost": type(strategy.cost).__name__ if strategy.cost is not None else None,
         "period": period,

--- a/fynance/strategy/strategy.py
+++ b/fynance/strategy/strategy.py
@@ -83,9 +83,24 @@ class Strategy:
 
         return np.asarray(self.features(prices), dtype=np.float64)
 
-    def _positions(self, prices: NDArray, y: NDArray | None) -> NDArray:
-        """ Compute the (unshifted) position series from a price series. """
-        feats = self._featurize(prices)
+    def _resolve_features(self, prices: NDArray, X: NDArray | None) -> NDArray:
+        """ Use a precomputed feature matrix ``X`` if given, else featurize prices.
+
+        ``X`` is the caller's responsibility to keep **aligned with the price
+        index** and **causal** — it carries exogenous features (engineered inputs,
+        a regime label, other venues) that the price-only featurizer cannot build.
+        Its dtype is preserved (so a float32 ``X`` matches a float32 torch model).
+        """
+        if X is not None:
+
+            return np.asarray(X)
+
+        return self._featurize(prices)
+
+    def _positions(self, prices: NDArray, y: NDArray | None,
+                   X: NDArray | None = None) -> NDArray:
+        """ Compute the (unshifted) position series. """
+        feats = self._resolve_features(prices, X)
 
         if self.model is not None:
             if y is not None:
@@ -98,16 +113,21 @@ class Strategy:
 
         return np.asarray(self.signal(preds), dtype=np.float64).reshape(-1)
 
-    def run(self, data: Any, y: NDArray | None = None) -> BacktestResult:
+    def run(self, data: Any, y: NDArray | None = None,
+            X: NDArray | None = None) -> BacktestResult:
         """ Run the strategy on a price series, returning a backtest result.
 
         Parameters
         ----------
         data : PriceSeries or array-like
-            Price series.
+            Price series (used for the P&L).
         y : array-like, optional
             Supervised target for the model (fit on the whole series; for
             leak-free training use :meth:`run_walk_forward`).
+        X : array-like, optional
+            Precomputed feature matrix aligned with ``data`` (rows = time). When
+            given it replaces ``features(prices)`` — use it to feed exogenous /
+            regime / multi-venue inputs the price-only featurizer cannot build.
 
         Returns
         -------
@@ -116,7 +136,7 @@ class Strategy:
         """
         prices = _as_array(data)
         returns = prices[1:] / prices[:-1] - 1.0
-        positions = self._positions(prices, y)
+        positions = self._positions(prices, y, X)
 
         # Align positions with the returns series (drop the first observation).
         if positions.shape[0] == prices.shape[0]:
@@ -132,16 +152,18 @@ class Strategy:
         test: int,
         step: int | None = None,
         purge: int = 0,
+        X: NDArray | None = None,
     ) -> BacktestResult:
         """ Walk-forward run: refit per window on train only, predict on test.
 
         The model and features are fit on each train slice only; out-of-sample
         positions are stitched together and backtested. Strictly no-lookahead.
+        This per-window refit *is* the rolling-NN pattern when ``model`` is a net.
 
         Parameters
         ----------
         data : PriceSeries or array-like
-            Price series.
+            Price series (used for the P&L).
         y : array-like
             Supervised target aligned with ``data``.
         train, test : int
@@ -150,6 +172,11 @@ class Strategy:
             Roll step (defaults to ``test``).
         purge : int
             Embargo removed at the train/test boundary.
+        X : array-like, optional
+            Precomputed feature matrix aligned with ``data`` (rows = time). When
+            given, each window slices ``X[train]`` / ``X[test]`` instead of
+            featurizing the price slices — the way to feed exogenous / regime /
+            multi-venue features. ``X`` must be causal and index-aligned.
 
         Returns
         -------
@@ -158,7 +185,8 @@ class Strategy:
 
         """
         prices = _as_array(data)
-        y_arr = np.asarray(y, dtype=np.float64)
+        y_arr = np.asarray(y)  # preserve caller dtype (match X / the model)
+        X_arr = None if X is None else np.asarray(X)  # preserve caller dtype
         n = prices.shape[0]
 
         oos_pos: list[float] = []
@@ -166,8 +194,13 @@ class Strategy:
 
         for tr, te in walk_forward(n, train=train, test=test, step=step,
                                    purge=purge):
-            feats_tr = self._featurize(prices[tr])
-            feats_te = self._featurize(prices[te])
+            if X_arr is not None:
+                feats_tr = X_arr[tr]
+                feats_te = X_arr[te]
+
+            else:
+                feats_tr = self._featurize(prices[tr])
+                feats_te = self._featurize(prices[te])
 
             if self.model is not None:
                 self.model.fit(feats_tr, y_arr[tr])

--- a/fynance/tests/research/test_xy_inputs.py
+++ b/fynance/tests/research/test_xy_inputs.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" I1 — precomputed feature-matrix ``X`` / ``y`` threaded through the harness. """
+
+# Third-party
+import numpy as np
+import torch
+import torch.nn as nn
+
+# Local
+from fynance.models import MultiLayerPerceptron
+from fynance.research import Experiment, gbm, run_experiment
+from fynance.signal import sign
+from fynance.strategy import Strategy
+
+
+class LinearStub:
+    """ Deterministic least-squares SignalModel stub (fit/predict). """
+
+    def fit(self, X, y):
+        X = np.asarray(X, dtype=float)
+        y = np.asarray(y, dtype=float).reshape(X.shape[0], -1)
+        self.w, *_ = np.linalg.lstsq(X, y, rcond=None)
+        return self
+
+    def predict(self, X):
+        return np.asarray(X, dtype=float) @ self.w
+
+
+def test_run_with_X_matches_features_callable():
+    # Single-pass run: precomputed X must equal the same feature via a callable.
+    prices = gbm(300, seed=1)
+    feat = lambda p: np.sign(np.diff(p, prepend=p[0]))  # noqa: E731
+
+    r_callable = Strategy(features=feat).run(prices)
+    r_matrix = Strategy().run(prices, X=feat(prices.to_numpy()))
+
+    assert np.allclose(r_callable.equity, r_matrix.equity)
+
+
+def test_walk_forward_X_runs_and_uses_the_matrix():
+    prices = gbm(400, seed=2)
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(len(prices.to_numpy()), 2))
+    y = (X[:, :1] - X[:, 1:2])  # a learnable linear target
+
+    strat = Strategy(model=LinearStub(), signal=sign)
+    res = strat.run_walk_forward(prices, y, train=80, test=40, X=X)
+
+    assert np.all(np.isfinite(res.equity))
+    # Positions actually depend on X: a different X gives a different result.
+    res2 = strat.run_walk_forward(prices, y, train=80, test=40, X=rng.normal(size=X.shape))
+    assert not np.allclose(res.equity, res2.equity)
+
+
+def test_walk_forward_X_is_deterministic():
+    prices = gbm(400, seed=2)
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(len(prices.to_numpy()), 2))
+    y = X[:, :1]
+
+    a = Strategy(model=LinearStub()).run_walk_forward(prices, y, train=80, test=40, X=X)
+    b = Strategy(model=LinearStub()).run_walk_forward(prices, y, train=80, test=40, X=X)
+    assert np.allclose(a.equity, b.equity)
+
+
+def test_no_lookahead_with_X_and_model():
+    # Perturbing the price tail leaves the earlier OOS returns unchanged (X is
+    # precomputed/causal; early windows never see the perturbed future).
+    prices = gbm(600, seed=7).to_numpy()
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(len(prices), 2))
+    y = X[:, :1]
+    wf = dict(train=120, test=60)
+
+    base = Strategy(model=LinearStub()).run_walk_forward(prices, y, **wf, X=X)
+
+    pert = prices.copy()
+    cut = int(len(prices) * 0.7)
+    pert[cut:] *= np.cumprod(1.0 + rng.standard_normal(len(prices) - cut) * 0.05)
+    moved = Strategy(model=LinearStub()).run_walk_forward(pert, y, **wf, X=X)
+
+    k = len(base.returns) // 3
+    assert np.allclose(base.returns[:k], moved.returns[:k])
+
+
+def test_run_experiment_threads_and_records_X():
+    prices = gbm(400, seed=3)
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(len(prices.to_numpy()), 2))
+    y = X[:, :1]
+
+    exp = run_experiment(Strategy(model=LinearStub(), signal=sign), prices,
+                         name="xy", X=X, y=y, walk_forward=dict(train=80, test=40))
+
+    assert isinstance(exp, Experiment)
+    assert exp.spec["features"] == {"X_shape": [X.shape[0], X.shape[1]]}
+    assert np.all(np.isfinite(list(exp.metrics.values())))
+
+
+def test_real_mlp_rolling_over_X():
+    # The rolling-NN path: a real MLP refit per walk-forward window over X.
+    prices = gbm(360, seed=5)
+    rng = np.random.default_rng(0)
+    n = len(prices.to_numpy())
+    X = rng.normal(size=(n, 2)).astype(np.float32)
+    y = (X.sum(axis=1, keepdims=True)).astype(np.float32)
+
+    mlp = MultiLayerPerceptron(2, 1, layers=[4])
+    mlp.set_optimizer(nn.MSELoss, torch.optim.SGD, lr=1e-3)
+
+    exp = run_experiment(Strategy(model=mlp, signal=np.sign), prices, name="mlp",
+                         X=X, y=y, walk_forward=dict(train=120, test=60), seed=0)
+
+    assert np.all(np.isfinite(list(exp.metrics.values())))
+    assert exp.series["equity"]


### PR DESCRIPTION
**I1** of the multi-input harness epic. Threads a precomputed feature matrix `X` (+ `y`) through `Strategy.run` / `Strategy.run_walk_forward` and `research.run_experiment`.

- When `X` is given it **replaces `features(prices)`**; walk-forward slices `X[train]`/`X[test]` per window (= the rolling-NN refit). Prices are used **only for the P&L**.
- `X` carries exogenous / regime / multi-venue inputs the price-only featurizer can't build. **`X`/`y` dtypes preserved** (float32 `X` matches a float32 torch model).
- Backward compatible (new optional kw-args).

### Test plan (synthetic only)
- single-pass `X` ≡ equivalent `features` callable; walk-forward uses `X` (different `X` → different result) and is deterministic; **no-lookahead** probe with `X`+model; `run_experiment` threads `X` and records its shape; a **real `MultiLayerPerceptron` refit per window over `X`** (the rolling-NN path).
- `pytest` → **550 passed, 1 skipped**; `ruff`/`mypy` clean; `sphinx-build -W` ok.