### PR TITLE
feat: turnover-penalized (net-of-cost) objective training

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Turnover-penalized (net-of-cost) objective training.** `ObjectiveModel` gains a `cost` parameter: when non-zero the objective is computed on `positions * returns - cost * |Δpositions|`, so the network learns to **hold** positions instead of churning — the anti-churn lever for high-cost / high-frequency settings. Defaults to `0` (unchanged behaviour).
+
 ### Changed
 
 ### Fixed

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -72,6 +72,19 @@ Template:
 
 <!-- new entries below, newest first -->
 
+### 2026-06-18 — Anti-churn brick 1: net-of-cost objective training (PR #169)  [accepted]
+- **Choice**: penalize turnover **inside the training objective** — `ObjectiveModel`
+  optimizes `Sharpe(positions*returns − cost*|Δpositions|)` via a new `cost` param —
+  rather than only post-processing positions or relying on the backtest cost.
+- **Why**: at realistic crypto fees (Kraken ~0.26% taker → ~0.52% round-trip) a
+  high-frequency strategy that flips often is structurally unprofitable. Teaching
+  the net the cost at train time makes it *hold* (the gradient couples positions
+  across bars), which a post-hoc filter cannot do as well. Generic, opt-in
+  (`cost=0` default = unchanged).
+- **Rejected alternatives**: only an inference-time smoother/deadband (necessary
+  but insufficient — the model still *wants* to churn); a separate cost-aware loss
+  class (more API surface than threading `cost` through the existing objective).
+
 ### 2026-06-17 — Self-describing experiments (provenance block) (PR #163)  [accepted]
 - **Choice**: provenance (what data + what features + run config produced a result)
   is recorded **generically in `fynance.research`** — `run_experiment` builds a

--- a/doc/source/models.neural_network.rst
+++ b/doc/source/models.neural_network.rst
@@ -34,6 +34,12 @@ with an identity signal::
     model = ObjectiveModel(layers=(16, 8), loss=SharpeLoss(), epochs=60, seed=0)
     strat = Strategy(model=model, signal=lambda positions: positions)
 
+Set ``cost`` (a per-bar proportional fee, e.g. ``0.0026``) to train on the
+**net-of-cost** return ``positions * returns - cost * |Δpositions|``: the net then
+learns to *hold* rather than churn — the anti-churn lever for high-cost or
+high-frequency settings (use the same value as the backtest's
+:class:`~fynance.backtest.ProportionalCost`).
+
 Feed it through the research harness via the ``X`` path with ``y`` = returns; see
 :doc:`research_workflow`.
 

--- a/fynance/models/objective.py
+++ b/fynance/models/objective.py
@@ -73,6 +73,14 @@ class ObjectiveModel:
     position_fn : callable
         Maps the net output to a position; default ``tanh`` (positions in
         ``[-1, 1]``).
+    cost : float
+        Per-bar proportional turnover cost penalized **during training** (e.g.
+        ``0.0026`` for 26 bps). When non-zero the objective is computed on the
+        **net-of-cost** return ``positions * returns - cost * |Δpositions|``, so
+        the net learns to hold positions instead of churning — the anti-churn
+        brick for high-cost / high-frequency settings. Use the same value as the
+        backtest's :class:`~fynance.backtest.ProportionalCost`. Default ``0``
+        (no penalty, original behaviour).
     seed : int
         Seed for reproducible initialization/training.
 
@@ -93,6 +101,7 @@ class ObjectiveModel:
         lr: float = 1e-3,
         epochs: int = 80,
         position_fn: Callable[[torch.Tensor], torch.Tensor] = torch.tanh,
+        cost: float = 0.0,
         seed: int = 0,
     ):
         self.net = net
@@ -102,6 +111,7 @@ class ObjectiveModel:
         self.lr = lr
         self.epochs = epochs
         self.position_fn = position_fn
