### PR TITLE
chore: release v2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [2.7.0] - 2026-06-18
+
+### Breaking Changes
+
+### Added
+
 - **Anti-churn signal mappers.** `fynance.signal` gains three causal, composable position mappers to cut turnover where transaction costs dominate: `ema_smooth` (EMA-smooth a position), `deadband` (sticky hold unless the target moves beyond a band, magnitude-preserving), and `min_hold` (enforce a minimum holding period between changes). They pair with the train-time `ObjectiveModel(cost=...)` penalty.
 - **Turnover-penalized (net-of-cost) objective training.** `ObjectiveModel` gains a `cost` parameter: when non-zero the objective is computed on `positions * returns - cost * |Δpositions|`, so the network learns to **hold** positions instead of churning — the anti-churn lever for high-cost / high-frequency settings. Defaults to `0` (unchanged behaviour).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fynance"
-version = "2.6.0"
+version = "2.7.0"
 description = "Pure-Python (Numba-accelerated) machine learning, econometrics and statistical tools for financial analysis and backtesting"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Release **v2.7.0** — anti-churn infrastructure.

## [2.7.0]

### Added
- **Turnover-penalized (net-of-cost) objective training** — `ObjectiveModel(cost=...)` optimizes `positions*returns − cost*|Δpositions|` (the model learns to hold).
- **Anti-churn signal mappers** — `ema_smooth`, `deadband`, `min_hold` in `fynance.signal` (inference-time turnover caps).

Together: the two-layer anti-churn system for high-cost / high-frequency settings (e.g. crypto 1-min at ~0.26% taker).

## Test plan
- Full suite green; `ruff` + `mypy` clean; `sphinx-build -W` clean. Both feature PRs (#169, #170) merged with the 7 gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)