### PR TITLE
feat: self-describing experiments (provenance block)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Self-describing experiments (provenance).** `run_experiment` now records a structured *provenance* block in `Experiment.spec` — `data` (kind, length, index span, optional `data_desc`), `features` (`X` shape, optional `feature_names`/`feature_desc`), `model`, `signal`, `walk_forward`, `cost`, `period`, `seed` — so every artifact records *what produced it*. `write_report` surfaces it as a **Provenance** table at the top of `report.md`. New optional `run_experiment` keyword args `feature_names`, `feature_desc`, `data_desc`. Backward compatible: older `experiment.json` specs still load and render (the table degrades to available fields).
+
 ### Changed
 
 ### Fixed

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -72,6 +72,19 @@ Template:
 
 <!-- new entries below, newest first -->
 
+### 2026-06-17 — Self-describing experiments (provenance block) (PR #163)  [accepted]
+- **Choice**: provenance (what data + what features + run config produced a result)
+  is recorded **generically in `fynance.research`** — `run_experiment` builds a
+  structured `spec` and `write_report` renders a Provenance table — rather than as
+  a per-repo manifest convention downstream.
+- **Why**: the pain ("can't see the data/features behind a result") is generic, so
+  the fix belongs in the tool: every consumer gets self-describing artifacts for
+  free, with no convention to drift. Backward compatible (optional fields; old
+  specs still render), so no break to existing `experiment.json`.
+- **Rejected alternatives**: a hand-maintained "strategy card" / manifest in the
+  private repo (manual, non-reusable, drifts); doing nothing (the result artifacts
+  stay opaque).
+
 ### 2026-06-16 — Fix RTD build + remove the GitHub Pages docs workflow (PR #131)  [accepted]
 - **Choice**: drop the `post_install: python setup.py build_ext --inplace` job
   from `.readthedocs.yaml`, and delete the master-only `.github/workflows/docs.yml`

--- a/fynance/research/report.py
+++ b/fynance/research/report.py
@@ -37,6 +37,48 @@ def _metrics_table(metrics: dict[str, float]) -> str:
     return "\n".join(lines) + "\n"
 
 
+def _provenance_table(spec: dict | None) -> str:
+    """ Render the experiment ``spec`` provenance as a markdown table.
+
+    Surfaces *what produced the result*: data, features, model, signal, and the
+    run config. Degrades gracefully to whatever fields are present (older specs).
+    """
+    if not spec:
+        return "_no provenance_\n"
+
+    rows: list[tuple[str, str]] = []
+
+    data = spec.get("data")
+    if isinstance(data, dict):
+        span = ""
+        if data.get("start") is not None or data.get("end") is not None:
+            span = f" ({data.get('start')} → {data.get('end')})"
+        rows.append(("data", f"{data.get('kind')} · n={data.get('n')}{span}"))
+        if data.get("desc"):
+            rows.append(("data desc", str(data["desc"])))
+    elif data is not None:
+        rows.append(("data", str(data)))
+
+    feats = spec.get("features")
+    if isinstance(feats, dict):
+        rows.append(("features", f"X={feats.get('X_shape')}"))
+        if feats.get("names"):
+            rows.append(("feature names", ", ".join(map(str, feats["names"]))))
+        if feats.get("desc"):
+            rows.append(("feature desc", str(feats["desc"])))
+    else:
+        rows.append(("features", "none (price-only)"))
+
+    for key in ("model", "signal", "walk_forward", "cost", "period", "seed"):
+        if key in spec and spec[key] is not None:
+            rows.append((key, f"`{spec[key]}`"))
+
+    lines = ["| field | value |", "| --- | --- |"]
+    lines += [f"| {k} | {v} |" for k, v in rows]
+
+    return "\n".join(lines) + "\n"
+
+
 def _write_png(experiment: Experiment, png_path: Path, period: int) -> bool:
     """ Render the tearsheet from the equity curve to ``png_path``.
 
@@ -76,7 +118,9 @@ def _build_notebook(experiment: Experiment, target: Path, period: int,
     nb.cells = [
         new_markdown_cell(f"# Experiment: {experiment.name}\n\n"
                           f"Reconstructed from `experiment.json` "
-                          f"(fynance {experiment.fynance_version})."),
+                          f"(fynance {experiment.fynance_version}). The full "
+                          f"provenance (data, features, model, run config) lives "
+                          f"under `exp['spec']`."),
         new_code_cell(
             "import json\n"
             "import numpy as np\n"
@@ -150,9 +194,8 @@ def write_report(
           f"- fynance: `{experiment.fynance_version}`",
           f"- created: `{experiment.created_at}`",
           f"- seed: `{experiment.seed}`",
-          f"- data: `{experiment.spec.get('data')}`" if experiment.spec else "",
-          f"- walk_forward: `{experiment.spec.get('walk_forward')}`"
-          if experiment.spec else "",
+          "\n## Provenance\n",
+          _provenance_table(experiment.spec),
           "\n## Metrics\n",
           _metrics_table(experiment.metrics)]
     if "png" in written:

--- a/fynance/research/runner.py
+++ b/fynance/research/runner.py
@@ -35,6 +35,33 @@ def _to_array(data: Any) -> NDArray[np.float64]:
     return np.asarray(data, dtype=np.float64).reshape(-1)
 
 
+def _index_bound(data: Any, pos: int) -> Any:
+    """ Return a JSON-friendly index value at ``pos`` (first/-1), or None. """
+    index = getattr(data, "index", None)
+    if index is None:
+        return None
+    try:
+        value = np.asarray(index).reshape(-1)[pos]
+    except (IndexError, ValueError):
+        return None
+    # datetime64 -> ISO string; numpy scalars -> native python.
+    if isinstance(value, np.datetime64):
+        return str(value)
+
+    return value.item() if hasattr(value, "item") else value
+
+
+def _callable_name(fn: Any) -> str | None:
+    """ Best-effort readable name for a signal/feature callable. """
+    if fn is None:
+        return None
+    name = getattr(fn, "__name__", None)
+    if name and name != "<lambda>":
+        return name
+
+    return type(fn).__name__ if not callable(fn) else name or "<callable>"
+
+
 def _seed_everything(seed: int) -> None:
     """ Seed numpy (and torch if present) for reproducibility. """
     np.random.seed(seed)
@@ -58,6 +85,9 @@ def run_experiment(
     period: int = 252,
     seed: int = 0,
     code: str | None = None,
+    feature_names: list[str] | None = None,
+    feature_desc: str | None = None,
+    data_desc: str | None = None,
     output_dir: str | Path | None = None,
 ) -> Experiment:
     """ Run a strategy experiment and return a populated :class:`Experiment`.
