### PR TITLE
docs: research workflow tutorial + runnable example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ TODO.md
 # only the plan trees and archived snapshots stay local
 doc/dev/plans/*/
 doc/dev/_archive/
+
+# Local output of examples/research_workflow.py (results live in a downstream repo)
+research_out/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Research workflow tutorial + runnable example.** New `doc/source/research_workflow.rst` walks the canonical loop end-to-end on synthetic data (data → causal `X`/`y` features → rule-based & objective-aligned strategies → walk-forward `run_experiment` → permutation/deflated-Sharpe guardrails → portable report) — the documented, portable form of the `/run-strategy` skill. Shipped alongside a runnable `examples/research_workflow.py` (exercised in CI so it cannot rot).
 - **Self-describing experiments (provenance).** `run_experiment` now records a structured *provenance* block in `Experiment.spec` — `data` (kind, length, index span, optional `data_desc`), `features` (`X` shape, optional `feature_names`/`feature_desc`), `model`, `signal`, `walk_forward`, `cost`, `period`, `seed` — so every artifact records *what produced it*. `write_report` surfaces it as a **Provenance** table at the top of `report.md`. New optional `run_experiment` keyword args `feature_names`, `feature_desc`, `data_desc`. Backward compatible: older `experiment.json` specs still load and render (the table degrades to available fields).
 
 ### Changed

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -85,6 +85,7 @@
 
    installation
    quickstart
+   research_workflow
    changelog
 
 .. toctree::

--- a/doc/source/research_workflow.rst
+++ b/doc/source/research_workflow.rst
@@ -1,0 +1,159 @@
+=================
+Research workflow
+=================
+
+The canonical loop for turning a strategy idea into a **reproducible experiment**
+with portable, remotely-viewable results — the documented form of what the
+``/run-strategy`` agent skill automates. Every step below is data-agnostic and
+runs on synthetic data; the full script lives in
+``examples/research_workflow.py``.
+
+.. note::
+
+   **fynance is the tool, not the results.** It ships only *synthetic* data
+   generators (:func:`~fynance.research.gbm`,
+   :func:`~fynance.research.regime_switching`) and **never stores results
+   itself** — every artifact is written under an ``output_dir`` *you* provide.
+   Real data and stored results belong in your own (downstream) repo.
+
+.. warning::
+
+   A result on synthetic data is a **plumbing check, not evidence of edge**. A
+   real claim needs real data **and** a small permutation p-value **and** a
+   healthy deflated Sharpe (below).
+
+The loop
+========
+
+.. code-block:: text
+
+   data → features (X, y) → strategy → run_experiment (walk-forward) → guardrails → report
+
+1. Data
+-------
+
+Start from a :class:`~fynance.core.PriceSeries`. Here it is synthetic; on real
+data you would build the series from your own source.
+
+.. code-block:: python
+
+   from fynance.research import gbm
+
+   prices = gbm(1500, seed=7)        # a PriceSeries named "synthetic-gbm"
+   train, test = 750, 250
+
+2. Features (``X`` / ``y``)
+---------------------------
+
+Build a **causal** feature matrix ``X`` (trailing/rolling only, standardized with
+**train-only** statistics) and a target ``y`` (the next-bar return). ``X`` is
+aligned row-for-row with the price index; in walk-forward the harness slices
+``X[train]`` / ``X[test]`` per window — that slice *is* the rolling model refit.
+See :doc:`strategy` for the full ``X`` / ``y`` contract.
+
+.. code-block:: python
+
+   import numpy as np
+   import fynance as fy
+
+   p = prices.to_numpy()
+   X = np.column_stack([fy.roc(p, 1), fy.roc(p, 5), fy.realized_volatility(p, w=20)])
+   mu, sd = X[:train].mean(0), X[:train].std(0)
+   sd[sd == 0] = 1.0
+   X = np.nan_to_num((X - mu) / sd).astype(np.float32)
+
+   y = np.zeros((p.shape[0], 1), dtype=np.float32)
+   y[:-1, 0] = (p[1:] / p[:-1] - 1.0)      # next-bar return
+
+3. Strategy
+-----------
+
+A :class:`~fynance.strategy.Strategy` composes the maillons. Two styles:
+
+A **rule-based** strategy (a causal feature → a signal):
+
+.. code-block:: python
+
+   from fynance.strategy import Strategy
+   from fynance.backtest import ProportionalCost
+
+   baseline = Strategy(features=lambda p: fy.roc(p, 20), signal=np.sign,
+                       cost=ProportionalCost(0.001))
+
+An **objective-aligned** neural strategy — the net outputs positions and is
+trained directly to maximize the Sharpe of ``positions * returns`` (not MSE on a
+target), via :class:`~fynance.models.ObjectiveModel` and
+:class:`~fynance.models.loss.SharpeLoss`. The signal is the identity (the model
+already emits positions):
+
+.. code-block:: python
+
+   from fynance.models import ObjectiveModel, SharpeLoss
+
+   model = ObjectiveModel(layers=(16, 8), loss=SharpeLoss(), epochs=60, seed=0)
+   objective = Strategy(model=model, signal=lambda pos: pos,
+                        cost=ProportionalCost(0.001))
+
+4. Run the experiment
+---------------------
+
+:func:`~fynance.research.run_experiment` runs a seeded, cost-aware, walk-forward
+backtest and returns a populated :class:`~fynance.research.Experiment`. Pass the
+``feature_names`` / ``feature_desc`` / ``data_desc`` so the result records **what
+produced it** (the provenance, surfaced in the report).
+
+.. code-block:: python
+
+   from fynance.research import run_experiment
+
+   exp = run_experiment(
+       objective, prices, name="sharpe_nn", X=X, y=y,
+       walk_forward={"train": train, "test": test}, seed=0,
+       feature_names=["roc_1", "roc_5", "realized_vol_20"],
+       feature_desc="3 causal cols, train-standardized",
+       data_desc="synthetic GBM (plumbing check, not real data)",
+       output_dir="research_out",
+   )
+
+5. Guardrails
+-------------
+
+Never read the raw Sharpe alone.
+
+- :func:`~fynance.research.permutation_test` — is the edge distinguishable from
+  shuffled-returns noise? A weak ``p_value`` means it is not.
+- :class:`~fynance.research.Ledger` + ``deflated_sharpe`` — does the Sharpe
+  survive the number of strategies you have tried? A high raw Sharpe with a low
+  deflated Sharpe is **overfitting**, not edge.
+
+.. code-block:: python
+
+   from fynance.research import Ledger, permutation_test
+
+   perm = permutation_test(baseline, prices, n_permutations=100, seed=0)
+   ledger = Ledger("research_out/ledger")
+   ledger.append(exp)
+   print(perm["p_value"], ledger.deflated_sharpe(exp))
+
+6. Report
+---------
+
+:func:`~fynance.research.write_report` writes portable artifacts under
+``output_dir``: a ``report.md`` (with the Provenance + Metrics tables and an
+embedded tearsheet PNG, viewable on GitHub from a phone) and a re-runnable
+notebook. Use :func:`~fynance.research.compare_report` to rank several candidates.
+
+.. code-block:: python
+
+   from fynance.research import write_report
+
+   write_report(exp, "research_out")
+
+Running it on real data
+=======================
+
+The example is deliberately data-agnostic. To run it for real, replace the
+synthetic generator with your own :class:`~fynance.core.PriceSeries` (and build
+``X`` from your data), then point ``output_dir`` at *your* results repo — fynance
+writes nothing anywhere else. See :doc:`research` for the full harness reference
+and :doc:`strategy` for the ``X`` / ``y`` contract.

--- a/examples/research_workflow.py
+++ b/examples/research_workflow.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" The canonical fynance research workflow, end-to-end, on synthetic data.
+
+This is the runnable, portable form of the strategy-research loop: synthetic data
+→ causal feature matrix (``X``/``y``) → a rule-based **and** an objective-aligned
+strategy → a seeded, cost-aware, walk-forward backtest via
+:func:`fynance.research.run_experiment` → the guardrails (permutation p-value +
+deflated Sharpe) → a portable report.
+
+It is **data-agnostic**: fynance ships only synthetic generators (``gbm`` /
+``regime_switching``); point ``X``/``data`` at your own ``PriceSeries`` to run it
+on real data. fynance never stores results — every artifact is written under the
+``output_dir`` you pass.
+
+Run it::
+
+    python examples/research_workflow.py            # writes to ./research_out
+
+Synthetic results are a **plumbing check, not evidence of edge**: a real claim
+needs real data *and* a small permutation p-value *and* a healthy deflated Sharpe.
+"""
+
+# Built-in
+from __future__ import annotations
+
+from pathlib import Path
+
+# Third-party
+import numpy as np
+
+# Local
+import fynance as fy
+from fynance.backtest import ProportionalCost
+from fynance.models import ObjectiveModel, SharpeLoss
+from fynance.research import (
+    Ledger,
+    gbm,
+    permutation_test,
+    run_experiment,
+    write_report,
+)
+from fynance.strategy import Strategy
+
+FEE = 0.001  # ~10 bps round-trip proportional cost
+
+
+def build_features(prices, *, train: int):
+    """ Build a small **causal** feature matrix ``X`` and target ``y``.
+
+    Columns are trailing/rolling only (no lookahead) and standardized with
+    **train-only** statistics. ``y`` is the next-bar return. Returns
+    ``(X, y, names)`` ready for ``run_experiment(..., X=X, y=y)``.
+    """
+    p = prices.to_numpy() if hasattr(prices, "to_numpy") else np.asarray(prices)
+    p = p.astype(np.float64)
+
+    cols = [fy.roc(p, 1), fy.roc(p, 5), fy.realized_volatility(p, w=20)]
+    names = ["roc_1", "roc_5", "realized_vol_20"]
+    X = np.column_stack(cols)
+
+    mu = X[:train].mean(axis=0)
+    sd = X[:train].std(axis=0)
+    sd[sd == 0] = 1.0
+    X = (X - mu) / sd
+    X = np.nan_to_num(X, nan=0.0, posinf=0.0, neginf=0.0).astype(np.float32)
+
+    y = np.zeros((p.shape[0], 1), dtype=np.float32)
+    y[:-1, 0] = (p[1:] / p[:-1] - 1.0).astype(np.float32)
+
+    return X, y, names
+
+
+def main(output_dir: str | Path = "research_out") -> dict:
+    """ Run the full workflow and return the two experiments' metrics. """
+    output_dir = Path(output_dir)
+
+    # 1. Data — synthetic here; swap for your own PriceSeries on real data.
+    prices = gbm(1500, seed=7)  # a PriceSeries named "synthetic-gbm"
+    train, test = 750, 250
+
+    # 2. Features — causal X/y (the rolling-NN refit slices these per window).
+    X, y, names = build_features(prices, train=train)
+
+    ledger = Ledger(output_dir / "ledger")
+
+    # 3a. A rule-based baseline (price-only) — used for the permutation test.
+    baseline = Strategy(features=lambda p: fy.roc(p, 20), signal=np.sign,
+                        cost=ProportionalCost(FEE))
+    base_exp = run_experiment(
+        baseline, prices, name="ts_momentum",
+        walk_forward={"train": train, "test": test}, seed=0,
+        data_desc="synthetic GBM (plumbing check, not real data)",
+        output_dir=output_dir,
+    )
+
+    # 3b. An objective-aligned NN: the net outputs positions, trained directly to
+    #     maximize the Sharpe of positions * returns (not MSE on a target).
+    model = ObjectiveModel(layers=(16, 8), loss=SharpeLoss(), epochs=60, seed=0)
+    objective = Strategy(model=model, signal=lambda pos: pos,
+                         cost=ProportionalCost(FEE))
+    obj_exp = run_experiment(
+        objective, prices, name="sharpe_nn", X=X, y=y,
+        walk_forward={"train": train, "test": test}, seed=0,
+        feature_names=names, feature_desc="3 causal cols, train-standardized",
+        data_desc="synthetic GBM (plumbing check, not real data)",
+        output_dir=output_dir,
+    )
+
+    # 4. Guardrails — never read the raw Sharpe alone.
+    perm = permutation_test(baseline, prices, n_permutations=100, seed=0)
+    for exp in (base_exp, obj_exp):
+        ledger.append(exp)
+
+    # 5. Reports — portable artifacts under output_dir (viewable on GitHub).
+    for exp in (base_exp, obj_exp):
+        write_report(exp, output_dir, notebook=False)
+
+    print(f"baseline  sharpe={base_exp.metrics['sharpe']:.3f}  "
+          f"perm p={perm['p_value']:.3f}  "
+          f"DSR={ledger.deflated_sharpe(base_exp):.3f}")
+    print(f"objective sharpe={obj_exp.metrics['sharpe']:.3f}  "
+          f"DSR={ledger.deflated_sharpe(obj_exp):.3f}")
+    print(f"artifacts under {output_dir.resolve()}  "
+          f"(synthetic = plumbing check, not edge)")
+
+    return {"baseline": base_exp.metrics, "objective": obj_exp.metrics,
+            "permutation": perm}
+
+
+if __name__ == "__main__":
+    main()

--- a/fynance/tests/research/test_examples.py
+++ b/fynance/tests/research/test_examples.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Smoke test for the shipped ``examples/research_workflow.py``.
+
+Runs the canonical workflow end-to-end on synthetic data into a tmp dir and
+asserts the portable artifacts exist — so the documented example cannot silently
+rot.
+"""
+
+# Built-in
+import importlib.util
+from pathlib import Path
+
+# Third-party
+import numpy as np
+
+# Local
+import fynance
+
+_EXAMPLE = (Path(fynance.__file__).resolve().parent.parent
+            / "examples" / "research_workflow.py")
+
+
+def _load_example():
+    spec = importlib.util.spec_from_file_location("research_workflow", _EXAMPLE)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    return module
+
+
+def test_example_file_exists():
+    assert _EXAMPLE.is_file()
+
+
+def test_example_runs_end_to_end(tmp_path):
+    module = _load_example()
+    out = module.main(output_dir=tmp_path)
+
+    # Both strategies produced finite metrics.
+    assert np.isfinite(out["baseline"]["sharpe"])
+    assert np.isfinite(out["objective"]["sharpe"])
+    assert 0.0 <= out["permutation"]["p_value"] <= 1.0
+
+    # Portable artifacts landed under the caller-provided output_dir.
+    for name in ("ts_momentum", "sharpe_nn"):
+        assert (tmp_path / name / "report.md").is_file()
+        assert (tmp_path / name / "experiment.json").is_file()
+
+    # The report carries the provenance (data + features visible).
+    text = (tmp_path / "sharpe_nn" / "report.md").read_text()
+    assert "## Provenance" in text
+    assert "roc_1" in text  # feature names surfaced


### PR DESCRIPTION
## What

The documented, portable form of the `/run-strategy` loop:

- **`doc/source/research_workflow.rst`** — narrative tutorial walking the canonical research loop end-to-end on synthetic data: data → causal `X`/`y` features → rule-based **and** objective-aligned (`ObjectiveModel` + `SharpeLoss`) strategies → walk-forward `run_experiment` (with provenance) → guardrails (permutation p-value + deflated Sharpe) → portable report. Ends with "how to point this at real data".
- **`examples/research_workflow.py`** — the runnable skeleton, exercised in CI so it cannot rot.
- Linked from the Getting Started toctree (after `quickstart`).

Data-agnostic (synthetic only), writes only under a caller `output_dir`.

(Recreated after #164 was auto-closed when its stacked base branch was deleted on merge of #163. Builds on #163, now in `develop`.)

## Test plan

- New `test_examples.py` runs the example end-to-end into a tmp dir and asserts artifacts + provenance.
- `sphinx-build -W` clean; `ruff` clean (fynance + examples); full research suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)