### PR TITLE
docs: finish multi-input harness epic

### DIFF
--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -40,9 +40,13 @@ so an agent doesn't re-investigate settled ground or assume a known stub is a bu
   **guardrails** (`permutation_test`, `probabilistic_sharpe_ratio`,
   `deflated_sharpe_ratio`), comparison report (`compare_report`/`leaderboard`) and a
   persistent `Ledger` (append/load/leaderboard, `n_trials`, deflated-Sharpe vs
-  trials). **Data-agnostic and result-free**: artifacts only go to a caller-provided
-  `output_dir`; real data + result storage live in a separate private repo. Driven
-  by the user-level `/run-strategy` skill.
+  trials). **Multi-input**: `Strategy`/`run_experiment` accept a precomputed
+  feature matrix `X`/`y` (price → P&L only; walk-forward slices `X` per window =
+  the rolling-NN refit), and `fynance.features.RegimeDetector` gives a **causal**
+  regime label (fit-on-train/assign-online; `detect_regimes` stays in-sample for
+  analysis). **Data-agnostic and result-free**: artifacts only go to a
+  caller-provided `output_dir`; real data + result storage live in a separate
+  private repo (`fynance-research`). Driven by the user-level `/run-strategy` skill.
 - **Numerical kernels on Numba `@njit`** — no Cython anywhere; the build is
   pure-Python (no `setup.py`, no compile step). Every kernel has a golden-value
   parity test (1e-9/1e-10) captured from the former Cython.

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -19,26 +19,6 @@ shipped, `03-decisions.md` for *why*. Keep it short and true.
 
 ---
 
-## 3. Harnais multi-input — entrées `X`/`y` + régime causal  ⭐ active
-
-Débloquer les **stratégies NN sophistiquées** (qui vivent dans le repo privé) en
-donnant au harnais ce qui lui manque : nourrir un **modèle** avec une **matrice de
-features `X` (+ cible `y`)** alignée sur le prix, et un **label de régime causal**
-(le `detect_regimes` actuel est in-sample → lookahead). Ces deux briques sont
-**génériques** (l'outil) ; les stratégies A/B/C les consomment côté privé.
-
-- [ ] **I1 entrées `X`/`y`** — `Strategy.run`/`run_walk_forward` et
-  `run_experiment` acceptent une matrice de features précalculée `X` (alignée sur
-  le prix) + `y`, slicée par fenêtre (refit walk-forward = le « rolling NN »). Le
-  prix ne sert plus qu'au PnL ; `X` porte features exogènes / régime / multi-venue.
-- [ ] **I2 régime causal** — un `RegimeDetector` (fit k-means sur le train,
-  assignation online du test au centroïde le plus proche) + `regime_features`
-  causales. `detect_regimes` (in-sample) reste pour l'analyse. Probe no-lookahead.
-
-> Les stratégies (C régime+rolling NN, B TCN/LSTM+SharpeLoss, A multi-venue) et les
-> adaptateurs de vraie data vivent dans le **repo privé** `fynance-research`, pas
-> ici. fynance ne fournit que les briques génériques ci-dessus.
-
 ## 2. Research harness — extensions optionnelles
 
 Le harnais R&D `fynance.research` est **livré** (S1–S3) : `Experiment`,


### PR DESCRIPTION
Closes the multi-input epic: **I1** (precomputed `X`/`y` through the harness, #151) and **I2** (causal `RegimeDetector`, #152). Removes roadmap §3 and records both in `06-status.md`. Docs-only. After merge → release (minor, new public API → 2.4.0).