### PR TITLE
Release v2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Anti-churn signal mappers.** `fynance.signal` gains three causal, composable position mappers to cut turnover where transaction costs dominate: `ema_smooth` (EMA-smooth a position), `deadband` (sticky hold unless the target moves beyond a band, magnitude-preserving), and `min_hold` (enforce a minimum holding period between changes). They pair with the train-time `ObjectiveModel(cost=...)` penalty.
 - **Turnover-penalized (net-of-cost) objective training.** `ObjectiveModel` gains a `cost` parameter: when non-zero the objective is computed on `positions * returns - cost * |Δpositions|`, so the network learns to **hold** positions instead of churning — the anti-churn lever for high-cost / high-frequency settings. Defaults to `0` (unchanged behaviour).
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [2.7.0] - 2026-06-18
+
+### Breaking Changes
+
+### Added
+
 - **Anti-churn signal mappers.** `fynance.signal` gains three causal, composable position mappers to cut turnover where transaction costs dominate: `ema_smooth` (EMA-smooth a position), `deadband` (sticky hold unless the target moves beyond a band, magnitude-preserving), and `min_hold` (enforce a minimum holding period between changes). They pair with the train-time `ObjectiveModel(cost=...)` penalty.
 - **Turnover-penalized (net-of-cost) objective training.** `ObjectiveModel` gains a `cost` parameter: when non-zero the objective is computed on `positions * returns - cost * |Δpositions|`, so the network learns to **hold** positions instead of churning — the anti-churn lever for high-cost / high-frequency settings. Defaults to `0` (unchanged behaviour).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Turnover-penalized (net-of-cost) objective training.** `ObjectiveModel` gains a `cost` parameter: when non-zero the objective is computed on `positions * returns - cost * |Δpositions|`, so the network learns to **hold** positions instead of churning — the anti-churn lever for high-cost / high-frequency settings. Defaults to `0` (unchanged behaviour).
+
 ### Changed
 
 ### Fixed

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -72,6 +72,19 @@ Template:
 
 <!-- new entries below, newest first -->
 
+### 2026-06-18 — Anti-churn brick 1: net-of-cost objective training (PR #169)  [accepted]
+- **Choice**: penalize turnover **inside the training objective** — `ObjectiveModel`
+  optimizes `Sharpe(positions*returns − cost*|Δpositions|)` via a new `cost` param —
+  rather than only post-processing positions or relying on the backtest cost.
+- **Why**: at realistic crypto fees (Kraken ~0.26% taker → ~0.52% round-trip) a
+  high-frequency strategy that flips often is structurally unprofitable. Teaching
+  the net the cost at train time makes it *hold* (the gradient couples positions
+  across bars), which a post-hoc filter cannot do as well. Generic, opt-in
+  (`cost=0` default = unchanged).
+- **Rejected alternatives**: only an inference-time smoother/deadband (necessary
+  but insufficient — the model still *wants* to churn); a separate cost-aware loss
+  class (more API surface than threading `cost` through the existing objective).
+
 ### 2026-06-17 — Self-describing experiments (provenance block) (PR #163)  [accepted]
 - **Choice**: provenance (what data + what features + run config produced a result)
   is recorded **generically in `fynance.research`** — `run_experiment` builds a

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -72,6 +72,18 @@ Template:
 
 <!-- new entries below, newest first -->
 
