### PR TITLE
Release v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Strategy.run` / `Strategy.run_walk_forward` and `fynance.research.run_experiment` accept a precomputed feature matrix `X` (aligned with the price index): when given it replaces `features(prices)` and the walk-forward slices `X[train]`/`X[test]` per window (the rolling-NN refit). Prices are used only for the P&L; `X` carries exogenous / regime / multi-venue inputs the price-only featurizer cannot build. `X`/`y` dtypes are preserved (so a float32 `X` matches a float32 torch model).
+
 ### Changed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `Strategy.run` / `Strategy.run_walk_forward` and `fynance.research.run_experiment` accept a precomputed feature matrix `X` (aligned with the price index): when given it replaces `features(prices)` and the walk-forward slices `X[train]`/`X[test]` per window (the rolling-NN refit). Prices are used only for the P&L; `X` carries exogenous / regime / multi-venue inputs the price-only featurizer cannot build. `X`/`y` dtypes are preserved (so a float32 `X` matches a float32 torch model).
+- `fynance.features.RegimeDetector` — a **causal** market-regime detector (fit k-means on a training slice, assign later points to the nearest training centroid), plus `regime_features` (the causal trailing vol / mean-return matrix). Unlike `detect_regimes` (in-sample), it is safe as a backtest feature. `detect_regimes` is unchanged (refactored to share `regime_features`).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [2.4.0] - 2026-06-17
+
+### Breaking Changes
+
+### Added
+
 - `Strategy.run` / `Strategy.run_walk_forward` and `fynance.research.run_experiment` accept a precomputed feature matrix `X` (aligned with the price index): when given it replaces `features(prices)` and the walk-forward slices `X[train]`/`X[test]` per window (the rolling-NN refit). Prices are used only for the P&L; `X` carries exogenous / regime / multi-venue inputs the price-only featurizer cannot build. `X`/`y` dtypes are preserved (so a float32 `X` matches a float32 torch model).
 - `fynance.features.RegimeDetector` — a **causal** market-regime detector (fit k-means on a training slice, assign later points to the nearest training centroid), plus `regime_features` (the causal trailing vol / mean-return matrix). Unlike `detect_regimes` (in-sample), it is safe as a backtest feature. `detect_regimes` is unchanged (refactored to share `regime_features`).
 

--- a/badges/interrogate_badge.svg
+++ b/badges/interrogate_badge.svg
@@ -1,5 +1,5 @@
 <svg width="140" height="20" viewBox="0 0 140 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <title>interrogate: 94.1%</title>
+    <title>interrogate: 94.2%</title>
     <g transform="matrix(1,0,0,1,22,0)">
         <g id="backgrounds" transform="matrix(1.32789,0,0,1,-22.3892,0)">
             <rect x="0" y="0" width="71" height="20" style="fill:rgb(85,85,85);"/>
@@ -12,8 +12,8 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
         <text x="590" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="610">interrogate</text>
         <text x="590" y="140" transform="scale(.1)" textLength="610">interrogate</text>
-        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">94.1%</text>
-        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">94.1%</text>
+        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">94.2%</text>
+        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">94.2%</text>
     </g>
     <g id="logo-shadow" serif:id="logo shadow" transform="matrix(0.854876,0,0,0.854876,-6.73514,1.732)">
         <g transform="matrix(0.299012,0,0,0.299012,9.70229,-6.68582)">

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -40,9 +40,13 @@ so an agent doesn't re-investigate settled ground or assume a known stub is a bu
   **guardrails** (`permutation_test`, `probabilistic_sharpe_ratio`,
   `deflated_sharpe_ratio`), comparison report (`compare_report`/`leaderboard`) and a
   persistent `Ledger` (append/load/leaderboard, `n_trials`, deflated-Sharpe vs
-  trials). **Data-agnostic and result-free**: artifacts only go to a caller-provided
-  `output_dir`; real data + result storage live in a separate private repo. Driven
-  by the user-level `/run-strategy` skill.
+  trials). **Multi-input**: `Strategy`/`run_experiment` accept a precomputed
+  feature matrix `X`/`y` (price → P&L only; walk-forward slices `X` per window =
+  the rolling-NN refit), and `fynance.features.RegimeDetector` gives a **causal**
+  regime label (fit-on-train/assign-online; `detect_regimes` stays in-sample for
+  analysis). **Data-agnostic and result-free**: artifacts only go to a
+  caller-provided `output_dir`; real data + result storage live in a separate
+  private repo (`fynance-research`). Driven by the user-level `/run-strategy` skill.
 - **Numerical kernels on Numba `@njit`** — no Cython anywhere; the build is
   pure-Python (no `setup.py`, no compile step). Every kernel has a golden-value
   parity test (1e-9/1e-10) captured from the former Cython.

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -19,6 +19,26 @@ shipped, `03-decisions.md` for *why*. Keep it short and true.
 
 ---
 
+## 3. Harnais multi-input — entrées `X`/`y` + régime causal  ⭐ active
+
+Débloquer les **stratégies NN sophistiquées** (qui vivent dans le repo privé) en
+donnant au harnais ce qui lui manque : nourrir un **modèle** avec une **matrice de
+features `X` (+ cible `y`)** alignée sur le prix, et un **label de régime causal**
+(le `detect_regimes` actuel est in-sample → lookahead). Ces deux briques sont
+**génériques** (l'outil) ; les stratégies A/B/C les consomment côté privé.
+
+- [ ] **I1 entrées `X`/`y`** — `Strategy.run`/`run_walk_forward` et
+  `run_experiment` acceptent une matrice de features précalculée `X` (alignée sur
+  le prix) + `y`, slicée par fenêtre (refit walk-forward = le « rolling NN »). Le
+  prix ne sert plus qu'au PnL ; `X` porte features exogènes / régime / multi-venue.
+- [ ] **I2 régime causal** — un `RegimeDetector` (fit k-means sur le train,
+  assignation online du test au centroïde le plus proche) + `regime_features`
+  causales. `detect_regimes` (in-sample) reste pour l'analyse. Probe no-lookahead.
+
+> Les stratégies (C régime+rolling NN, B TCN/LSTM+SharpeLoss, A multi-venue) et les
+> adaptateurs de vraie data vivent dans le **repo privé** `fynance-research`, pas
+> ici. fynance ne fournit que les briques génériques ci-dessus.
+
 ## 2. Research harness — extensions optionnelles
 
 Le harnais R&D `fynance.research` est **livré** (S1–S3) : `Experiment`,

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -19,26 +19,6 @@ shipped, `03-decisions.md` for *why*. Keep it short and true.
 
 ---
 
-## 3. Harnais multi-input — entrées `X`/`y` + régime causal  ⭐ active
-
-Débloquer les **stratégies NN sophistiquées** (qui vivent dans le repo privé) en
-donnant au harnais ce qui lui manque : nourrir un **modèle** avec une **matrice de
-features `X` (+ cible `y`)** alignée sur le prix, et un **label de régime causal**
-(le `detect_regimes` actuel est in-sample → lookahead). Ces deux briques sont
-**génériques** (l'outil) ; les stratégies A/B/C les consomment côté privé.
-
-- [ ] **I1 entrées `X`/`y`** — `Strategy.run`/`run_walk_forward` et
-  `run_experiment` acceptent une matrice de features précalculée `X` (alignée sur
-  le prix) + `y`, slicée par fenêtre (refit walk-forward = le « rolling NN »). Le
-  prix ne sert plus qu'au PnL ; `X` porte features exogènes / régime / multi-venue.
-- [ ] **I2 régime causal** — un `RegimeDetector` (fit k-means sur le train,
-  assignation online du test au centroïde le plus proche) + `regime_features`
-  causales. `detect_regimes` (in-sample) reste pour l'analyse. Probe no-lookahead.
-
-> Les stratégies (C régime+rolling NN, B TCN/LSTM+SharpeLoss, A multi-venue) et les
-> adaptateurs de vraie data vivent dans le **repo privé** `fynance-research`, pas
-> ici. fynance ne fournit que les briques génériques ci-dessus.
-
 ## 2. Research harness — extensions optionnelles
 
 Le harnais R&D `fynance.research` est **livré** (S1–S3) : `Experiment`,

--- a/doc/source/features.regime.rst
+++ b/doc/source/features.regime.rst
@@ -2,7 +2,10 @@
 Market regime
 *************
 
-Unsupervised market-regime labelling by clustering rolling volatility / return features (:func:`~fynance.features.regime.detect_regimes`).
+Unsupervised market-regime labelling by clustering rolling volatility / return
+features. :func:`~fynance.features.regime.detect_regimes` is the in-sample
+convenience (for analysis); :class:`~fynance.features.regime.RegimeDetector` is
+the **causal** fit-on-train / assign-online variant for backtests.
 
 .. currentmodule:: fynance.features.regime
 
@@ -10,3 +13,5 @@ Unsupervised market-regime labelling by clustering rolling volatility / return f
    :toctree: generated/
 
    detect_regimes
+   regime_features
+   RegimeDetector

--- a/doc/source/generated/fynance.features.regime.RegimeDetector.rst
+++ b/doc/source/generated/fynance.features.regime.RegimeDetector.rst
@@ -1,0 +1,13 @@
+﻿RegimeDetector
+======================================
+
+*Defined in* :mod:`fynance.features.regime`
+
+.. currentmodule:: fynance.features.regime
+
+.. autoclass:: RegimeDetector
+   :members:
+   :inherited-members:
+   :special-members: __call__, __iter__, __next__
+   :show-inheritance:
+   :no-index:

--- a/doc/source/generated/fynance.features.regime.regime_features.rst
+++ b/doc/source/generated/fynance.features.regime.regime_features.rst
@@ -1,0 +1,9 @@
+﻿regime_features
+=======================================
+
+*Defined in* :mod:`fynance.features.regime`
+
+.. currentmodule:: fynance.features.regime
+
+.. autofunction:: regime_features
+   :no-index:

--- a/fynance/features/regime.py
+++ b/fynance/features/regime.py
@@ -19,7 +19,113 @@ from scipy.cluster.vq import kmeans2
 # Local packages
 from fynance.features.indicators import realized_volatility
 
-__all__ = ['detect_regimes']
+__all__ = ['detect_regimes', 'regime_features', 'RegimeDetector']
+
+
+def regime_features(X: NDArray, w: int = 21, period: int = 252) -> NDArray:
+    """ Build the causal regime feature matrix: trailing vol and mean return.
+
+    Both columns use **trailing** windows (past only), so the matrix is causal —
+    the value at ``t`` depends on ``X[:t+1]`` only.
+
+    Parameters
+    ----------
+    X : np.ndarray
+        One-dimensional price/level series.
+    w : int
+        Rolling window.
+    period : int
+        Annualization factor for the volatility column.
+
+    Returns
+    -------
+    np.ndarray
+        Shape ``(len(X), 2)`` — ``[realized_volatility, rolling_mean_log_return]``.
+
+    """
+    X = np.asarray(X, dtype=np.float64).reshape(-1)
+    vol = np.asarray(realized_volatility(X, w=w, period=period))
+    ret = np.zeros_like(X)
+    ret[1:] = np.log(X[1:] / X[:-1])
+    roll_ret = np.zeros_like(X)
+    for t in range(X.shape[0]):
+        roll_ret[t] = ret[max(0, t - w + 1):t + 1].mean()
+
+    return np.column_stack([vol, roll_ret])
+
+
+class RegimeDetector:
+    """ Causal market-regime detector (fit on the past, assign online).
+
+    Unlike :func:`detect_regimes` (which clusters in-sample and therefore peeks
+    at the whole series), this fits k-means on a **training** slice only and
+    assigns any later point to the nearest training centroid — so labels are a
+    **strictly causal** feature usable in a backtest. Labels are ordered by
+    increasing mean volatility (0 = calmest), like :func:`detect_regimes`.
+
+    Parameters
+    ----------
+    n_regimes : int
+        Number of regimes (clusters).
+    w : int
+        Rolling window for the features.
+    period : int
+        Annualization factor for the volatility feature.
+    seed : int
+        Seed for the k-means initialization.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from fynance.features import RegimeDetector
+    >>> rng = np.random.default_rng(0)
+    >>> p = 100 * np.exp(np.cumsum(rng.standard_normal(400) * 0.01))
+    >>> det = RegimeDetector(n_regimes=2, w=10).fit(p[:300])
+    >>> labels = det.predict(p)
+    >>> labels.shape, set(np.unique(labels)) <= {0, 1}
+    ((400,), True)
+
+    """
+
+    def __init__(self, n_regimes: int = 3, w: int = 21, period: int = 252,
+                 seed: int = 0):
+        self.n_regimes = n_regimes
+        self.w = w
+        self.period = period
+        self.seed = seed
+
+    def fit(self, X: NDArray) -> RegimeDetector:
+        """ Fit k-means on the training series ``X`` (past only). """
+        feats = regime_features(X, self.w, self.period)
+        self._mu = feats.mean(axis=0)
+        self._sd = feats.std(axis=0)
+        self._sd[self._sd == 0] = 1.0
+        z = (feats - self._mu) / self._sd
+
+        centroids, labels = kmeans2(z, self.n_regimes, seed=self.seed,
+                                    minit='++', missing='raise')
+        self._centroids = centroids
+
+        # Order clusters by mean (unstandardized) volatility for stable labels.
+        vol = feats[:, 0]
+        order = np.argsort([vol[labels == k].mean() for k in range(self.n_regimes)])
+        remap = np.empty(self.n_regimes, dtype=int)
+        remap[order] = np.arange(self.n_regimes)
+        self._remap = remap
+
+        return self
+
+    def predict(self, X: NDArray) -> NDArray:
+        """ Assign each point of ``X`` to the nearest training centroid. """
+        feats = regime_features(X, self.w, self.period)
+        z = (feats - self._mu) / self._sd
+        dist = ((z[:, None, :] - self._centroids[None, :, :]) ** 2).sum(axis=-1)
+
+        return self._remap[dist.argmin(axis=1)]
+
+    def fit_predict(self, X: NDArray) -> NDArray:
+        """ Convenience: :meth:`fit` then :meth:`predict` on the same series. """
+        return self.fit(X).predict(X)
 
 
 def detect_regimes(
@@ -59,21 +165,14 @@ def detect_regimes(
         ``[0, n_regimes)`` and ordered by increasing average volatility.
 
     """
-    X = np.asarray(X, dtype=np.float64).reshape(-1)
-    vol = np.asarray(realized_volatility(X, w=w, period=period))
-    ret = np.zeros_like(X)
-    ret[1:] = np.log(X[1:] / X[:-1])
-    roll_ret = np.zeros_like(X)
-    for t in range(X.shape[0]):
-        roll_ret[t] = ret[max(0, t - w + 1):t + 1].mean()
-
-    feats = np.column_stack([vol, roll_ret])
+    feats = regime_features(X, w=w, period=period)
+    vol = feats[:, 0]
     mu = feats.mean(axis=0)
     sd = feats.std(axis=0)
     sd[sd == 0] = 1.0
-    feats = (feats - mu) / sd
+    z = (feats - mu) / sd
 
-    _, labels = kmeans2(feats, n_regimes, seed=seed, minit='++', missing='raise')
+    _, labels = kmeans2(z, n_regimes, seed=seed, minit='++', missing='raise')
 
     # Re-order labels by increasing mean volatility for stable interpretation.
     order = np.argsort([vol[labels == k].mean() for k in range(n_regimes)])

--- a/fynance/research/runner.py
+++ b/fynance/research/runner.py
@@ -51,6 +51,7 @@ def run_experiment(
     data: Any,
     *,
     name: str,
+    X: NDArray | None = None,
     y: NDArray | None = None,
     walk_forward: dict[str, Any] | None = None,
     costs: Any = None,
@@ -69,6 +70,10 @@ def run_experiment(
         Price series the strategy runs on (coerced to float64).
     name : str
         Experiment slug (also the output sub-directory).
+    X : array-like, optional
+        Precomputed feature matrix aligned with ``data`` (rows = time). Passed
+        through to the strategy — the way to feed exogenous / regime / multi-venue
+        features the price-only featurizer cannot build. Must be causal.
     y : array-like, optional
         Supervised target for a model-based strategy run via ``walk_forward``.
         Defaults to zeros (ignored by rule-based strategies).
@@ -101,17 +106,18 @@ def run_experiment(
     n = prices.shape[0]
 
     if walk_forward is not None:
-        target = np.zeros(n) if y is None else np.asarray(y, dtype=np.float64)
-        result = strategy.run_walk_forward(data, target, **walk_forward)
+        target = np.zeros(n) if y is None else np.asarray(y)  # preserve dtype
+        result = strategy.run_walk_forward(data, target, **walk_forward, X=X)
 
     else:
-        result = strategy.run(data, y)
+        result = strategy.run(data, y, X=X)
 
     metrics = result.summary(period=period)
 
     spec: dict[str, Any] = {
         "data": {"kind": getattr(data, "name", None) or type(data).__name__,
                  "n": int(n)},
+        "features": None if X is None else {"X_shape": list(np.asarray(X).shape)},
         "walk_forward": walk_forward,
         "cost": type(strategy.cost).__name__ if strategy.cost is not None else None,
         "period": period,

--- a/fynance/strategy/strategy.py
+++ b/fynance/strategy/strategy.py
@@ -83,9 +83,24 @@ class Strategy:
 
         return np.asarray(self.features(prices), dtype=np.float64)
 
-    def _positions(self, prices: NDArray, y: NDArray | None) -> NDArray:
-        """ Compute the (unshifted) position series from a price series. """
-        feats = self._featurize(prices)
+    def _resolve_features(self, prices: NDArray, X: NDArray | None) -> NDArray:
+        """ Use a precomputed feature matrix ``X`` if given, else featurize prices.
+
+        ``X`` is the caller's responsibility to keep **aligned with the price
+        index** and **causal** — it carries exogenous features (engineered inputs,
+        a regime label, other venues) that the price-only featurizer cannot build.
+        Its dtype is preserved (so a float32 ``X`` matches a float32 torch model).
+        """
+        if X is not None:
+
+            return np.asarray(X)
+
+        return self._featurize(prices)
+
+    def _positions(self, prices: NDArray, y: NDArray | None,
+                   X: NDArray | None = None) -> NDArray:
+        """ Compute the (unshifted) position series. """
+        feats = self._resolve_features(prices, X)
 
         if self.model is not None:
             if y is not None:
@@ -98,16 +113,21 @@ class Strategy:
 
         return np.asarray(self.signal(preds), dtype=np.float64).reshape(-1)
 
-    def run(self, data: Any, y: NDArray | None = None) -> BacktestResult:
+    def run(self, data: Any, y: NDArray | None = None,
+            X: NDArray | None = None) -> BacktestResult:
         """ Run the strategy on a price series, returning a backtest result.
 
         Parameters
         ----------
         data : PriceSeries or array-like
-            Price series.
+            Price series (used for the P&L).
         y : array-like, optional
             Supervised target for the model (fit on the whole series; for
             leak-free training use :meth:`run_walk_forward`).
+        X : array-like, optional
+            Precomputed feature matrix aligned with ``data`` (rows = time). When
+            given it replaces ``features(prices)`` — use it to feed exogenous /
+            regime / multi-venue inputs the price-only featurizer cannot build.
 
         Returns
         -------
@@ -116,7 +136,7 @@ class Strategy:
         """
         prices = _as_array(data)
         returns = prices[1:] / prices[:-1] - 1.0
-        positions = self._positions(prices, y)
+        positions = self._positions(prices, y, X)
 
         # Align positions with the returns series (drop the first observation).
         if positions.shape[0] == prices.shape[0]:
@@ -132,16 +152,18 @@ class Strategy:
         test: int,
         step: int | None = None,
         purge: int = 0,
+        X: NDArray | None = None,
     ) -> BacktestResult:
         """ Walk-forward run: refit per window on train only, predict on test.
 
         The model and features are fit on each train slice only; out-of-sample
         positions are stitched together and backtested. Strictly no-lookahead.
+        This per-window refit *is* the rolling-NN pattern when ``model`` is a net.
 
         Parameters
         ----------
         data : PriceSeries or array-like
-            Price series.
+            Price series (used for the P&L).
         y : array-like
             Supervised target aligned with ``data``.
         train, test : int
@@ -150,6 +172,11 @@ class Strategy:
             Roll step (defaults to ``test``).
         purge : int
             Embargo removed at the train/test boundary.
+        X : array-like, optional
+            Precomputed feature matrix aligned with ``data`` (rows = time). When
+            given, each window slices ``X[train]`` / ``X[test]`` instead of
+            featurizing the price slices — the way to feed exogenous / regime /
+            multi-venue features. ``X`` must be causal and index-aligned.
 
         Returns
         -------
@@ -158,7 +185,8 @@ class Strategy:
 
         """
         prices = _as_array(data)
-        y_arr = np.asarray(y, dtype=np.float64)
+        y_arr = np.asarray(y)  # preserve caller dtype (match X / the model)
+        X_arr = None if X is None else np.asarray(X)  # preserve caller dtype
         n = prices.shape[0]
 
         oos_pos: list[float] = []
@@ -166,8 +194,13 @@ class Strategy:
 
         for tr, te in walk_forward(n, train=train, test=test, step=step,
                                    purge=purge):
-            feats_tr = self._featurize(prices[tr])
-            feats_te = self._featurize(prices[te])
+            if X_arr is not None:
+                feats_tr = X_arr[tr]
+                feats_te = X_arr[te]
+
+            else:
+                feats_tr = self._featurize(prices[tr])
+                feats_te = self._featurize(prices[te])
 
             if self.model is not None:
                 self.model.fit(feats_tr, y_arr[tr])

--- a/fynance/tests/features/test_regime_causal.py
+++ b/fynance/tests/features/test_regime_causal.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" I2 — causal `RegimeDetector` (fit-on-train / assign-online). """
+
+# Third-party
+import numpy as np
+
+# Local
+from fynance.features import RegimeDetector, detect_regimes, regime_features
+from fynance.research import regime_switching
+
+
+def _series(n=600, seed=1):
+    return regime_switching(
+        n, regimes=((0.0, 0.004), (0.0, 0.03)), p_switch=0.01, seed=seed
+    ).to_numpy()
+
+
+def test_regime_features_shape_and_causality():
+    p = _series(300)
+    f = regime_features(p, w=20)
+    assert f.shape == (300, 2)
+    # Causal: perturbing the tail leaves earlier feature rows untouched.
+    pert = p.copy()
+    pert[200:] *= 1.5
+    assert np.array_equal(regime_features(p, w=20)[:200],
+                          regime_features(pert, w=20)[:200])
+
+
+def test_detector_determinism_and_shapes():
+    p = _series()
+    a = RegimeDetector(n_regimes=2, w=20, seed=0).fit_predict(p)
+    b = RegimeDetector(n_regimes=2, w=20, seed=0).fit_predict(p)
+
+    assert a.shape == (len(p),)
+    assert np.array_equal(a, b)
+    assert set(np.unique(a)) <= {0, 1}
+
+
+def test_labels_ordered_by_volatility():
+    p = _series(900, seed=3)
+    det = RegimeDetector(n_regimes=3, w=21, seed=0).fit(p)
+    labels = det.predict(p)
+    vol = regime_features(p, w=21)[:, 0]
+
+    present = [k for k in range(3) if np.any(labels == k)]
+    means = [vol[labels == k].mean() for k in present]
+    # Label index increases with mean volatility (calmest = 0).
+    assert means == sorted(means)
+
+
+def test_no_lookahead_fit_on_past_assign_online():
+    # THE causality guarantee: fit on a prefix, then perturb the future — the
+    # labels on the earlier (unperturbed) prefix must be identical.
+    p = _series(600, seed=1)
+    det = RegimeDetector(n_regimes=2, w=20, seed=0).fit(p[:400])
+
+    base = det.predict(p)
+    pert = p.copy()
+    cut = 450
+    rng = np.random.default_rng(0)
+    pert[cut:] *= np.cumprod(1.0 + rng.standard_normal(len(p) - cut) * 0.05)
+    moved = det.predict(pert)
+
+    assert np.array_equal(base[:cut], moved[:cut])
+
+
+def test_fit_predict_matches_in_sample_detect_regimes():
+    # Fit-predict on the whole series ≈ the in-sample detect_regimes (nearest
+    # centroid == the k-means assignment).
+    p = _series(500, seed=2)
+    a = RegimeDetector(n_regimes=3, w=21, seed=0).fit_predict(p)
+    b = detect_regimes(p, n_regimes=3, w=21, seed=0)
+
+    # Same regimes; the few % gap is k-means' own labels vs nearest-centroid
+    # reassignment on borderline points (the detector uses the latter, which is
+    # also what it must do out-of-sample).
+    assert (a == b).mean() > 0.90

--- a/fynance/tests/research/test_xy_inputs.py
+++ b/fynance/tests/research/test_xy_inputs.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" I1 — precomputed feature-matrix ``X`` / ``y`` threaded through the harness. """
+
+# Third-party
+import numpy as np
+import torch
+import torch.nn as nn
+
+# Local
+from fynance.models import MultiLayerPerceptron
+from fynance.research import Experiment, gbm, run_experiment
+from fynance.signal import sign
+from fynance.strategy import Strategy
+
+
+class LinearStub:
+    """ Deterministic least-squares SignalModel stub (fit/predict). """
+
+    def fit(self, X, y):
+        X = np.asarray(X, dtype=float)
+        y = np.asarray(y, dtype=float).reshape(X.shape[0], -1)
+        self.w, *_ = np.linalg.lstsq(X, y, rcond=None)
+        return self
+
+    def predict(self, X):
+        return np.asarray(X, dtype=float) @ self.w
+
+
+def test_run_with_X_matches_features_callable():
+    # Single-pass run: precomputed X must equal the same feature via a callable.
+    prices = gbm(300, seed=1)
+    feat = lambda p: np.sign(np.diff(p, prepend=p[0]))  # noqa: E731
+
+    r_callable = Strategy(features=feat).run(prices)
+    r_matrix = Strategy().run(prices, X=feat(prices.to_numpy()))
+
+    assert np.allclose(r_callable.equity, r_matrix.equity)
+
+
+def test_walk_forward_X_runs_and_uses_the_matrix():
+    prices = gbm(400, seed=2)
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(len(prices.to_numpy()), 2))
+    y = (X[:, :1] - X[:, 1:2])  # a learnable linear target
+
+    strat = Strategy(model=LinearStub(), signal=sign)
+    res = strat.run_walk_forward(prices, y, train=80, test=40, X=X)
+
+    assert np.all(np.isfinite(res.equity))
+    # Positions actually depend on X: a different X gives a different result.
+    res2 = strat.run_walk_forward(prices, y, train=80, test=40, X=rng.normal(size=X.shape))
+    assert not np.allclose(res.equity, res2.equity)
+
+
+def test_walk_forward_X_is_deterministic():
+    prices = gbm(400, seed=2)
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(len(prices.to_numpy()), 2))
+    y = X[:, :1]
+
+    a = Strategy(model=LinearStub()).run_walk_forward(prices, y, train=80, test=40, X=X)
+    b = Strategy(model=LinearStub()).run_walk_forward(prices, y, train=80, test=40, X=X)
+    assert np.allclose(a.equity, b.equity)
+
+
+def test_no_lookahead_with_X_and_model():
+    # Perturbing the price tail leaves the earlier OOS returns unchanged (X is
+    # precomputed/causal; early windows never see the perturbed future).
+    prices = gbm(600, seed=7).to_numpy()
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(len(prices), 2))
+    y = X[:, :1]
+    wf = dict(train=120, test=60)
+
+    base = Strategy(model=LinearStub()).run_walk_forward(prices, y, **wf, X=X)
+
+    pert = prices.copy()
+    cut = int(len(prices) * 0.7)
+    pert[cut:] *= np.cumprod(1.0 + rng.standard_normal(len(prices) - cut) * 0.05)
+    moved = Strategy(model=LinearStub()).run_walk_forward(pert, y, **wf, X=X)
+
+    k = len(base.returns) // 3
+    assert np.allclose(base.returns[:k], moved.returns[:k])
+
+
+def test_run_experiment_threads_and_records_X():
+    prices = gbm(400, seed=3)
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(len(prices.to_numpy()), 2))
+    y = X[:, :1]
+
+    exp = run_experiment(Strategy(model=LinearStub(), signal=sign), prices,
+                         name="xy", X=X, y=y, walk_forward=dict(train=80, test=40))
+
+    assert isinstance(exp, Experiment)
+    assert exp.spec["features"] == {"X_shape": [X.shape[0], X.shape[1]]}
+    assert np.all(np.isfinite(list(exp.metrics.values())))
+
+
+def test_real_mlp_rolling_over_X():
+    # The rolling-NN path: a real MLP refit per walk-forward window over X.
+    prices = gbm(360, seed=5)
+    rng = np.random.default_rng(0)
+    n = len(prices.to_numpy())
+    X = rng.normal(size=(n, 2)).astype(np.float32)
+    y = (X.sum(axis=1, keepdims=True)).astype(np.float32)
+
+    mlp = MultiLayerPerceptron(2, 1, layers=[4])
+    mlp.set_optimizer(nn.MSELoss, torch.optim.SGD, lr=1e-3)
+
+    exp = run_experiment(Strategy(model=mlp, signal=np.sign), prices, name="mlp",
+                         X=X, y=y, walk_forward=dict(train=120, test=60), seed=0)
+
+    assert np.all(np.isfinite(list(exp.metrics.values())))
+    assert exp.series["equity"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fynance"
-version = "2.3.0"
+version = "2.4.0"
 description = "Pure-Python (Numba-accelerated) machine learning, econometrics and statistical tools for financial analysis and backtesting"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Promotes develop (v2.4.0) to master. Merge after CI, then tag.

## [2.4.0]
### Added
- Multi-input harness: precomputed `X`/`y` through `Strategy`/`run_experiment` (rolling-NN refit), and a causal `fynance.features.RegimeDetector` + `regime_features`.