### PR TITLE
chore: release v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [2.4.0] - 2026-06-17
+
+### Breaking Changes
+
+### Added
+
 - `Strategy.run` / `Strategy.run_walk_forward` and `fynance.research.run_experiment` accept a precomputed feature matrix `X` (aligned with the price index): when given it replaces `features(prices)` and the walk-forward slices `X[train]`/`X[test]` per window (the rolling-NN refit). Prices are used only for the P&L; `X` carries exogenous / regime / multi-venue inputs the price-only featurizer cannot build. `X`/`y` dtypes are preserved (so a float32 `X` matches a float32 torch model).
 - `fynance.features.RegimeDetector` — a **causal** market-regime detector (fit k-means on a training slice, assign later points to the nearest training centroid), plus `regime_features` (the causal trailing vol / mean-return matrix). Unlike `detect_regimes` (in-sample), it is safe as a backtest feature. `detect_regimes` is unchanged (refactored to share `regime_features`).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fynance"
-version = "2.3.0"
+version = "2.4.0"
 description = "Pure-Python (Numba-accelerated) machine learning, econometrics and statistical tools for financial analysis and backtesting"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Minor release — multi-input harness (X/y feature matrices + causal regime).

## [2.4.0]
### Added
- Precomputed feature matrix `X`/`y` threaded through `Strategy`/`run_experiment` (price → P&L only; walk-forward slices `X` per window = the rolling-NN refit; dtypes preserved).
- `fynance.features.RegimeDetector` (causal fit-on-train/assign-online) + `regime_features`; `detect_regimes` unchanged.

## Test plan
- CI green on develop (556 tests + 1 skipped, ruff, mypy, Sphinx -W).