+### 2026-06-18 — Anti-churn brick 2: inference-time turnover mappers (PR #170)  [accepted]
+- **Choice**: add three causal, composable position mappers to `fynance.signal` —
+  `ema_smooth`, `deadband` (sticky/hysteretic, magnitude-preserving), `min_hold`
+  (minimum dwell). The inference-time complement to brick 1's train-time penalty.
+- **Why**: two layers beat one. The net-of-cost objective makes the model *want*
+  to hold; the mappers give a hard, model-agnostic turnover cap on top (and work
+  for rule-based strategies too). Kept as separate small functions (composable)
+  rather than one mega-mapper.
+- **Rejected alternatives**: folding everything into the existing `threshold`
+  (it discards magnitude and is stateless — wrong tool); only the train-time
+  penalty (can't hard-cap trade frequency).
+
 ### 2026-06-18 — Anti-churn brick 1: net-of-cost objective training (PR #169)  [accepted]
 - **Choice**: penalize turnover **inside the training objective** — `ObjectiveModel`
   optimizes `Sharpe(positions*returns − cost*|Δpositions|)` via a new `cost` param —

--- a/doc/source/generated/fynance.signal.deadband.rst
+++ b/doc/source/generated/fynance.signal.deadband.rst
@@ -1,0 +1,9 @@
+﻿deadband
+=======================
+
+*Defined in* :mod:`fynance.signal`
+
+.. currentmodule:: fynance.signal
+
+.. autofunction:: deadband
+   :no-index:

--- a/doc/source/generated/fynance.signal.ema_smooth.rst
+++ b/doc/source/generated/fynance.signal.ema_smooth.rst
@@ -1,0 +1,9 @@
+﻿ema_smooth
+=========================
+
+*Defined in* :mod:`fynance.signal`
+
+.. currentmodule:: fynance.signal
+
+.. autofunction:: ema_smooth
+   :no-index:

--- a/doc/source/generated/fynance.signal.min_hold.rst
+++ b/doc/source/generated/fynance.signal.min_hold.rst
@@ -1,0 +1,9 @@
+﻿min_hold
+=======================
+
+*Defined in* :mod:`fynance.signal`
+
+.. currentmodule:: fynance.signal
+
+.. autofunction:: min_hold
+   :no-index:

--- a/doc/source/models.neural_network.rst
+++ b/doc/source/models.neural_network.rst
@@ -34,6 +34,12 @@ with an identity signal::
     model = ObjectiveModel(layers=(16, 8), loss=SharpeLoss(), epochs=60, seed=0)
     strat = Strategy(model=model, signal=lambda positions: positions)
 
+Set ``cost`` (a per-bar proportional fee, e.g. ``0.0026``) to train on the
+**net-of-cost** return ``positions * returns - cost * |Δpositions|``: the net then
+learns to *hold* rather than churn — the anti-churn lever for high-cost or
+high-frequency settings (use the same value as the backtest's
+:class:`~fynance.backtest.ProportionalCost`).
+
 Feed it through the research harness via the ``X`` path with ``y`` = returns; see
 :doc:`research_workflow`.
 

--- a/doc/source/signal.rst
+++ b/doc/source/signal.rst
@@ -4,6 +4,12 @@
 
 The bridge from predictions to positions: mappers and a model+mapper pipeline.
 
+The **anti-churn** mappers (:func:`ema_smooth`, :func:`deadband`,
+:func:`min_hold`) are stateful but strictly causal; compose them on top of a
+position to cut turnover where transaction costs would otherwise dominate (high
+fees / high frequency). They pair with the train-time turnover penalty in
+:class:`~fynance.models.ObjectiveModel` (its ``cost`` argument).
+
 .. currentmodule:: fynance.signal
 
 .. autosummary::
@@ -13,4 +19,7 @@ The bridge from predictions to positions: mappers and a model+mapper pipeline.
    threshold
    rank
    vol_target_position
+   ema_smooth
+   deadband
+   min_hold
    SignalPipeline

--- a/fynance/models/objective.py
+++ b/fynance/models/objective.py
@@ -73,6 +73,14 @@ class ObjectiveModel:
     position_fn : callable
         Maps the net output to a position; default ``tanh`` (positions in
         ``[-1, 1]``).
+    cost : float
+        Per-bar proportional turnover cost penalized **during training** (e.g.
+        ``0.0026`` for 26 bps). When non-zero the objective is computed on the
+        **net-of-cost** return ``positions * returns - cost * |Δpositions|``, so
+        the net learns to hold positions instead of churning — the anti-churn
+        brick for high-cost / high-frequency settings. Use the same value as the
+        backtest's :class:`~fynance.backtest.ProportionalCost`. Default ``0``
+        (no penalty, original behaviour).
     seed : int
         Seed for reproducible initialization/training.
 
@@ -93,6 +101,7 @@ class ObjectiveModel:
         lr: float = 1e-3,
         epochs: int = 80,
         position_fn: Callable[[torch.Tensor], torch.Tensor] = torch.tanh,
+        cost: float = 0.0,
         seed: int = 0,
     ):
         self.net = net
@@ -102,6 +111,7 @@ class ObjectiveModel:
         self.lr = lr
         self.epochs = epochs
         self.position_fn = position_fn
+        self.cost = cost
         self.seed = seed
         self._optim: torch.optim.Optimizer | None = None
 
