### PR TITLE
chore: release v2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [2.6.0] - 2026-06-17
+
+### Breaking Changes
+
+### Added
+
 - **Reference narrative for the new capabilities.** `strategy.rst` documents the `X`/`y` multi-input contract (precomputed causal feature matrix; walk-forward slices it per window = the model refit; dtypes preserved); `models.neural_network.rst` gains an objective-aligned training section on `ObjectiveModel`; `features.regime.rst` spells out the causal `RegimeDetector` contract; `quickstart` links to the new workflow tutorial.
 - **Research workflow tutorial + runnable example.** New `doc/source/research_workflow.rst` walks the canonical loop end-to-end on synthetic data (data → causal `X`/`y` features → rule-based & objective-aligned strategies → walk-forward `run_experiment` → permutation/deflated-Sharpe guardrails → portable report) — the documented, portable form of the `/run-strategy` skill. Shipped alongside a runnable `examples/research_workflow.py` (exercised in CI so it cannot rot).
 - **Self-describing experiments (provenance).** `run_experiment` now records a structured *provenance* block in `Experiment.spec` — `data` (kind, length, index span, optional `data_desc`), `features` (`X` shape, optional `feature_names`/`feature_desc`), `model`, `signal`, `walk_forward`, `cost`, `period`, `seed` — so every artifact records *what produced it*. `write_report` surfaces it as a **Provenance** table at the top of `report.md`. New optional `run_experiment` keyword args `feature_names`, `feature_desc`, `data_desc`. Backward compatible: older `experiment.json` specs still load and render (the table degrades to available fields).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fynance"
-version = "2.5.0"
+version = "2.6.0"
 description = "Pure-Python (Numba-accelerated) machine learning, econometrics and statistical tools for financial analysis and backtesting"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Release **v2.6.0** — Phase 1 of the research process/docs cleanup.

## [2.6.0]

### Added

- **Self-describing experiments (provenance).** `run_experiment`/`Experiment` record a structured provenance block (data, features, model, signal, walk_forward, cost, period, seed); `write_report` surfaces it as a **Provenance** table. New optional kwargs `feature_names`/`feature_desc`/`data_desc`. Backward compatible.
- **Research workflow tutorial + runnable example.** `doc/source/research_workflow.rst` walks the canonical loop end-to-end on synthetic data; `examples/research_workflow.py` is the runnable skeleton (exercised in CI).
- **Reference narrative** for the `X`/`y` multi-input contract, `ObjectiveModel` (objective-aligned training) and the causal `RegimeDetector`; quickstart links the tutorial.

## Test plan

- Full suite green (573+ passed); `ruff` + `mypy` clean; `sphinx-build -W` clean.
- All three feature PRs (#163, #166, #165) merged into `develop` with the 7 required gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)