### PR TITLE
feat: ObjectiveModel — objective-aligned training

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `fynance.models.ObjectiveModel` — **objective-aligned training**: a `SignalModel` that trains a neural network (any `nn.Module`; a clean MLP by default) **directly on a differentiable financial objective** (`SharpeLoss`/`SortinoLoss`/…) rather than MSE. The net outputs positions and the loss is computed on `positions * returns`; `fit(X, y)` reads `y` as the realized returns, `predict(X)` returns positions in `[-1, 1]`. Plugs into the harness via the `X` path with `signal=identity`, `y=returns`.
+
 ### Changed
 
 ### Fixed

--- a/doc/source/generated/fynance.models.objective.ObjectiveModel.rst
+++ b/doc/source/generated/fynance.models.objective.ObjectiveModel.rst
@@ -1,0 +1,13 @@
+﻿ObjectiveModel
+=======================================
+
+*Defined in* :mod:`fynance.models.objective`
+
+.. currentmodule:: fynance.models.objective
+
+.. autoclass:: ObjectiveModel
+   :members:
+   :inherited-members:
+   :special-members: __call__, __iter__, __next__
+   :show-inheritance:
+   :no-index:

--- a/doc/source/models.neural_network.rst
+++ b/doc/source/models.neural_network.rst
@@ -34,3 +34,4 @@ time-ordered sequences, prefer the recurrent architectures described in
 
    _base.BaseNeuralNet
    mlp.MultiLayerPerceptron
+   objective.ObjectiveModel

--- a/fynance/models/__init__.py
+++ b/fynance/models/__init__.py
@@ -55,6 +55,7 @@ from .loss import (
 )
 from .lstm import LongShortTermMemory, LSTMCell
 from .mlp import MultiLayerPerceptron
+from .objective import ObjectiveModel
 from .rnn import RecurrentNeuralNetwork
 from .rolling import CVResult, RollMultiLayerPerceptron, _RollingBasis
 from .tcn import TemporalConvNet
