### PR TITLE
chore: release v2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+### Deprecated
+
+### Removed
+
+## [2.4.1] - 2026-06-17
+
+### Breaking Changes
+
+### Added
+
+### Changed
+
+### Fixed
+
 - `sharpe` / `sortino` crashed (`TypeError`) on a **constant / zero-volatility** equity curve — a legitimate result for a flat ("do-nothing") strategy. They now return `0.0` when the excess return is also zero and `+inf` for a riskless positive drift, for both scalar (1-D) and array (2-D) inputs (shared `_safe_ratio` helper). `summary()` no longer crashes on a flat curve.
 
 ### Deprecated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fynance"
-version = "2.4.0"
+version = "2.4.1"
 description = "Pure-Python (Numba-accelerated) machine learning, econometrics and statistical tools for financial analysis and backtesting"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Patch — fix `sharpe`/`sortino` crash on a zero-volatility (flat) equity curve. CI green; pyproject → 2.4.1.