### PR TITLE
Release v2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [2.8.0] - 2026-06-18
+
+### Breaking Changes
+
+### Added
+
 - **Mini-batch training for `ObjectiveModel`.** New `batch_size` (and `shuffle`) parameters train on **contiguous** mini-batches instead of full-batch — so a `fit` does `epochs * ceil(T / batch_size)` optimizer steps instead of just `epochs`. This is what makes the objective actually converge on long (e.g. minute-resolution) series, where full-batch gave far too few updates. The turnover penalty is carried across chunk boundaries (in time order); `batch_size=None` keeps the original full-batch behaviour.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Mini-batch training for `ObjectiveModel`.** New `batch_size` (and `shuffle`) parameters train on **contiguous** mini-batches instead of full-batch — so a `fit` does `epochs * ceil(T / batch_size)` optimizer steps instead of just `epochs`. This is what makes the objective actually converge on long (e.g. minute-resolution) series, where full-batch gave far too few updates. The turnover penalty is carried across chunk boundaries (in time order); `batch_size=None` keeps the original full-batch behaviour.
+
 ### Changed
 
 ### Fixed

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -72,6 +72,20 @@ Template:
 
 <!-- new entries below, newest first -->
 
+### 2026-06-18 — Mini-batch training for ObjectiveModel (PR #173)  [accepted]
+- **Choice**: add contiguous mini-batch SGD (`batch_size`/`shuffle`) to
+  `ObjectiveModel`; a `fit` now does `epochs * ceil(T/batch_size)` steps instead of
+  `epochs` full-batch steps. Chunks stay time-ordered so the turnover penalty
+  remains meaningful (carried across chunk boundaries when not shuffled).
+- **Why**: the full-batch path gave only `epochs` (~40) gradient updates on
+  hundreds-of-thousands of bars — the minute-resolution models were drastically
+  **under-trained**, which alone could explain weak/null results. Mini-batching is
+  the prerequisite to honestly test whether OHLC carries edge. `batch_size=None`
+  preserves the old behaviour (backward compatible).
+- **Rejected alternatives**: only raising `epochs` (full-batch steps are O(T) each
+  and still few); shuffling individual rows (breaks the turnover diff / Sharpe
+  temporal structure) — hence *chunk-order* shuffle, rows kept ordered.
+
 ### 2026-06-18 — Anti-churn brick 2: inference-time turnover mappers (PR #170)  [accepted]
 - **Choice**: add three causal, composable position mappers to `fynance.signal` —
   `ema_smooth`, `deadband` (sticky/hysteretic, magnitude-preserving), `min_hold`

--- a/fynance/models/objective.py
+++ b/fynance/models/objective.py
@@ -69,7 +69,18 @@ class ObjectiveModel:
     lr : float
         Learning rate.
     epochs : int
-        Full-batch training steps per :meth:`fit`.
+        Passes over the data per :meth:`fit`. With full-batch (``batch_size``
+        ``None``) this is the number of optimizer steps; with mini-batches it is
+        ``epochs * ceil(T / batch_size)`` steps — **far more updates**, which the
+        objective usually needs to converge on long series.
+    batch_size : int, optional
+        Train on **contiguous** mini-batches of this many bars (order preserved so
+        the turnover penalty stays meaningful). ``None`` (default) = full batch.
+        Mini-batching is the practical way to actually train on long (e.g. minute)
+        series — full-batch gives only ``epochs`` gradient steps total.
+    shuffle : bool
+        When mini-batching, shuffle the **order of the contiguous chunks** each
+        epoch (rows within a chunk stay ordered). Improves SGD; default True.
     position_fn : callable
         Maps the net output to a position; default ``tanh`` (positions in
         ``[-1, 1]``).
@@ -100,6 +111,8 @@ class ObjectiveModel:
         optimizer: type[torch.optim.Optimizer] = torch.optim.Adam,
         lr: float = 1e-3,
         epochs: int = 80,
+        batch_size: int | None = None,
+        shuffle: bool = True,
         position_fn: Callable[[torch.Tensor], torch.Tensor] = torch.tanh,
         cost: float = 0.0,
         seed: int = 0,
@@ -110,6 +123,8 @@ class ObjectiveModel:
         self.optimizer_cls = optimizer
         self.lr = lr
         self.epochs = epochs
+        self.batch_size = batch_size
+        self.shuffle = shuffle
         self.position_fn = position_fn
         self.cost = cost
         self.seed = seed
@@ -129,8 +144,24 @@ class ObjectiveModel:
 
         return self.position_fn(out)
 
+    def _strat_return(self, pos: torch.Tensor, ret: torch.Tensor,
+                      prev: torch.Tensor | None) -> torch.Tensor:
+        """ Net-of-cost strategy return ``pos*ret - cost*|Δpos|`` for a chunk.
+
+        ``prev`` is the (detached) last position of the previous contiguous chunk
+        so the turnover at the chunk boundary is charged correctly; ``None`` (or a
+        shuffled chunk) charges entry from flat on the first bar.
+        """
+        strat = pos * ret
+        if self.cost:
+            first = pos[:1].abs() if prev is None else (pos[:1] - prev).abs()
+            turnover = torch.cat([first, torch.abs(pos[1:] - pos[:-1])])
+            strat = strat - self.cost * turnover
+
+        return strat
+
     def fit(self, X: NDArray, y: NDArray) -> ObjectiveModel:
-        """ Train the net to maximize the objective of ``positions * y``.
+        """ Train the net to maximize the objective of the net-of-cost return.
 
         Parameters
         ----------
@@ -149,21 +180,30 @@ class ObjectiveModel:
         rt = torch.as_tensor(np.asarray(y, dtype=np.float32).reshape(-1))
         self._ensure_net(Xt.shape[1])
 
+        T = Xt.shape[0]
+        bs = self.batch_size or T
+        n_chunks = (T + bs - 1) // bs
+        gen = torch.Generator().manual_seed(self.seed)
+
         self.net.train()  # type: ignore[union-attr]
         for _ in range(self.epochs):
-            self._optim.zero_grad()  # type: ignore[union-attr]
-            pos = self._positions(Xt)
-            strat_ret = pos * rt
-            if self.cost:
-                # Turnover penalty: charge ``cost * |Δposition|`` each bar (the
-                # first bar charges entry from flat). This couples positions
-                # across time so the net learns to *hold* rather than churn —
-                # the loss optimizes the **net-of-cost** return series.
-                turnover = torch.cat([pos[:1].abs(), torch.abs(pos[1:] - pos[:-1])])
-                strat_ret = strat_ret - self.cost * turnover
-            loss = self.loss(strat_ret)
-            loss.backward()
-            self._optim.step()  # type: ignore[union-attr]
+            order: list[int] = list(range(n_chunks))
+            if self.shuffle and n_chunks > 1:
+                order = torch.randperm(n_chunks, generator=gen).tolist()
+
+            prev: torch.Tensor | None = None
+            for ci in order:
+                a, b = ci * bs, min((ci + 1) * bs, T)
+                self._optim.zero_grad()  # type: ignore[union-attr]
+                pos = self._positions(Xt[a:b])
+                # Carry the previous chunk's last position only when chunks run in
+                # time order (no shuffle); a shuffled chunk charges entry-from-flat.
+                strat_ret = self._strat_return(pos, rt[a:b],
+                                               None if self.shuffle else prev)
+                loss = self.loss(strat_ret)
+                loss.backward()
+                self._optim.step()  # type: ignore[union-attr]
+                prev = pos[-1].detach()
 
         return self
 

--- a/fynance/tests/models/test_objective.py
+++ b/fynance/tests/models/test_objective.py
@@ -92,3 +92,36 @@ def test_cost_default_zero_is_unchanged():
     a = ObjectiveModel(epochs=20, seed=3).fit(X, returns).predict(X)
     b = ObjectiveModel(epochs=20, cost=0.0, seed=3).fit(X, returns).predict(X)
     assert np.allclose(a, b)
+
+
+def _sr(model, X, returns):
+    pos = np.asarray(model.predict(X)).reshape(-1)
+    return sharpe(np.cumprod(1 + pos * returns), period=252)
+
+
+def test_minibatch_trains_more_than_full_batch():
+    # Full-batch does only `epochs` gradient steps; mini-batching does
+    # `epochs * n_chunks` -> at the same (low) epoch budget it should learn more.
+    X, returns = _edge_data()
+    full = ObjectiveModel(layers=(8,), epochs=5, lr=5e-3, seed=0).fit(X, returns)
+    mini = ObjectiveModel(layers=(8,), epochs=5, lr=5e-3, batch_size=256,
+                          seed=0).fit(X, returns)
+
+    assert _sr(mini, X, returns) > _sr(full, X, returns)
+
+
+def test_minibatch_reproducible_with_seed():
+    X, returns = _edge_data(n=600)
+    a = ObjectiveModel(epochs=8, batch_size=128, seed=5).fit(X, returns).predict(X)
+    b = ObjectiveModel(epochs=8, batch_size=128, seed=5).fit(X, returns).predict(X)
+    assert np.allclose(a, b)
+
+
+def test_minibatch_with_cost_reduces_turnover():
+    X, returns = _alternating_edge()
+    free = ObjectiveModel(layers=(8,), epochs=20, lr=5e-3, batch_size=256,
+                          seed=0).fit(X, returns)
+    pricey = ObjectiveModel(layers=(8,), epochs=20, lr=5e-3, batch_size=256,
+                            cost=0.1, seed=0).fit(X, returns)
+
+    assert _turnover(pricey.predict(X)) < _turnover(free.predict(X))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fynance"
-version = "2.7.0"
+version = "2.8.0"
 description = "Pure-Python (Numba-accelerated) machine learning, econometrics and statistical tools for financial analysis and backtesting"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Release **v2.8.0** — mini-batch training for `ObjectiveModel`.

## [2.8.0]
### Added
- **Mini-batch training** (`batch_size`/`shuffle`): `epochs * ceil(T/batch_size)` optimizer steps instead of `epochs` full-batch steps — lets the objective converge on long minute-resolution series (full-batch gave far too few updates). Turnover penalty carried across chunk boundaries; `batch_size=None` = original behaviour.

## Test plan
CI green (tests 3.10-3.13, ruff+interrogate, sphinx -W, mypy); PR #173 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
> À merger dans master après le merge de chore/release-2.8.0 dans develop.