@@ -79,6 +80,8 @@ __all__ = [
     'BaseNeuralNet',
     'StackingEnsemble',
     'MultiLayerPerceptron',
+    # objective-aligned training
+    'ObjectiveModel',
     # rnn / gru / lstm
     'GRUCell',
     'GatedRecurrentUnit',

--- a/fynance/models/objective.py
+++ b/fynance/models/objective.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Objective-aligned training.
+
+:class:`ObjectiveModel` trains a neural network **directly on a risk-adjusted
+objective** (e.g. :class:`~fynance.models.SharpeLoss`) instead of MSE against a
+target: the network outputs **positions**, and the loss is computed on the
+strategy returns ``positions * returns``. It conforms to the ``SignalModel``
+protocol (``fit``/``predict``), so it drops into the harness via the precomputed
+``X`` path::
+
+    from fynance.models import ObjectiveModel, SharpeLoss
+    from fynance.strategy import Strategy
+
+    model = ObjectiveModel(loss=SharpeLoss(), epochs=80)
+    strat = Strategy(model=model, signal=lambda p: p)   # net already outputs positions
+    run_experiment(strat, prices, X=features, y=returns, walk_forward=...)
+
+``fit(X, y)`` interprets ``y`` as the **realized per-bar returns** aligned with
+``X``; ``predict(X)`` returns positions in ``[-1, 1]`` (via ``tanh``).
+
+"""
+
+# Built-in
+from __future__ import annotations
+
+from typing import Any, Callable
+
+# Third-party
+import numpy as np
+import torch
+from numpy.typing import NDArray
+
+# Local
+from fynance.models.loss import SharpeLoss
+
+__all__ = ['ObjectiveModel']
+
+
+def _default_net(n_features: int, layers: tuple[int, ...]) -> torch.nn.Module:
+    """ A plain feed-forward net with ReLU hidden layers and a linear head. """
+    mods: list[torch.nn.Module] = []
+    dim = n_features
+    for h in layers:
+        mods += [torch.nn.Linear(dim, h), torch.nn.ReLU()]
+        dim = h
+    mods += [torch.nn.Linear(dim, 1)]  # linear position head
+
+    return torch.nn.Sequential(*mods)
+
+
+class ObjectiveModel:
+    """ Train a net to maximize a differentiable financial objective.
+
+    Parameters
+    ----------
+    net : torch.nn.Module, optional
+        Architecture mapping a feature matrix ``(T, F)`` to ``(T, 1)``. Defaults
+        to an MLP built lazily on the first :meth:`fit` (so it learns ``F``). Pass
+        any ``nn.Module`` (e.g. a TCN/LSTM) to use a custom architecture.
+    layers : tuple of int
+        Hidden sizes of the default MLP (ignored when ``net`` is given).
+    loss : BaseLoss, optional
+        Differentiable financial loss applied to the strategy returns
+        ``positions * returns``. Defaults to :class:`SharpeLoss`.
+    optimizer : type[torch.optim.Optimizer]
+        Optimizer class (default :class:`~torch.optim.Adam`).
+    lr : float
+        Learning rate.
+    epochs : int
+        Full-batch training steps per :meth:`fit`.
+    position_fn : callable
+        Maps the net output to a position; default ``tanh`` (positions in
+        ``[-1, 1]``).
+    seed : int
+        Seed for reproducible initialization/training.
+
+    Notes
+    -----
+    The net is **warm-started** across successive :meth:`fit` calls (so a
+    walk-forward refit adapts online). Build a fresh model for an independent run.
+
+    """
+
+    def __init__(
+        self,
+        net: torch.nn.Module | None = None,
+        *,
+        layers: tuple[int, ...] = (16, 8),
+        loss: Any = None,
+        optimizer: type[torch.optim.Optimizer] = torch.optim.Adam,
+        lr: float = 1e-3,
+        epochs: int = 80,
+        position_fn: Callable[[torch.Tensor], torch.Tensor] = torch.tanh,
+        seed: int = 0,
+    ):
+        self.net = net
+        self.layers = tuple(layers)
+        self.loss = loss if loss is not None else SharpeLoss()
+        self.optimizer_cls = optimizer
+        self.lr = lr
+        self.epochs = epochs
+        self.position_fn = position_fn
+        self.seed = seed
+        self._optim: torch.optim.Optimizer | None = None
+
+    def _ensure_net(self, n_features: int) -> None:
+        if self.net is None:
+            torch.manual_seed(self.seed)
+            self.net = _default_net(n_features, self.layers)
+        if self._optim is None:
+            self._optim = self.optimizer_cls(
+                self.net.parameters(), lr=self.lr,  # type: ignore[call-arg]
+            )
+
+    def _positions(self, X: torch.Tensor) -> torch.Tensor:
+        out = self.net(X).reshape(-1)  # type: ignore[misc]
+
+        return self.position_fn(out)
+
+    def fit(self, X: NDArray, y: NDArray) -> ObjectiveModel:
+        """ Train the net to maximize the objective of ``positions * y``.
+
+        Parameters
+        ----------
+        X : array-like, shape (T, F)
+            Feature matrix.
+        y : array-like, shape (T,)
+            Realized per-bar returns aligned with ``X`` (not a supervised label).
+
+        Returns
+        -------
+        ObjectiveModel
+            ``self``.
+
+        """
+        Xt = torch.as_tensor(np.asarray(X, dtype=np.float32))
+        rt = torch.as_tensor(np.asarray(y, dtype=np.float32).reshape(-1))
+        self._ensure_net(Xt.shape[1])
+
+        self.net.train()  # type: ignore[union-attr]
+        for _ in range(self.epochs):
+            self._optim.zero_grad()  # type: ignore[union-attr]
+            strat_ret = self._positions(Xt) * rt
+            loss = self.loss(strat_ret)
+            loss.backward()
+            self._optim.step()  # type: ignore[union-attr]
+
+        return self
+
+    @torch.no_grad()
+    def predict(self, X: NDArray) -> NDArray:
+        """ Return positions in ``[-1, 1]`` for each row of ``X``. """
+        self.net.eval()  # type: ignore[union-attr]
+        Xt = torch.as_tensor(np.asarray(X, dtype=np.float32))
+
+        return self._positions(Xt).reshape(-1, 1).cpu().numpy()

--- a/fynance/tests/models/test_objective.py
+++ b/fynance/tests/models/test_objective.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Objective-aligned training: ObjectiveModel maximizes a financial loss. """
+
+# Third-party
+import numpy as np
+import torch
+
+# Local
+from fynance.core import SignalModel
+from fynance.metrics import sharpe
+from fynance.models import ObjectiveModel, SortinoLoss
+
+
+def _edge_data(n=1500, seed=0):
+    """ A learnable edge: feature s in {-1,1} predicts the next return's sign. """
+    rng = np.random.default_rng(seed)
+    s = rng.choice([-1.0, 1.0], size=n)
+    noise = rng.standard_normal(n) * 0.01
+    returns = (s * 0.01 + noise).astype(np.float32)  # position s earns ~+1%/bar
+    X = np.column_stack([s, rng.standard_normal(n)]).astype(np.float32)
+    return X, returns
+
+
+def test_conforms_to_signalmodel():
+    assert isinstance(ObjectiveModel(), SignalModel)
+
+
+def test_learns_a_known_edge():
+    X, returns = _edge_data()
+    model = ObjectiveModel(layers=(8,), epochs=150, lr=5e-3, seed=0).fit(X, returns)
+
+    pos = np.asarray(model.predict(X)).reshape(-1)
+    strat_ret = pos * returns
+    # The learned positions should align with the edge -> clearly positive Sharpe.
+    assert sharpe(np.cumprod(1 + strat_ret), period=252) > 1.0
+    # and beat the do-nothing / wrong-way baseline.
+    assert strat_ret.mean() > 0.0
+
+
+def test_positions_are_bounded():
+    X, returns = _edge_data(n=300)
+    pos = np.asarray(ObjectiveModel(epochs=10).fit(X, returns).predict(X))
+    assert pos.shape == (300, 1)
+    assert np.all(np.abs(pos) <= 1.0 + 1e-6)
+
+
+def test_reproducible_with_seed():
+    X, returns = _edge_data(n=400)
+    a = ObjectiveModel(epochs=20, seed=7).fit(X, returns).predict(X)
+    b = ObjectiveModel(epochs=20, seed=7).fit(X, returns).predict(X)
+    assert np.allclose(a, b)
+
+
+def test_accepts_custom_net_and_loss():
+    X, returns = _edge_data(n=300)
+    net = torch.nn.Sequential(torch.nn.Linear(2, 4), torch.nn.ReLU(),
+                              torch.nn.Linear(4, 1))
+    model = ObjectiveModel(net=net, loss=SortinoLoss(), epochs=10).fit(X, returns)
+    assert np.asarray(model.predict(X)).shape == (300, 1)


### PR DESCRIPTION
The generic fynance brick for option B: train a net **directly on a risk-adjusted objective** instead of MSE.

- `fynance.models.ObjectiveModel` — a `SignalModel`. The net outputs **positions**; the loss (`SharpeLoss` by default, any `BaseLoss`) is computed on `positions * returns`. `fit(X, y)` reads `y` as the **realized returns**; `predict(X)` → positions in `[-1, 1]` (tanh). Any `nn.Module` works (clean MLP w/ linear head by default).
- Composes with the I1 harness: `Strategy(model=ObjectiveModel(...), signal=lambda p: p)` + `run_experiment(X=features, y=returns, walk_forward=...)`.

### Test plan (synthetic only)
- conforms to `SignalModel`; **learns a known edge** (Sharpe > 1 on a synthetic series where a feature predicts the next return); positions bounded in [-1,1]; reproducible with seed; accepts a custom net + loss (`SortinoLoss`).
- `pytest` → **565 passed, 1 skipped**; `ruff`/`mypy` clean; `sphinx-build -W` ok (stub committed).