+        self.cost = cost
         self.seed = seed
         self._optim: torch.optim.Optimizer | None = None
 
@@ -142,7 +152,15 @@ class ObjectiveModel:
         self.net.train()  # type: ignore[union-attr]
         for _ in range(self.epochs):
             self._optim.zero_grad()  # type: ignore[union-attr]
-            strat_ret = self._positions(Xt) * rt
+            pos = self._positions(Xt)
+            strat_ret = pos * rt
+            if self.cost:
+                # Turnover penalty: charge ``cost * |Δposition|`` each bar (the
+                # first bar charges entry from flat). This couples positions
+                # across time so the net learns to *hold* rather than churn —
+                # the loss optimizes the **net-of-cost** return series.
+                turnover = torch.cat([pos[:1].abs(), torch.abs(pos[1:] - pos[:-1])])
+                strat_ret = strat_ret - self.cost * turnover
             loss = self.loss(strat_ret)
             loss.backward()
             self._optim.step()  # type: ignore[union-attr]

--- a/fynance/tests/models/test_objective.py
+++ b/fynance/tests/models/test_objective.py
@@ -59,3 +59,36 @@ def test_accepts_custom_net_and_loss():
                               torch.nn.Linear(4, 1))
     model = ObjectiveModel(net=net, loss=SortinoLoss(), epochs=10).fit(X, returns)
     assert np.asarray(model.predict(X)).shape == (300, 1)
+
+
+def _alternating_edge(n=1500, seed=0):
+    """ Sign flips every bar: the no-cost optimum churns (turnover ~2/bar). """
+    s = np.where(np.arange(n) % 2 == 0, 1.0, -1.0)
+    rng = np.random.default_rng(seed)
+    returns = (s * 0.01 + rng.standard_normal(n) * 0.005).astype(np.float32)
+    X = np.column_stack([s, rng.standard_normal(n)]).astype(np.float32)
+
+    return X, returns
+
+
+def _turnover(pos):
+    return float(np.abs(np.diff(np.asarray(pos).reshape(-1), prepend=0.0)).mean())
+
+
+def test_cost_reduces_turnover():
+    # On a fast-flipping edge, a no-cost model churns; a turnover-penalized one
+    # holds. The cost term should cut realized turnover substantially.
+    X, returns = _alternating_edge()
+    free = ObjectiveModel(layers=(8,), epochs=200, lr=5e-3, seed=0).fit(X, returns)
+    pricey = ObjectiveModel(layers=(8,), epochs=200, lr=5e-3, cost=0.1,
+                            seed=0).fit(X, returns)
+
+    assert _turnover(pricey.predict(X)) < _turnover(free.predict(X))
+
+
+def test_cost_default_zero_is_unchanged():
+    # cost defaults to 0 -> identical to not passing it (pure refactor safety).
+    X, returns = _edge_data(n=400)
+    a = ObjectiveModel(epochs=20, seed=3).fit(X, returns).predict(X)
+    b = ObjectiveModel(epochs=20, cost=0.0, seed=3).fit(X, returns).predict(X)
+    assert np.allclose(a, b)


### PR DESCRIPTION
## What

`ObjectiveModel` gains a `cost` parameter. When non-zero, training optimizes the **net-of-cost** return series `positions * returns - cost * |Δpositions|`, so the network learns to **hold** positions rather than churn.

This is anti-churn **brick 1** (train-time). It exists because at realistic crypto fees (Kraken ~0.26% taker → ~0.52% round-trip) any high-frequency strategy that flips often is structurally unprofitable — the model must internalize the cost.

- Opt-in: `cost=0` default = unchanged behaviour.
- Use the same value as the backtest's `ProportionalCost`.

## Test plan

- New tests: turnover penalty cuts realized turnover on a fast-flipping edge; `cost=0` is identical to the prior behaviour.
- Full objective suite green; `ruff` + `mypy` clean; docs narrative updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)