### PR TITLE
feat: anti-churn signal mappers (ema_smooth, deadband, min_hold)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Anti-churn signal mappers.** `fynance.signal` gains three causal, composable position mappers to cut turnover where transaction costs dominate: `ema_smooth` (EMA-smooth a position), `deadband` (sticky hold unless the target moves beyond a band, magnitude-preserving), and `min_hold` (enforce a minimum holding period between changes). They pair with the train-time `ObjectiveModel(cost=...)` penalty.
 - **Turnover-penalized (net-of-cost) objective training.** `ObjectiveModel` gains a `cost` parameter: when non-zero the objective is computed on `positions * returns - cost * |Δpositions|`, so the network learns to **hold** positions instead of churning — the anti-churn lever for high-cost / high-frequency settings. Defaults to `0` (unchanged behaviour).
 
 ### Changed

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -72,6 +72,18 @@ Template:
 
 <!-- new entries below, newest first -->
 
+### 2026-06-18 — Anti-churn brick 2: inference-time turnover mappers (PR #170)  [accepted]
+- **Choice**: add three causal, composable position mappers to `fynance.signal` —
+  `ema_smooth`, `deadband` (sticky/hysteretic, magnitude-preserving), `min_hold`
+  (minimum dwell). The inference-time complement to brick 1's train-time penalty.
+- **Why**: two layers beat one. The net-of-cost objective makes the model *want*
+  to hold; the mappers give a hard, model-agnostic turnover cap on top (and work
+  for rule-based strategies too). Kept as separate small functions (composable)
+  rather than one mega-mapper.
+- **Rejected alternatives**: folding everything into the existing `threshold`
+  (it discards magnitude and is stateless — wrong tool); only the train-time
+  penalty (can't hard-cap trade frequency).
+
 ### 2026-06-18 — Anti-churn brick 1: net-of-cost objective training (PR #169)  [accepted]
 - **Choice**: penalize turnover **inside the training objective** — `ObjectiveModel`
   optimizes `Sharpe(positions*returns − cost*|Δpositions|)` via a new `cost` param —

--- a/doc/source/generated/fynance.signal.deadband.rst
+++ b/doc/source/generated/fynance.signal.deadband.rst
@@ -1,0 +1,9 @@
+﻿deadband
+=======================
+
+*Defined in* :mod:`fynance.signal`
+
+.. currentmodule:: fynance.signal
+
+.. autofunction:: deadband
+   :no-index:

--- a/doc/source/generated/fynance.signal.ema_smooth.rst
+++ b/doc/source/generated/fynance.signal.ema_smooth.rst
@@ -1,0 +1,9 @@
+﻿ema_smooth
+=========================
+
+*Defined in* :mod:`fynance.signal`
+
+.. currentmodule:: fynance.signal
+
+.. autofunction:: ema_smooth
+   :no-index:

--- a/doc/source/generated/fynance.signal.min_hold.rst
+++ b/doc/source/generated/fynance.signal.min_hold.rst
@@ -1,0 +1,9 @@
+﻿min_hold
+=======================
+
+*Defined in* :mod:`fynance.signal`
+
+.. currentmodule:: fynance.signal
+
+.. autofunction:: min_hold
+   :no-index:

--- a/doc/source/signal.rst
+++ b/doc/source/signal.rst
@@ -4,6 +4,12 @@
 
 The bridge from predictions to positions: mappers and a model+mapper pipeline.
 
+The **anti-churn** mappers (:func:`ema_smooth`, :func:`deadband`,
+:func:`min_hold`) are stateful but strictly causal; compose them on top of a
+position to cut turnover where transaction costs would otherwise dominate (high
+fees / high frequency). They pair with the train-time turnover penalty in
+:class:`~fynance.models.ObjectiveModel` (its ``cost`` argument).
+
 .. currentmodule:: fynance.signal
 
 .. autosummary::
@@ -13,4 +19,7 @@ The bridge from predictions to positions: mappers and a model+mapper pipeline.
    threshold
    rank
    vol_target_position
+   ema_smooth
+   deadband
+   min_hold
    SignalPipeline

--- a/fynance/signal/__init__.py
+++ b/fynance/signal/__init__.py
@@ -12,7 +12,15 @@ with a mapper.
 """
 
 # Local packages
-from .mappers import rank, sign, threshold, vol_target_position
+from .mappers import (
+    deadband,
+    ema_smooth,
+    min_hold,
+    rank,
+    sign,
+    threshold,
+    vol_target_position,
+)
 from .pipeline import SignalPipeline
 
 __all__ = [
@@ -20,5 +28,8 @@ __all__ = [
     'threshold',
     'rank',
     'vol_target_position',
+    'ema_smooth',
+    'deadband',
+    'min_hold',
     'SignalPipeline',
 ]

--- a/fynance/signal/mappers.py
+++ b/fynance/signal/mappers.py
@@ -6,6 +6,11 @@
 Pure numpy and causal: the position at ``t`` depends only on the prediction at
 ``t`` (the engine in :mod:`fynance.backtest` applies the causal one-step shift).
 
+The **anti-churn** mappers — :func:`ema_smooth`, :func:`deadband`,
+:func:`min_hold` — are stateful (each output depends on the past output) but
+strictly causal; compose them to cut turnover where transaction costs would
+otherwise eat the edge (high fees / high frequency).
+
 """
 
 from __future__ import annotations
@@ -17,7 +22,8 @@ from numpy.typing import NDArray
 # Local packages
 from fynance.portfolio.sizing import vol_target
 
-__all__ = ['sign', 'threshold', 'rank', 'vol_target_position']
+__all__ = ['sign', 'threshold', 'rank', 'vol_target_position',
+           'ema_smooth', 'deadband', 'min_hold']
 
 
 def sign(pred: NDArray) -> NDArray[np.float64]:
@@ -120,3 +126,115 @@ def vol_target_position(
     )
 
     return sig * lev
+
+
+def ema_smooth(pred: NDArray, alpha: float = 0.2) -> NDArray[np.float64]:
+    """ Causally smooth a position with an exponential moving average.
+
+    ``out[t] = alpha * pred[t] + (1 - alpha) * out[t-1]`` — a low ``alpha`` reacts
+    slowly, cutting turnover by damping minute-to-minute flips. Anti-churn.
+
+    Parameters
+    ----------
+    pred : array-like, shape (T,)
+        Raw position / prediction series.
+    alpha : float
+        Smoothing factor in ``(0, 1]`` (``1`` = no smoothing).
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> ema_smooth(np.array([0.0, 1.0, 1.0, -1.0]), alpha=0.5)
+    array([ 0.   ,  0.5  ,  0.75 , -0.125])
+
+    """
+    if not 0.0 < alpha <= 1.0:
+
+        raise ValueError("alpha must be in (0, 1]")
+
+    p = np.asarray(pred, dtype=np.float64).reshape(-1)
+    out = np.empty_like(p)
+    acc = 0.0 if p.size == 0 else p[0]
+    for t in range(p.size):
+        acc = alpha * p[t] + (1.0 - alpha) * acc
+        out[t] = acc
+
+    return out
+
+
+def deadband(pred: NDArray, band: float = 0.1) -> NDArray[np.float64]:
+    """ Hold the previous position unless the target moves by more than ``band``.
+
+    A *sticky* dead-band: ``out[t] = pred[t]`` only when
+    ``|pred[t] - out[t-1]| > band``, else ``out[t] = out[t-1]``. Magnitude is
+    preserved (unlike :func:`threshold`), but small oscillations are ignored, so
+    the position changes only on meaningful moves. Anti-churn.
+
+    Parameters
+    ----------
+    pred : array-like, shape (T,)
+        Raw position / prediction series.
+    band : float
+        Minimum change required to update the held position (``>= 0``).
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> deadband(np.array([0.0, 0.05, 0.5, 0.55, -0.4]), band=0.2)
+    array([ 0. ,  0. ,  0.5,  0.5, -0.4])
+
+    """
+    if band < 0.0:
+
+        raise ValueError("band must be >= 0")
+
+    p = np.asarray(pred, dtype=np.float64).reshape(-1)
+    out = np.empty_like(p)
+    held = 0.0 if p.size == 0 else p[0]
+    for t in range(p.size):
+        if abs(p[t] - held) > band:
+            held = p[t]
+        out[t] = held
+
+    return out
+
+
+def min_hold(pos: NDArray, hold: int, tol: float = 1e-9) -> NDArray[np.float64]:
+    """ Enforce a minimum holding period between position changes.
+
+    Once the position changes, it is **frozen for ``hold`` bars** before another
+    change can take effect — a hard cap on trade frequency. Strictly causal.
+
+    Parameters
+    ----------
+    pos : array-like, shape (T,)
+        Position series (e.g. already mapped to a target).
+    hold : int
+        Minimum number of bars between two changes (``hold <= 1`` is a no-op).
+    tol : float
+        Changes smaller than ``tol`` are treated as no change.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> min_hold(np.array([1., -1., 1., -1., 1., -1.]), hold=3)
+    array([ 1.,  1.,  1., -1., -1., -1.])
+
+    """
+    p = np.asarray(pos, dtype=np.float64).reshape(-1)
+    if hold <= 1 or p.size == 0:
+
+        return p.copy()
+
+    out = np.empty_like(p)
+    held = p[0]
+    out[0] = held
+    since = 0
+    for t in range(1, p.size):
+        since += 1
+        if since >= hold and abs(p[t] - held) > tol:
+            held = p[t]
+            since = 0
+        out[t] = held
+
+    return out

--- a/fynance/tests/signal/test_signal.py
+++ b/fynance/tests/signal/test_signal.py
@@ -10,11 +10,18 @@ import numpy as np
 from fynance.core import SignalModel
 from fynance.signal import (
     SignalPipeline,
+    deadband,
+    ema_smooth,
+    min_hold,
     rank,
     sign,
     threshold,
     vol_target_position,
 )
+
+
+def _turnover(pos):
+    return float(np.abs(np.diff(np.asarray(pos, dtype=float), prepend=0.0)).sum())
 
 
 def test_sign():
@@ -77,3 +84,62 @@ def test_dummy_model_conforms_to_signalmodel():
             return np.zeros(len(X))
 
     assert isinstance(DummyModel(), SignalModel)
+
+
+# --- anti-churn mappers -----------------------------------------------------
+
+def test_ema_smooth_cuts_turnover_and_is_causal():
+    flips = np.array([1.0, -1.0] * 50)               # churns every bar
+    smoothed = ema_smooth(flips, alpha=0.2)
+    assert _turnover(smoothed) < _turnover(flips)     # turnover reduced
+    # causal: a future value cannot change an earlier output
+    other = flips.copy()
+    other[60:] = 0.0
+    assert np.allclose(ema_smooth(flips, 0.2)[:60], ema_smooth(other, 0.2)[:60])
+
+
+def test_ema_smooth_alpha_one_is_identity():
+    p = np.array([0.3, -0.7, 1.0, -0.2])
+    assert np.allclose(ema_smooth(p, alpha=1.0), p)
+
+
+def test_ema_smooth_rejects_bad_alpha():
+    import pytest
+    for bad in (0.0, -0.1, 1.5):
+        with pytest.raises(ValueError):
+            ema_smooth(np.zeros(3), alpha=bad)
+
+
+def test_deadband_holds_through_small_moves():
+    out = deadband(np.array([0.0, 0.05, 0.5, 0.55, -0.4]), band=0.2)
+    assert np.allclose(out, [0.0, 0.0, 0.5, 0.5, -0.4])
+
+
+def test_deadband_cuts_turnover():
+    rng = np.random.default_rng(0)
+    noisy = rng.normal(0, 0.05, 200)                 # jitter around 0
+    assert _turnover(deadband(noisy, band=0.2)) < _turnover(noisy)
+
+
+def test_deadband_is_causal():
+    p = np.array([0.0, 0.5, 0.55, 0.9, -0.4])
+    other = p.copy()
+    other[3:] = 5.0
+    assert np.allclose(deadband(p, 0.2)[:3], deadband(other, 0.2)[:3])
+
+
+def test_min_hold_enforces_dwell():
+    out = min_hold(np.array([1.0, -1.0, 1.0, -1.0, 1.0, -1.0]), hold=3)
+    assert np.allclose(out, [1.0, 1.0, 1.0, -1.0, -1.0, -1.0])
+
+
+def test_min_hold_noop_when_hold_leq_one():
+    p = np.array([1.0, -1.0, 1.0])
+    assert np.allclose(min_hold(p, hold=1), p)
+
+
+def test_min_hold_is_causal():
+    p = np.array([1.0, 1.0, -1.0, -1.0, 1.0, 1.0])
+    other = p.copy()
+    other[4:] = -1.0
+    assert np.allclose(min_hold(p, 3)[:4], min_hold(other, 3)[:4])


### PR DESCRIPTION
## What

Anti-churn **brick 2** (inference-time). Three causal, composable position mappers in `fynance.signal`:

- **`ema_smooth(pred, alpha)`** — EMA-smooth a position (damps minute-to-minute flips).
- **`deadband(pred, band)`** — sticky/hysteretic hold: update only when the target moves beyond `band`; magnitude-preserving (unlike `threshold`).
- **`min_hold(pos, hold)`** — enforce a minimum holding period between changes (hard cap on trade frequency).

They complement brick 1's train-time `ObjectiveModel(cost=...)`: the model learns to hold, the mappers give a hard, model-agnostic turnover cap on top (and work for rule-based strategies too).

## Test plan

- Tests per mapper: turnover reduction, exact behaviour, causality, edge cases; doctests.
- `sphinx-build -W` clean (autosummary stubs committed); `ruff` + `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)