### PR TITLE
feat: causal RegimeDetector (I2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `Strategy.run` / `Strategy.run_walk_forward` and `fynance.research.run_experiment` accept a precomputed feature matrix `X` (aligned with the price index): when given it replaces `features(prices)` and the walk-forward slices `X[train]`/`X[test]` per window (the rolling-NN refit). Prices are used only for the P&L; `X` carries exogenous / regime / multi-venue inputs the price-only featurizer cannot build. `X`/`y` dtypes are preserved (so a float32 `X` matches a float32 torch model).
+- `fynance.features.RegimeDetector` — a **causal** market-regime detector (fit k-means on a training slice, assign later points to the nearest training centroid), plus `regime_features` (the causal trailing vol / mean-return matrix). Unlike `detect_regimes` (in-sample), it is safe as a backtest feature. `detect_regimes` is unchanged (refactored to share `regime_features`).
 
 ### Changed
 

--- a/doc/source/features.regime.rst
+++ b/doc/source/features.regime.rst
@@ -2,7 +2,10 @@
 Market regime
 *************
 
-Unsupervised market-regime labelling by clustering rolling volatility / return features (:func:`~fynance.features.regime.detect_regimes`).
+Unsupervised market-regime labelling by clustering rolling volatility / return
+features. :func:`~fynance.features.regime.detect_regimes` is the in-sample
+convenience (for analysis); :class:`~fynance.features.regime.RegimeDetector` is
+the **causal** fit-on-train / assign-online variant for backtests.
 
 .. currentmodule:: fynance.features.regime
 
@@ -10,3 +13,5 @@ Unsupervised market-regime labelling by clustering rolling volatility / return f
    :toctree: generated/
 
    detect_regimes
+   regime_features
+   RegimeDetector

--- a/doc/source/generated/fynance.features.regime.RegimeDetector.rst
+++ b/doc/source/generated/fynance.features.regime.RegimeDetector.rst
@@ -1,0 +1,13 @@
+﻿RegimeDetector
+======================================
+
+*Defined in* :mod:`fynance.features.regime`
+
+.. currentmodule:: fynance.features.regime
+
+.. autoclass:: RegimeDetector
+   :members:
+   :inherited-members:
+   :special-members: __call__, __iter__, __next__
+   :show-inheritance:
+   :no-index:

--- a/doc/source/generated/fynance.features.regime.regime_features.rst
+++ b/doc/source/generated/fynance.features.regime.regime_features.rst
@@ -1,0 +1,9 @@
+﻿regime_features
+=======================================
+
+*Defined in* :mod:`fynance.features.regime`
+
+.. currentmodule:: fynance.features.regime
+
+.. autofunction:: regime_features
+   :no-index:

--- a/fynance/features/regime.py
+++ b/fynance/features/regime.py
@@ -19,7 +19,113 @@ from scipy.cluster.vq import kmeans2
 # Local packages
 from fynance.features.indicators import realized_volatility
 
-__all__ = ['detect_regimes']
+__all__ = ['detect_regimes', 'regime_features', 'RegimeDetector']
+
+
+def regime_features(X: NDArray, w: int = 21, period: int = 252) -> NDArray:
+    """ Build the causal regime feature matrix: trailing vol and mean return.
+
+    Both columns use **trailing** windows (past only), so the matrix is causal —
+    the value at ``t`` depends on ``X[:t+1]`` only.
+
+    Parameters
+    ----------
+    X : np.ndarray
+        One-dimensional price/level series.
+    w : int
+        Rolling window.
+    period : int
+        Annualization factor for the volatility column.
+
+    Returns
+    -------
+    np.ndarray
+        Shape ``(len(X), 2)`` — ``[realized_volatility, rolling_mean_log_return]``.
+
+    """
+    X = np.asarray(X, dtype=np.float64).reshape(-1)
+    vol = np.asarray(realized_volatility(X, w=w, period=period))
+    ret = np.zeros_like(X)
+    ret[1:] = np.log(X[1:] / X[:-1])
+    roll_ret = np.zeros_like(X)
+    for t in range(X.shape[0]):
+        roll_ret[t] = ret[max(0, t - w + 1):t + 1].mean()
+
+    return np.column_stack([vol, roll_ret])
+
+
+class RegimeDetector:
+    """ Causal market-regime detector (fit on the past, assign online).
+
+    Unlike :func:`detect_regimes` (which clusters in-sample and therefore peeks
+    at the whole series), this fits k-means on a **training** slice only and
+    assigns any later point to the nearest training centroid — so labels are a
+    **strictly causal** feature usable in a backtest. Labels are ordered by
+    increasing mean volatility (0 = calmest), like :func:`detect_regimes`.
+
+    Parameters
+    ----------
+    n_regimes : int
+        Number of regimes (clusters).
+    w : int
+        Rolling window for the features.
+    period : int
+        Annualization factor for the volatility feature.
+    seed : int
+        Seed for the k-means initialization.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from fynance.features import RegimeDetector
+    >>> rng = np.random.default_rng(0)
+    >>> p = 100 * np.exp(np.cumsum(rng.standard_normal(400) * 0.01))
+    >>> det = RegimeDetector(n_regimes=2, w=10).fit(p[:300])
+    >>> labels = det.predict(p)
+    >>> labels.shape, set(np.unique(labels)) <= {0, 1}
+    ((400,), True)
+
+    """
+
+    def __init__(self, n_regimes: int = 3, w: int = 21, period: int = 252,
+                 seed: int = 0):
+        self.n_regimes = n_regimes
+        self.w = w
+        self.period = period
+        self.seed = seed
+
+    def fit(self, X: NDArray) -> RegimeDetector:
+        """ Fit k-means on the training series ``X`` (past only). """
+        feats = regime_features(X, self.w, self.period)
+        self._mu = feats.mean(axis=0)
+        self._sd = feats.std(axis=0)
+        self._sd[self._sd == 0] = 1.0
+        z = (feats - self._mu) / self._sd
+
+        centroids, labels = kmeans2(z, self.n_regimes, seed=self.seed,
+                                    minit='++', missing='raise')
+        self._centroids = centroids
+
+        # Order clusters by mean (unstandardized) volatility for stable labels.
+        vol = feats[:, 0]
+        order = np.argsort([vol[labels == k].mean() for k in range(self.n_regimes)])
+        remap = np.empty(self.n_regimes, dtype=int)
+        remap[order] = np.arange(self.n_regimes)
+        self._remap = remap
+
+        return self
+
+    def predict(self, X: NDArray) -> NDArray:
+        """ Assign each point of ``X`` to the nearest training centroid. """
+        feats = regime_features(X, self.w, self.period)
+        z = (feats - self._mu) / self._sd
+        dist = ((z[:, None, :] - self._centroids[None, :, :]) ** 2).sum(axis=-1)
+
+        return self._remap[dist.argmin(axis=1)]
+
+    def fit_predict(self, X: NDArray) -> NDArray:
+        """ Convenience: :meth:`fit` then :meth:`predict` on the same series. """
+        return self.fit(X).predict(X)
 
 
 def detect_regimes(
@@ -59,21 +165,14 @@ def detect_regimes(
         ``[0, n_regimes)`` and ordered by increasing average volatility.
 
     """
-    X = np.asarray(X, dtype=np.float64).reshape(-1)
-    vol = np.asarray(realized_volatility(X, w=w, period=period))
-    ret = np.zeros_like(X)
-    ret[1:] = np.log(X[1:] / X[:-1])
-    roll_ret = np.zeros_like(X)
-    for t in range(X.shape[0]):
-        roll_ret[t] = ret[max(0, t - w + 1):t + 1].mean()
-
-    feats = np.column_stack([vol, roll_ret])
+    feats = regime_features(X, w=w, period=period)
+    vol = feats[:, 0]
     mu = feats.mean(axis=0)
     sd = feats.std(axis=0)
     sd[sd == 0] = 1.0
-    feats = (feats - mu) / sd
+    z = (feats - mu) / sd
 
-    _, labels = kmeans2(feats, n_regimes, seed=seed, minit='++', missing='raise')
+    _, labels = kmeans2(z, n_regimes, seed=seed, minit='++', missing='raise')
 
     # Re-order labels by increasing mean volatility for stable interpretation.
     order = np.argsort([vol[labels == k].mean() for k in range(n_regimes)])

--- a/fynance/tests/features/test_regime_causal.py
+++ b/fynance/tests/features/test_regime_causal.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" I2 — causal `RegimeDetector` (fit-on-train / assign-online). """
+
+# Third-party
+import numpy as np
+
+# Local
+from fynance.features import RegimeDetector, detect_regimes, regime_features
+from fynance.research import regime_switching
+
+
+def _series(n=600, seed=1):
+    return regime_switching(
+        n, regimes=((0.0, 0.004), (0.0, 0.03)), p_switch=0.01, seed=seed
+    ).to_numpy()
+
+
+def test_regime_features_shape_and_causality():
+    p = _series(300)
+    f = regime_features(p, w=20)
+    assert f.shape == (300, 2)
+    # Causal: perturbing the tail leaves earlier feature rows untouched.
+    pert = p.copy()
+    pert[200:] *= 1.5
+    assert np.array_equal(regime_features(p, w=20)[:200],
+                          regime_features(pert, w=20)[:200])
+
+
+def test_detector_determinism_and_shapes():
+    p = _series()
+    a = RegimeDetector(n_regimes=2, w=20, seed=0).fit_predict(p)
+    b = RegimeDetector(n_regimes=2, w=20, seed=0).fit_predict(p)
+
+    assert a.shape == (len(p),)
+    assert np.array_equal(a, b)
+    assert set(np.unique(a)) <= {0, 1}
+
+
+def test_labels_ordered_by_volatility():
+    p = _series(900, seed=3)
+    det = RegimeDetector(n_regimes=3, w=21, seed=0).fit(p)
+    labels = det.predict(p)
+    vol = regime_features(p, w=21)[:, 0]
+
+    present = [k for k in range(3) if np.any(labels == k)]
+    means = [vol[labels == k].mean() for k in present]
+    # Label index increases with mean volatility (calmest = 0).
+    assert means == sorted(means)
+
+
+def test_no_lookahead_fit_on_past_assign_online():
+    # THE causality guarantee: fit on a prefix, then perturb the future — the
+    # labels on the earlier (unperturbed) prefix must be identical.
+    p = _series(600, seed=1)
+    det = RegimeDetector(n_regimes=2, w=20, seed=0).fit(p[:400])
+
+    base = det.predict(p)
+    pert = p.copy()
+    cut = 450
+    rng = np.random.default_rng(0)
+    pert[cut:] *= np.cumprod(1.0 + rng.standard_normal(len(p) - cut) * 0.05)
+    moved = det.predict(pert)
+
+    assert np.array_equal(base[:cut], moved[:cut])
+
+
+def test_fit_predict_matches_in_sample_detect_regimes():
+    # Fit-predict on the whole series ≈ the in-sample detect_regimes (nearest
+    # centroid == the k-means assignment).
+    p = _series(500, seed=2)
+    a = RegimeDetector(n_regimes=3, w=21, seed=0).fit_predict(p)
+    b = detect_regimes(p, n_regimes=3, w=21, seed=0)
+
+    # Same regimes; the few % gap is k-means' own labels vs nearest-centroid
+    # reassignment on borderline points (the detector uses the latter, which is
+    # also what it must do out-of-sample).
+    assert (a == b).mean() > 0.90


### PR DESCRIPTION
**I2** of the multi-input harness epic. `detect_regimes` clusters in-sample (sees the whole series → lookahead), so it is unsafe as a backtest feature.

- `RegimeDetector(n_regimes, w, period, seed)` — `fit(X_train)` (k-means on the training slice) + `predict(X)` (assign to the nearest **training** centroid), labels ordered by volatility. A **strictly causal** regime feature.
- `regime_features(X, w, period)` — the causal trailing vol / mean-log-return matrix; `detect_regimes` refactored to reuse it (behaviour unchanged).

### Test plan (synthetic only)
- **no-lookahead**: fit on a prefix, perturb the future → earlier labels identical; feature-matrix causality; determinism; vol-ordering; fit_predict ≈ in-sample `detect_regimes` (~0.96 agreement).
- `pytest` → **556 passed, 1 skipped**; `ruff`/`mypy` clean; `sphinx-build -W` ok (2 stubs committed).