### PR TITLE
chore: release v2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [2.8.0] - 2026-06-18
+
+### Breaking Changes
+
+### Added
+
 - **Mini-batch training for `ObjectiveModel`.** New `batch_size` (and `shuffle`) parameters train on **contiguous** mini-batches instead of full-batch — so a `fit` does `epochs * ceil(T / batch_size)` optimizer steps instead of just `epochs`. This is what makes the objective actually converge on long (e.g. minute-resolution) series, where full-batch gave far too few updates. The turnover penalty is carried across chunk boundaries (in time order); `batch_size=None` keeps the original full-batch behaviour.
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fynance"
-version = "2.7.0"
+version = "2.8.0"
 description = "Pure-Python (Numba-accelerated) machine learning, econometrics and statistical tools for financial analysis and backtesting"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Release **v2.8.0** — mini-batch training for `ObjectiveModel`.

## [2.8.0]
### Added
- **Mini-batch training** (`batch_size`/`shuffle`): `epochs * ceil(T/batch_size)` optimizer steps instead of `epochs` full-batch steps — lets the objective converge on long minute-resolution series (full-batch gave far too few updates). Turnover penalty carried across chunk boundaries; `batch_size=None` = original behaviour.

## Test plan
CI green (tests 3.10-3.13, ruff+interrogate, sphinx -W, mypy); PR #173 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)