@@ -142,7 +152,15 @@ class ObjectiveModel:
         self.net.train()  # type: ignore[union-attr]
         for _ in range(self.epochs):
             self._optim.zero_grad()  # type: ignore[union-attr]
-            strat_ret = self._positions(Xt) * rt
+            pos = self._positions(Xt)
+            strat_ret = pos * rt
+            if self.cost:
+                # Turnover penalty: charge ``cost * |Δposition|`` each bar (the
+                # first bar charges entry from flat). This couples positions
+                # across time so the net learns to *hold* rather than churn —
+                # the loss optimizes the **net-of-cost** return series.
+                turnover = torch.cat([pos[:1].abs(), torch.abs(pos[1:] - pos[:-1])])
+                strat_ret = strat_ret - self.cost * turnover
             loss = self.loss(strat_ret)
             loss.backward()
             self._optim.step()  # type: ignore[union-attr]

--- a/fynance/signal/__init__.py
+++ b/fynance/signal/__init__.py
@@ -12,7 +12,15 @@ with a mapper.
 """
 
 # Local packages
-from .mappers import rank, sign, threshold, vol_target_position
+from .mappers import (
+    deadband,
+    ema_smooth,
+    min_hold,
+    rank,
+    sign,
+    threshold,
+    vol_target_position,
+)
 from .pipeline import SignalPipeline
 
 __all__ = [
@@ -20,5 +28,8 @@ __all__ = [
     'threshold',
     'rank',
     'vol_target_position',
+    'ema_smooth',
+    'deadband',
+    'min_hold',
     'SignalPipeline',
 ]

--- a/fynance/signal/mappers.py
+++ b/fynance/signal/mappers.py
@@ -6,6 +6,11 @@
 Pure numpy and causal: the position at ``t`` depends only on the prediction at
 ``t`` (the engine in :mod:`fynance.backtest` applies the causal one-step shift).
 
+The **anti-churn** mappers — :func:`ema_smooth`, :func:`deadband`,
+:func:`min_hold` — are stateful (each output depends on the past output) but
+strictly causal; compose them to cut turnover where transaction costs would
+otherwise eat the edge (high fees / high frequency).
+
 """
 
 from __future__ import annotations
@@ -17,7 +22,8 @@ from numpy.typing import NDArray
 # Local packages
 from fynance.portfolio.sizing import vol_target
 
-__all__ = ['sign', 'threshold', 'rank', 'vol_target_position']
+__all__ = ['sign', 'threshold', 'rank', 'vol_target_position',
+           'ema_smooth', 'deadband', 'min_hold']
 
 
 def sign(pred: NDArray) -> NDArray[np.float64]:
@@ -120,3 +126,115 @@ def vol_target_position(
     )
 
     return sig * lev