@@ -88,8 +118,24 @@ def run_experiment(
         Master seed (numpy + torch).
     code : str, optional
         Generated strategy source, stored verbatim on the experiment.
+    feature_names : list of str, optional
+        Column names of ``X`` — recorded in the provenance so a report shows what
+        each feature is. Ignored when ``X`` is None.
+    feature_desc : str, optional
+        Free-text description of how ``X`` was built (the feature recipe),
+        recorded in the provenance. Ignored when ``X`` is None.
+    data_desc : str, optional
+        Free-text description of the price data (source, instrument, resolution),
+        recorded in the provenance.
     output_dir : str or pathlib.Path, optional
         When given, the experiment is saved under ``<output_dir>/<name>/``.
+
+    Notes
+    -----
+    The returned experiment's ``spec`` carries a self-describing **provenance**
+    block (``data``, ``features``, ``model``, ``signal``, ``walk_forward``,
+    ``cost``, ``period``, ``seed``) so an artifact always records *what produced
+    it*. :func:`fynance.research.write_report` renders it as a Provenance table.
 
     Returns
     -------
@@ -114,10 +160,29 @@ def run_experiment(
 
     metrics = result.summary(period=period)
 
+    data_block: dict[str, Any] = {
+        "kind": getattr(data, "name", None) or type(data).__name__,
+        "n": int(n),
+        "start": _index_bound(data, 0),
+        "end": _index_bound(data, -1),
+        "desc": data_desc,
+    }
+
+    if X is None:
+        features_block: dict[str, Any] | None = None
+    else:
+        features_block = {
+            "X_shape": [int(d) for d in np.asarray(X).shape],
+            "names": list(feature_names) if feature_names is not None else None,
+            "desc": feature_desc,
+        }
+
     spec: dict[str, Any] = {
-        "data": {"kind": getattr(data, "name", None) or type(data).__name__,
-                 "n": int(n)},
-        "features": None if X is None else {"X_shape": list(np.asarray(X).shape)},
+        "data": data_block,
+        "features": features_block,
+        "model": type(strategy.model).__name__ if getattr(
+            strategy, "model", None) is not None else None,
+        "signal": _callable_name(getattr(strategy, "signal", None)),
         "walk_forward": walk_forward,
         "cost": type(strategy.cost).__name__ if strategy.cost is not None else None,
         "period": period,

--- a/fynance/tests/research/test_provenance.py
+++ b/fynance/tests/research/test_provenance.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Tests for the self-describing provenance block of an experiment.
+
+``run_experiment`` records *what produced the result* (data, features, model,
+signal, run config) in ``Experiment.spec`` and ``write_report`` surfaces it as a
+Provenance table — backward compatible with older specs.
+"""
+
+# Third-party
+import numpy as np
+
+# Local
+from fynance.research import Experiment, gbm, run_experiment, write_report
+from fynance.research.report import _provenance_table
+from fynance.strategy import Strategy
+
+
+def _rule_strategy() -> Strategy:
+    return Strategy(features=lambda p: np.diff(p, prepend=p[0]), signal=np.sign)
+
+
+def test_data_provenance_recorded():
+    exp = run_experiment(_rule_strategy(), gbm(300, seed=1), name="d",
+                         data_desc="synthetic GBM, daily")
+    data = exp.spec["data"]
+
+    assert data["kind"] == "synthetic-gbm"
+    assert data["n"] == 300
+    assert data["start"] == 0 and data["end"] == 299  # default int index bounds
+    assert data["desc"] == "synthetic GBM, daily"
+
+
+def test_features_provenance_recorded():
+    n = 300
+    X = np.random.default_rng(0).standard_normal((n, 2)).astype(np.float32)
+    exp = run_experiment(
+        Strategy(signal=lambda z: np.sign(z[:, 0])), gbm(n, seed=1), name="f",
+        X=X, feature_names=["roc", "vol"], feature_desc="2 causal cols",
+    )
+    feats = exp.spec["features"]
+
+    assert feats["X_shape"] == [n, 2]
+    assert feats["names"] == ["roc", "vol"]
+    assert feats["desc"] == "2 causal cols"
+
+
+def test_features_none_without_X():
+    exp = run_experiment(_rule_strategy(), gbm(200, seed=2), name="g")
+
+    assert exp.spec["features"] is None
+    # The price-only path still records data + run config.
+    assert exp.spec["data"]["n"] == 200
+    assert exp.spec["seed"] == 0
+
+
+def test_signal_name_recorded():
+    exp = run_experiment(_rule_strategy(), gbm(150, seed=3), name="s")
+
+    assert exp.spec["signal"] == "sign"  # np.sign exposes __name__
+
+
+def test_provenance_survives_json_roundtrip():
+    exp = run_experiment(_rule_strategy(), gbm(150, seed=3), name="r",
+                         data_desc="x")
+    again = Experiment.from_dict(exp.to_dict())
+
+    assert again.spec == exp.spec
+
+
+def test_report_renders_provenance_table(tmp_path):
+    n = 200
+    X = np.random.default_rng(0).standard_normal((n, 1)).astype(np.float32)
+    exp = run_experiment(
+        Strategy(signal=lambda z: np.sign(z[:, 0])), gbm(n, seed=4), name="rep",
+        X=X, feature_names=["mom"], feature_desc="one momentum column",
+    )
+    write_report(exp, tmp_path, notebook=False)
+    text = (tmp_path / "rep" / "report.md").read_text()
+
+    assert "## Provenance" in text
+    assert "synthetic-gbm" in text
+    assert "X=[200, 1]" in text
+    assert "mom" in text
+    assert "one momentum column" in text
+
+
+def test_provenance_table_degrades_on_old_spec():
+    # An older experiment.json with a flat data string and no feature keys.
+    legacy = {"data": "some-old-series", "walk_forward": None, "seed": 7}
+    table = _provenance_table(legacy)
+
+    assert "some-old-series" in table
+    assert "none (price-only)" in table  # features absent -> graceful default
+
+
+def test_provenance_table_empty_spec():
+    assert "_no provenance_" in _provenance_table(None)
+    assert "_no provenance_" in _provenance_table({})

--- a/fynance/tests/research/test_xy_inputs.py
+++ b/fynance/tests/research/test_xy_inputs.py
@@ -95,7 +95,9 @@ def test_run_experiment_threads_and_records_X():
                          name="xy", X=X, y=y, walk_forward=dict(train=80, test=40))
 
     assert isinstance(exp, Experiment)
-    assert exp.spec["features"] == {"X_shape": [X.shape[0], X.shape[1]]}
+    assert exp.spec["features"]["X_shape"] == [X.shape[0], X.shape[1]]
+    assert exp.spec["features"]["names"] is None  # no names provided
+    assert exp.spec["model"] == "LinearStub"      # model recorded in provenance
     assert np.all(np.isfinite(list(exp.metrics.values())))
 
 


### PR DESCRIPTION
## What

`run_experiment` now records a structured **provenance** block in `Experiment.spec`, and `write_report` surfaces it as a **Provenance** table at the top of `report.md` — so every result artifact records *what produced it*.

- `spec` now carries: `data` (kind, n, index span, optional `data_desc`), `features` (`X` shape, optional `feature_names`/`feature_desc`), `model`, `signal`, `walk_forward`, `cost`, `period`, `seed`.
- New optional `run_experiment` kwargs: `feature_names`, `feature_desc`, `data_desc`.
- Backward compatible: older `experiment.json` specs still load; the table degrades to available fields.

## Why

The "we can't see the data/features behind a result" pain is generic, so the fix lives in the tool (Phase 1 of the docs/structure cleanup). Downstream repos get self-describing artifacts for free — no per-repo manifest convention to drift.

## Test plan

- New `fynance/tests/research/test_provenance.py` (data/features/signal/model recording, JSON round-trip, report rendering, graceful degradation on legacy/empty specs).
- Updated `test_xy_inputs.py` for the enriched features block.
- Full suite green (573 passed, 1 skipped); `ruff` + `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)