### PR TITLE
chore: release v2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [2.5.0] - 2026-06-17
+
+### Breaking Changes
+
+### Added
+
 - `fynance.models.ObjectiveModel` — **objective-aligned training**: a `SignalModel` that trains a neural network (any `nn.Module`; a clean MLP by default) **directly on a differentiable financial objective** (`SharpeLoss`/`SortinoLoss`/…) rather than MSE. The net outputs positions and the loss is computed on `positions * returns`; `fit(X, y)` reads `y` as the realized returns, `predict(X)` returns positions in `[-1, 1]`. Plugs into the harness via the `X` path with `signal=identity`, `y=returns`.
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fynance"
-version = "2.4.1"
+version = "2.5.0"
 description = "Pure-Python (Numba-accelerated) machine learning, econometrics and statistical tools for financial analysis and backtesting"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Minor — `fynance.models.ObjectiveModel` (objective-aligned training: train a net directly on a differentiable financial objective; net outputs positions, loss on `positions × returns`). CI green; pyproject → 2.5.0.