+
+
+def ema_smooth(pred: NDArray, alpha: float = 0.2) -> NDArray[np.float64]:
+    """ Causally smooth a position with an exponential moving average.
+
+    ``out[t] = alpha * pred[t] + (1 - alpha) * out[t-1]`` — a low ``alpha`` reacts
+    slowly, cutting turnover by damping minute-to-minute flips. Anti-churn.
+
+    Parameters
+    ----------
+    pred : array-like, shape (T,)
+        Raw position / prediction series.
+    alpha : float
+        Smoothing factor in ``(0, 1]`` (``1`` = no smoothing).
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> ema_smooth(np.array([0.0, 1.0, 1.0, -1.0]), alpha=0.5)
+    array([ 0.   ,  0.5  ,  0.75 , -0.125])
+
+    """
+    if not 0.0 < alpha <= 1.0:
+
+        raise ValueError("alpha must be in (0, 1]")
+
+    p = np.asarray(pred, dtype=np.float64).reshape(-1)
+    out = np.empty_like(p)
+    acc = 0.0 if p.size == 0 else p[0]
+    for t in range(p.size):
+        acc = alpha * p[t] + (1.0 - alpha) * acc
+        out[t] = acc
+
+    return out
+
+
+def deadband(pred: NDArray, band: float = 0.1) -> NDArray[np.float64]:
+    """ Hold the previous position unless the target moves by more than ``band``.
+
+    A *sticky* dead-band: ``out[t] = pred[t]`` only when
+    ``|pred[t] - out[t-1]| > band``, else ``out[t] = out[t-1]``. Magnitude is
+    preserved (unlike :func:`threshold`), but small oscillations are ignored, so
+    the position changes only on meaningful moves. Anti-churn.
+
+    Parameters
+    ----------
+    pred : array-like, shape (T,)
+        Raw position / prediction series.
+    band : float
+        Minimum change required to update the held position (``>= 0``).
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> deadband(np.array([0.0, 0.05, 0.5, 0.55, -0.4]), band=0.2)
+    array([ 0. ,  0. ,  0.5,  0.5, -0.4])
+
+    """
+    if band < 0.0:
+
+        raise ValueError("band must be >= 0")
+
+    p = np.asarray(pred, dtype=np.float64).reshape(-1)
+    out = np.empty_like(p)
+    held = 0.0 if p.size == 0 else p[0]
+    for t in range(p.size):
+        if abs(p[t] - held) > band:
+            held = p[t]
+        out[t] = held
+
+    return out
+
+
+def min_hold(pos: NDArray, hold: int, tol: float = 1e-9) -> NDArray[np.float64]:
+    """ Enforce a minimum holding period between position changes.
+
+    Once the position changes, it is **frozen for ``hold`` bars** before another
+    change can take effect — a hard cap on trade frequency. Strictly causal.
+
+    Parameters
+    ----------
+    pos : array-like, shape (T,)
+        Position series (e.g. already mapped to a target).
+    hold : int
+        Minimum number of bars between two changes (``hold <= 1`` is a no-op).
+    tol : float
+        Changes smaller than ``tol`` are treated as no change.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> min_hold(np.array([1., -1., 1., -1., 1., -1.]), hold=3)
+    array([ 1.,  1.,  1., -1., -1., -1.])
+
+    """
+    p = np.asarray(pos, dtype=np.float64).reshape(-1)
+    if hold <= 1 or p.size == 0:
+
+        return p.copy()
+
+    out = np.empty_like(p)
+    held = p[0]
+    out[0] = held
+    since = 0
+    for t in range(1, p.size):
+        since += 1
+        if since >= hold and abs(p[t] - held) > tol:
+            held = p[t]
+            since = 0
+        out[t] = held
+
+    return out

--- a/fynance/tests/models/test_objective.py
+++ b/fynance/tests/models/test_objective.py
@@ -59,3 +59,36 @@ def test_accepts_custom_net_and_loss():
                               torch.nn.Linear(4, 1))
     model = ObjectiveModel(net=net, loss=SortinoLoss(), epochs=10).fit(X, returns)
     assert np.asarray(model.predict(X)).shape == (300, 1)
+
+
+def _alternating_edge(n=1500, seed=0):
+    """ Sign flips every bar: the no-cost optimum churns (turnover ~2/bar). """
+    s = np.where(np.arange(n) % 2 == 0, 1.0, -1.0)
+    rng = np.random.default_rng(seed)
+    returns = (s * 0.01 + rng.standard_normal(n) * 0.005).astype(np.float32)
+    X = np.column_stack([s, rng.standard_normal(n)]).astype(np.float32)
+
+    return X, returns
+
+
+def _turnover(pos):
+    return float(np.abs(np.diff(np.asarray(pos).reshape(-1), prepend=0.0)).mean())
+
+
+def test_cost_reduces_turnover():
+    # On a fast-flipping edge, a no-cost model churns; a turnover-penalized one
+    # holds. The cost term should cut realized turnover substantially.
+    X, returns = _alternating_edge()
+    free = ObjectiveModel(layers=(8,), epochs=200, lr=5e-3, seed=0).fit(X, returns)
+    pricey = ObjectiveModel(layers=(8,), epochs=200, lr=5e-3, cost=0.1,
+                            seed=0).fit(X, returns)
+
+    assert _turnover(pricey.predict(X)) < _turnover(free.predict(X))
+
+
+def test_cost_default_zero_is_unchanged():
+    # cost defaults to 0 -> identical to not passing it (pure refactor safety).
+    X, returns = _edge_data(n=400)
+    a = ObjectiveModel(epochs=20, seed=3).fit(X, returns).predict(X)
+    b = ObjectiveModel(epochs=20, cost=0.0, seed=3).fit(X, returns).predict(X)
+    assert np.allclose(a, b)

