### PR TITLE
fix: sharpe/sortino crash on zero-volatility curve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `sharpe` / `sortino` crashed (`TypeError`) on a **constant / zero-volatility** equity curve — a legitimate result for a flat ("do-nothing") strategy. They now return `0.0` when the excess return is also zero and `+inf` for a riskless positive drift, for both scalar (1-D) and array (2-D) inputs (shared `_safe_ratio` helper). `summary()` no longer crashes on a flat curve.
+
 ### Deprecated
 
 ### Removed

--- a/fynance/metrics/ratios.py
+++ b/fynance/metrics/ratios.py
@@ -6,6 +6,8 @@
 from __future__ import annotations
 
 # Built-in packages
+from typing import Any
+
 # Third-party packages
 import numpy as np
 from numpy.typing import NDArray
@@ -16,6 +18,32 @@ from fynance._wrappers import WrapperArray
 from fynance.features._metrics_helpers import *  # noqa: F401,F403
 
 __all__ = ['annual_volatility', 'sharpe', 'sortino', 'calmar', 'diversified_ratio', 'roll_annual_volatility', 'roll_sharpe', 'roll_calmar']
+
+
+def _safe_ratio(excess: NDArray, denom: NDArray) -> Any:
+    """ ``excess / denom`` robust to a zero denominator (scalar **or** array).
+
+    A zero-volatility series has an undefined ratio: it is ``+inf`` when the
+    excess return is non-zero (a riskless gain), and ``0`` when the excess is also
+    zero (a flat, do-nothing curve). Returns a numpy scalar for 0-D input and an
+    array otherwise — matching the surrounding ratio functions' shape contract.
+    """
+    excess = np.asarray(excess, dtype=np.float64)
+    denom = np.asarray(denom, dtype=np.float64)
+
+    if denom.ndim == 0:
+        if denom != 0.:
+
+            return np.float64(excess / denom)
+
+        return np.float64(np.inf if excess != 0. else 0.)
+
+    res = np.full(denom.shape, np.inf, dtype=np.float64)
+    nz = denom != 0.
+    res[nz] = excess[nz] / denom[nz]
+    res[(~nz) & (excess == 0.)] = 0.
+
+    return res
 
 
 @WrapperArray('dtype', 'axis', 'null', 'ddof', min_size=2)
@@ -162,14 +190,8 @@ def sharpe(X: NDArray, rf: float = 0, period: int = 252, log: bool = False, axis
     """
     ret = _annual_return(X, period, ddof)
     vol = _annual_volatility(X, period, log, axis, ddof)
-    if (vol == 0.).any():
-        res = ret - rf
-        res[vol == 0.] = np.inf
-        res[vol != 0.] = res[vol != 0.] / vol[vol != 0.]
 
-        return res
-
-    return (ret - rf) / vol
+    return _safe_ratio(ret - rf, vol)
 
 
 @WrapperArray('dtype', 'axis', 'null', 'ddof', min_size=2)
@@ -238,14 +260,7 @@ def sortino(
     ret = _annual_return(X, period, ddof)
     downside_vol = np.sqrt(period) * np.std(np.where(R < 0, R, 0.), axis=axis, ddof=ddof)
 
-    if (downside_vol == 0.).any():
-        res = ret - rf
-        res[downside_vol == 0.] = np.inf
-        res[downside_vol != 0.] = res[downside_vol != 0.] / downside_vol[downside_vol != 0.]
-
-        return res
-
-    return (ret - rf) / downside_vol
+    return _safe_ratio(ret - rf, downside_vol)
 
 
 @WrapperArray('dtype', 'axis', 'ddof', min_size=2)

--- a/fynance/tests/metrics/test_zero_vol_ratios.py
+++ b/fynance/tests/metrics/test_zero_vol_ratios.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" sharpe/sortino must not crash on a zero-volatility (constant) curve. """
+
+# Third-party
+import numpy as np
+
+# Local
+from fynance.metrics import sharpe, sortino
+from fynance.metrics.ratios import _safe_ratio
+from fynance.metrics.summary import summary
+
+
+def test_flat_curve_is_zero_not_crash():
+    flat = np.full(20, 100.0)
+    assert sharpe(flat) == 0.0
+    assert sortino(flat) == 0.0
+
+
+def test_safe_ratio_zero_denominator():
+    # Riskless gain -> +inf; flat (0/0) -> 0; mixed array handled element-wise.
+    assert np.isposinf(_safe_ratio(1.0, 0.0))
+    assert _safe_ratio(0.0, 0.0) == 0.0
+    r = _safe_ratio(np.array([1.0, 0.0, 2.0]), np.array([0.0, 0.0, 2.0]))
+    assert np.isposinf(r[0]) and r[1] == 0.0 and r[2] == 1.0
+
+
+def test_2d_mixed_columns_no_crash():
+    rng = np.random.default_rng(0)
+    normal = 100.0 * np.cumprod(1 + rng.standard_normal(50) * 0.01)
+    flat = np.full(50, 100.0)
+    X = np.column_stack([flat, normal])
+
+    res = sharpe(X, axis=0)
+    assert res.shape == (2,)
+    assert res[0] == 0.0
+    assert np.isfinite(res[1])
+
+
+def test_summary_on_flat_curve():
+    # The regression that surfaced the bug: summary() over a flat equity curve.
+    out = summary(np.full(30, 100.0))
+    assert out["sharpe"] == 0.0
+    assert np.isfinite(out["max_drawdown"])


### PR DESCRIPTION
A flat (do-nothing) strategy yields a constant equity curve → zero volatility. `sharpe`/`sortino` did `res[vol == 0.] = np.inf`, which raises `TypeError` when `res` is a **scalar** (1-D input).

Replaced both with a shared `_safe_ratio(excess, denom)`: zero denominator → `+inf` when the excess is non-zero (riskless gain), else `0.0` (flat); works for scalar **and** array inputs, preserving the scalar-for-1-D / array-for-2-D contract. `calmar` already zero-inits, so it was fine.

Surfaced while running a real regime-NN strategy whose early walk-forward window produced a flat out-of-sample block (the harness should never crash on a legitimate flat result).

### Test plan
- New `test_zero_vol_ratios.py`: flat curve → 0 (no crash); `_safe_ratio` inf/0 branches; 2-D mixed columns; `summary()` on a flat curve.
- `pytest` → **560 passed, 1 skipped**; `ruff`/`mypy` clean; `sphinx-build -W` ok; existing sharpe/sortino doctests unchanged.