--- a/fynance/tests/signal/test_signal.py
+++ b/fynance/tests/signal/test_signal.py
@@ -10,11 +10,18 @@ import numpy as np
 from fynance.core import SignalModel
 from fynance.signal import (
     SignalPipeline,
+    deadband,
+    ema_smooth,
+    min_hold,
     rank,
     sign,
     threshold,
     vol_target_position,
 )
+
+
+def _turnover(pos):
+    return float(np.abs(np.diff(np.asarray(pos, dtype=float), prepend=0.0)).sum())
 
 
 def test_sign():
@@ -77,3 +84,62 @@ def test_dummy_model_conforms_to_signalmodel():
             return np.zeros(len(X))
 
     assert isinstance(DummyModel(), SignalModel)
+
+
+# --- anti-churn mappers -----------------------------------------------------
+
+def test_ema_smooth_cuts_turnover_and_is_causal():
+    flips = np.array([1.0, -1.0] * 50)               # churns every bar
+    smoothed = ema_smooth(flips, alpha=0.2)
+    assert _turnover(smoothed) < _turnover(flips)     # turnover reduced
+    # causal: a future value cannot change an earlier output
+    other = flips.copy()
+    other[60:] = 0.0
+    assert np.allclose(ema_smooth(flips, 0.2)[:60], ema_smooth(other, 0.2)[:60])
+
+
+def test_ema_smooth_alpha_one_is_identity():
+    p = np.array([0.3, -0.7, 1.0, -0.2])
+    assert np.allclose(ema_smooth(p, alpha=1.0), p)
+
+
+def test_ema_smooth_rejects_bad_alpha():
+    import pytest
+    for bad in (0.0, -0.1, 1.5):
+        with pytest.raises(ValueError):
+            ema_smooth(np.zeros(3), alpha=bad)
+
+
+def test_deadband_holds_through_small_moves():
+    out = deadband(np.array([0.0, 0.05, 0.5, 0.55, -0.4]), band=0.2)
+    assert np.allclose(out, [0.0, 0.0, 0.5, 0.5, -0.4])
+
+
+def test_deadband_cuts_turnover():
+    rng = np.random.default_rng(0)
+    noisy = rng.normal(0, 0.05, 200)                 # jitter around 0
+    assert _turnover(deadband(noisy, band=0.2)) < _turnover(noisy)
+
+
+def test_deadband_is_causal():
+    p = np.array([0.0, 0.5, 0.55, 0.9, -0.4])
+    other = p.copy()
+    other[3:] = 5.0
+    assert np.allclose(deadband(p, 0.2)[:3], deadband(other, 0.2)[:3])
+
+
+def test_min_hold_enforces_dwell():
+    out = min_hold(np.array([1.0, -1.0, 1.0, -1.0, 1.0, -1.0]), hold=3)
+    assert np.allclose(out, [1.0, 1.0, 1.0, -1.0, -1.0, -1.0])
+
+
+def test_min_hold_noop_when_hold_leq_one():
+    p = np.array([1.0, -1.0, 1.0])
+    assert np.allclose(min_hold(p, hold=1), p)
+
+
+def test_min_hold_is_causal():
+    p = np.array([1.0, 1.0, -1.0, -1.0, 1.0, 1.0])
+    other = p.copy()
+    other[4:] = -1.0
+    assert np.allclose(min_hold(p, 3)[:4], min_hold(other, 3)[:4])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fynance"
-version = "2.6.0"
+version = "2.7.0"
 description = "Pure-Python (Numba-accelerated) machine learning, econometrics and statistical tools for financial analysis and backtesting"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Release **v2.7.0** — anti-churn infrastructure.

## [2.7.0]

### Added
- **Turnover-penalized (net-of-cost) objective training** — `ObjectiveModel(cost=...)` optimizes `positions*returns − cost*|Δpositions|` (the model learns to hold).
- **Anti-churn signal mappers** — `ema_smooth`, `deadband`, `min_hold` in `fynance.signal` (inference-time turnover caps).

Together: the two-layer anti-churn system for high-cost / high-frequency settings (e.g. crypto 1-min at ~0.26% taker).

## Test plan
- Full suite green; `ruff` + `mypy` clean; `sphinx-build -W` clean. Both feature PRs (#169, #170) merged with the 7 gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
> À merger dans master après le merge de chore/release-2.7.0 dans develop.