### PR TITLE
docs: groom dev docs to v2.8.0; re-scope roadmap to library bricks

### DIFF
--- a/doc/dev/01-overview.md
+++ b/doc/dev/01-overview.md
@@ -33,11 +33,11 @@ library's core invariant, enforced in tests.
 
 ## Current state (snapshot)
 
-- **Version `2.1.1`** (in `pyproject.toml`, static), released on `master` and
+- **Version `2.8.0`** (in `pyproject.toml`, static), released on `master` and
   published to PyPI; `Development Status :: 5 - Production/Stable`.
 - **Python 3.10–3.13** (CI matrix). Build is **pure-Python** (setuptools, no
   compile step) — numerical kernels are Numba `@njit`. No Cython.
-- **501 tests** under `fynance/tests/` (mirrors the package), **plus doctests**
+- **518 tests** under `fynance/tests/` (mirrors the package), **plus doctests**
   run on every module via `--doctest-modules` — docstring examples are part of
   the suite and must stay runnable.
 - **Four CI gates**: pytest (3.10–3.13), `ruff`, `interrogate` (docstring

--- a/doc/dev/02-architecture.md
+++ b/doc/dev/02-architecture.md
@@ -39,12 +39,14 @@ stability policy per package.)
   `_metrics_helpers` (the Numba metric kernels), `money_management`.
 - **`metrics/`** — performance/evaluation metrics split by concern: `ratios`
   (Sharpe/Sortino/Calmar/…), `drawdown`, `returns`, `summary` (one-call panel).
-- **`signal/` · `portfolio/`** — `sign`/`threshold`/`rank`/vol-target mappers +
-  `SignalPipeline`; `allocation.py` (ERC/HRP/IVP/MDP/MVP + `rolling_allocation()`,
-  stable public API) and `sizing.py`.
+- **`signal/` · `portfolio/`** — `sign`/`threshold`/`rank`/vol-target +
+  anti-churn (`ema_smooth`/`deadband`/`min_hold`) mappers + `SignalPipeline`;
+  `allocation.py` (ERC/HRP/IVP/MDP/MVP + `rolling_allocation()`, stable public
+  API) and `sizing.py`.
 - **`models/`** — econometric (`econometric_models.py`, Numba ARMA/GARCH) and
   neural (`mlp`, `rnn`, `gru`, `lstm`, `attention`, `tcn`, `transformer`) on a
-  rolling/walk-forward base; `loss/` (torch losses), `training.py`, `ensemble.py`.
+  rolling/walk-forward base; `loss/` (torch losses), `objective.py`
+  (objective-aligned training), `training.py`, `ensemble.py`.
 - **`backtest/`** — vectorized `engine` + `cost` + `result`; the legacy live-viz
   plot stack (`plot_backtest`/`dynamic_plot_backtest`/`backtest_neural_net`) is
   kept for `RollMultiLayerPerceptron` but off the eager public surface.

--- a/doc/dev/04-subpackages.md
+++ b/doc/dev/04-subpackages.md
@@ -31,14 +31,15 @@ modernisation).
   `annual_return`/`annual_volatility`, `drawdown`/`mdd`, `perf_*`, `roll_*`
   variants, plus one-call `summary`.
 - **`signal` / `portfolio`** — `sign`/`threshold`/`rank`/vol-target mappers +
-  `SignalPipeline`; allocation (`ERC`/`HRP`/`IVP`/`MDP`/`MVP`,
-  `rolling_allocation()`) and sizing (`kelly_fraction`/`vol_target`/
-  `transaction_cost`).
+  anti-churn `ema_smooth`/`deadband`/`min_hold` + `SignalPipeline`; allocation
+  (`ERC`/`HRP`/`IVP`/`MDP`/`MVP`, `rolling_allocation()`) and sizing
+  (`kelly_fraction`/`vol_target`/`transaction_cost`).
 - **`models`** — econometric (`ARMA`/`GARCH` family via `get_parameters`) and
   neural (`MultiLayerPerceptron`, `RollMultiLayerPerceptron`, RNN/`GRU`/`LSTM`,
   attention, `TemporalConvNet`, `Transformer`), `StackingEnsemble`; custom losses
-  under `models/loss/` (Sharpe/Sortino/Calmar/Omega/directional/hybrid); training
-  utils in `models/training.py`.
+  under `models/loss/` (Sharpe/Sortino/Calmar/Omega/directional/hybrid);
+  `ObjectiveModel` (objective-aligned training — net-of-cost, mini-batch) in
+  `models/objective.py`; training utils in `models/training.py`.
 - **`backtest` / `plot` / `strategy`** — `backtest()` + `BacktestResult` +
   `ProportionalCost`; `tearsheet`/`tearsheet_text`; `Strategy` +
   `run_walk_forward`. (The legacy live-viz objects `PlotBackTest`/

--- a/doc/dev/05-testing.md
+++ b/doc/dev/05-testing.md
@@ -4,7 +4,7 @@
 
 | Layer | Command | Catches |
 |-------|---------|---------|
-| **Unit** | `pytest` | logic, shapes, regressions (501 tests under `fynance/tests/`) |
+| **Unit** | `pytest` | logic, shapes, regressions (518 tests under `fynance/tests/`) |
 | **Doctests** | `pytest --doctest-modules` (on by default in `pyproject.toml`) | every docstring `>>>` example — they are part of the suite |
 | **Benchmarks** | `pytest-benchmark` (e.g. `test_filters_benchmark.py`) | perf regressions on hot paths |
 | **Coverage** | `pytest --cov=fynance --cov-report=term-missing` | untested branches |

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -27,16 +27,26 @@ so an agent doesn't re-investigate settled ground or assume a known stub is a bu
   hybrid) in `models/loss/`; robust-training utils (purged CV, early stopping,
   sample weighting) in `models/training.py`. All NN models conform to
   `SignalModel` (`fit`/`predict`).
+- **Objective-aligned training** (`models/objective.py`): `ObjectiveModel` trains
+  any `nn.Module` (MLP by default) **directly on a differentiable financial
+  objective** (`SharpeLoss`/`SortinoLoss`/…) — the net outputs positions, the loss
+  is computed on `positions * returns`. **Net-of-cost** (`cost=` penalizes
+  turnover so the net learns to *hold*) and **mini-batch** (`batch_size`/`shuffle`,
+  contiguous chunks — what makes it converge on long minute-resolution series).
+  Plugs into the harness via the `X` path with `signal=identity`, `y=returns`.
 - **Signal / Portfolio**: `signal/` mappers (`sign`/`threshold`/`rank`/
-  vol-targeting + `SignalPipeline`); `portfolio/` allocation (ERC/HRP/IVP/MDP/MVP)
-  + sizing (fractional Kelly, vol-targeting, transaction costs).
+  vol-targeting + **anti-churn** `ema_smooth`/`deadband`/`min_hold` +
+  `SignalPipeline`); `portfolio/` allocation (ERC/HRP/IVP/MDP/MVP) + sizing
+  (fractional Kelly, vol-targeting, transaction costs).
 - **Backtest / Plot**: vectorized `backtest()` engine → `BacktestResult`,
   `ProportionalCost`; reporting via `fynance.plot` (`tearsheet`, composable
   figures, lazy matplotlib so `import fynance` stays matplotlib-free).
 - **Research harness** (`fynance.research`, S1–S3 complete): `Experiment`
   (serializable spec + code + seed + metrics + curves), `run_experiment` (seeded,
-  cost-aware, walk-forward; no-lookahead probe), `write_report` (portable markdown +
-  tearsheet PNG + notebook), `gbm`/`regime_switching` synthetic generators,
+  cost-aware, walk-forward; no-lookahead probe; records a **provenance** block —
+  data/features/model/run config — into the spec), `write_report` (portable
+  markdown with a Provenance table + tearsheet PNG + notebook),
+  `gbm`/`regime_switching` synthetic generators,
   **guardrails** (`permutation_test`, `probabilistic_sharpe_ratio`,
   `deflated_sharpe_ratio`), comparison report (`compare_report`/`leaderboard`) and a
   persistent `Ledger` (append/load/leaderboard, `n_trials`, deflated-Sharpe vs
@@ -50,23 +60,26 @@ so an agent doesn't re-investigate settled ground or assume a known stub is a bu
 - **Numerical kernels on Numba `@njit`** — no Cython anywhere; the build is
   pure-Python (no `setup.py`, no compile step). Every kernel has a golden-value
   parity test (1e-9/1e-10) captured from the former Cython.
-- **Quality gates (all 4 enforced in CI)**: 501 unit tests + doctests on every
-  module (`--doctest-modules`), incl. property tests (kernel parity + no-lookahead);
+- **Quality gates (all 4 enforced in CI)**: 593 tests collected (unit + doctests
+  on every module via `--doctest-modules`), incl. property tests (kernel parity + no-lookahead);
   `ruff`; `interrogate` (docstring coverage ≥ 80%, currently ~93.6%); Sphinx
   build `-W`; **`mypy` clean (0 errors)**.
-- **Released**: `v2.1.1` on `master` + PyPI; `Production/Stable`. CI matrix
+- **Released**: `v2.8.0` on `master` + PyPI; `Production/Stable`. CI matrix
   3.10–3.13; release builds a pure-Python universal wheel + sdist and creates the
   GitHub Release from the CHANGELOG on tag.
 
 ## In progress / active surface
 
-- **R&D** (`models/`): empirical comparison of losses / architectures / feature
-  normalization on real out-of-sample data, market-regime conditioning, and
-  multi-series OHLCV indicators — see the roadmap (§1). Most items are blocked on
-  having a real dataset / orchestration rather than on missing code.
-- **Research harness** (roadmap §2): S1–S3 shipped (above). Optional next: a
-  Streamlit explorer over the ledger; real-data adapters + result storage live in
-  the separate private research repo, not here.
+Nothing is currently in flight (`develop` is clean). The 2.x library is
+feature-complete for its current scope; remaining open work is **library bricks**
+only — multi-series OHLCV indicators, regime-conditioned architecture, adaptive
+windows, a richer backtest, and an optional Streamlit ledger explorer. See the
+roadmap (§1–§2) and the **Deferred** section below.
+
+**Out of scope here**: strategy research on **real data** (empirical loss /
+architecture / normalization benchmarks, out-of-sample Sharpe, online regimes,
+feature selection) lives in the separate **private repo** `fynance-research`,
+which depends on fynance. This public repo stays data-agnostic and result-free.
 
 ## Known gaps / sharp edges (by design or deferred)
 
@@ -101,6 +114,20 @@ Larger axes parked for later: realistic backtesting beyond proportional cost
 (non-linear slippage / market impact), market-regime conditioning of the
 architecture, adaptive windows, and multi-series OHLCV indicators (ATR/ADX/OBV/
 VWAP) requiring a multi-series input API. Tracked in the roadmap; not bugs.
+
+## 2026-06-21 — research line shipped (v2.2 → v2.8); roadmap re-scoped
+
+Since 2.1.1 the **R&D enablement line** shipped end-to-end: the `fynance.research`
+harness (S1–S3 — `Experiment`/`run_experiment`/`write_report`, synthetic
+generators, permutation / deflated-Sharpe guardrails, `Ledger`/leaderboard,
+multi-input `X`/`y`, causal `RegimeDetector`, self-describing provenance) and the
+**objective-aligned training brick** `ObjectiveModel` (v2.5 differentiable
+objective → v2.7 net-of-cost turnover penalty + anti-churn signal mappers → v2.8
+mini-batch training that makes it converge on long series). The roadmap was
+**re-scoped**: strategy research on real data moves to the private
+`fynance-research` repo; the public roadmap keeps only data-agnostic library
+bricks (multi-series OHLCV indicators, regime-conditioned architecture, adaptive
+windows, realistic backtest, Streamlit explorer). Latest release **v2.8.0**.
 
 ## 2026-06-16 — fynance 2.1.x shipped; post-release audit clean
 

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -12,109 +12,61 @@ shipped, `03-decisions.md` for *why*. Keep it short and true.
 > Loop : `/pick-task` → `/plan` (arbre dans `plans/`) → `/execute-leaf` →
 > `/finish-task`. Release : `/release` quand `[Unreleased]` est suffisamment rempli.
 
-> **fynance 2.0 + 2.1 livrés** (v2.1.1 sur `master`/PyPI). Le refactor en couches,
-> le port Cython→Numba (build pure-Python) et la passe perf sont terminés — voir
-> `CHANGELOG.md` / `03-decisions.md`. Reste l'axe R&D ci-dessous, majoritairement
-> bloqué sur la disponibilité de données réelles plutôt que sur du code manquant.
+> **fynance 2.x livré** (v2.8.0 sur `master`/PyPI). Le refactor en couches, le port
+> Cython→Numba (build pure-Python), le harnais R&D `fynance.research` (S1–S3) et la
+> brique d'entraînement aligné-objectif (`ObjectiveModel` : objectif différentiable,
+> net de coûts, mini-batch) sont **terminés** — voir `CHANGELOG.md` / `03-decisions.md`.
+> Reste, ci-dessous, des **bricks de librairie** non bloquées par la donnée.
+
+> ⚠️ **Hors scope ici** : la recherche de stratégie sur **vraie data** (benchmarks
+> empiriques loss / architecture / normalisation, évaluation Sharpe out-of-sample,
+> régimes en ligne, sélection de features) vit dans le **repo privé**
+> `fynance-research` qui dépend de fynance. La roadmap publique ne tient que du
+> code de librairie réutilisable, data-agnostique.
 
 ---
 
-## 3. Entraînement aligné-objectif (`ObjectiveModel`)  ⭐ active
+## 2. Research harness — extension optionnelle
 
-Brique **générique** fynance débloquant la stratégie B (repo privé) : entraîner un
-réseau directement sur un **objectif risque-ajusté** (`SharpeLoss`/`SortinoLoss`…)
-plutôt qu'en MSE sur une cible. Le réseau sort des **positions** ; la loss porte sur
-`positions × returns`. Se branche sur le harnais I1 (`X`=features, `y`=returns,
-`signal=identity`).
-
-- [ ] **OBJ** `ObjectiveModel` — un `SignalModel` (`fit(X, returns)`/`predict→positions`)
-  qui entraîne un `nn.Module` quelconque (MLP par défaut, tête linéaire ;
-  TCN/LSTM passables) sur une loss financière différentiable. Reproductible (seed),
-  testé sur data synthétique à edge connu (apprend des positions à Sharpe > 0).
-
-> Les stratégies (B objectif-aligné, A multi-venue) vivent dans le repo privé.
-
-## 2. Research harness — extensions optionnelles
-
-Le harnais R&D `fynance.research` est **livré** (S1–S3) : `Experiment`,
+Le harnais `fynance.research` est **livré** (S1–S3) : `Experiment`,
 `run_experiment`, `write_report`, générateurs synthétiques, garde-fous
-(`permutation_test`, `deflated_sharpe_ratio`) et `Ledger`/`leaderboard` — piloté
-par la skill `/run-strategy`. Voir `CHANGELOG.md`. Data-agnostique et sans
-stockage de résultats (tout vers un `output_dir`). Restent optionnels :
+(`permutation_test`, `deflated_sharpe_ratio`), `Ledger`/`leaderboard`, multi-input
+`X`/`y` et provenance auto-descriptive. Reste optionnel :
 
-- [ ] Explorateur **Streamlit** au-dessus du ledger (parcourir/filtrer/comparer les
-  runs persistés) — interactif, plus tardif.
-- [ ] (**hors fynance**) adaptateurs de vraie data (dccd…) + stockage des
-  résultats : dans le **repo privé** de recherche qui dépend de fynance.
+- [ ] Explorateur **Streamlit** au-dessus du Ledger (parcourir / filtrer / comparer
+  les runs persistés) — interactif, plus tardif.
 
-## 1. R&D — Loss, architecture, données
+## 1. Bricks library (non bloquées par la donnée)
 
-Objectif : identifier empiriquement la meilleure combinaison loss / architecture / features
-pour les séries temporelles financières. Chaque sous-tâche est exploratoire :
-elle peut déboucher sur du code dans `fynance/models/` ou rester à l'état de
-notebook/rapport.
+Travail de librairie pur, testable sur data synthétique. Exploratoire : peut
+déboucher sur du code dans `fynance/` ou rester à l'état de rapport.
 
-### 1.1 Nouvelles loss functions
+### 1.1 Indicateurs OHLCV multi-séries
 
-Fait (PR #88) : `CalmarLoss`, `OmegaLoss`, `HybridLoss` (α fixe ou learnable).
+Single-série & causaux déjà présents : EMA/MACD/RSI/Bollinger/CCI/HMA, `roc`,
+`realized_volatility`, `rolling_skewness`/`kurtosis`/`autocorr`. Manquent les
+indicateurs exigeant plusieurs séries :
 
-- [ ] 🟡 **Benchmark empirique** : comparer les loss sur un jeu de données réel
-  (out-of-sample Sharpe/Sortino/Calmar/accuracy/drawdown) — nécessite des données.
-
-### 1.2 Architecture : ensemble direction + magnitude avec meta-modèle
-
-Fait (PR #93) : `StackingEnsemble` — bases direction/magnitude + méta-modèle
-entraîné sur les prédictions **out-of-fold** (leak-free).
-
-- [ ] 🟡 Comparer empiriquement vs modèle unique `SharpeLoss` (besoin de données).
-
-### 1.3 Régimes de marché
-
-Fait (PR #92) : `detect_regimes` (k-means in-sample sur vol/return, labels
-ordonnés par vol). Reste 🟡 (besoin de données / orchestration) :
-
-- [ ] Conditionner l'architecture (mixture-of-experts / embedding de régime).
-- [ ] Assignation online causale + évaluer l'impact sur le Sharpe out-of-sample.
-
-### 1.4 Features / indicateurs techniques
-
-Fait (single-série, causaux) : `roc`, `realized_volatility`, `rolling_skewness`,
-`rolling_kurtosis`, `rolling_autocorr` (PR #86) ; déjà présents : EMA/MACD/RSI/
-Bollinger/CCI/HMA. Reste **différé** (nécessite une API multi-séries OHLCV) :
-
-- [ ] **ATR / ADX / Williams %R** (High/Low) et **OBV / VWAP** (Volume) — exigent
-  des entrées OHLCV ; concevoir une API multi-séries d'abord.
+- [ ] Concevoir une **API multi-séries OHLCV** d'abord, puis **ATR / ADX /
+  Williams %R** (High/Low) et **OBV / VWAP** (Volume).
 - [ ] **GARCH(1,1) comme feature** (via `fynance.estimator`).
 
-### 1.5 Normalisation des features
+### 1.2 Architecture conditionnée par le régime
 
-Couvert : rolling z-score (`roll_standardize`/`roll_z_score`), vol-targeting
-(`sizing.vol_target`), rank-based (`scale.roll_rank`, PR #89).
+`RegimeDetector` causal (fit-on-train / assign-online) est déjà livré ; reste à
+s'en servir pour piloter l'architecture :
 
-- [ ] 🟡 Comparer empiriquement les trois approches sur le Sharpe out-of-sample
-  (nécessite des données).
+- [ ] Conditionner le modèle sur le régime — **mixture-of-experts** /
+  embedding de régime.
 
-### 1.6 Protocole d'entraînement robuste
+### 1.3 Fenêtres adaptatives (dépend de §1.2)
 
-Fait (PR #90) : purged walk-forward CV (`cross_validate(..., purge=)`),
-`exp_sample_weights` (décroissance exponentielle), `EarlyStopping` (sur métrique).
-La construction causale des features reste garantie par les property tests
-(parité + non-lookahead) — convention continue, pas de code dédié.
+- [ ] `window` variable selon le régime de volatilité.
 
-- [ ] (optionnel) down-weight basse vol dans `exp_sample_weights` (variante).
+### 1.4 Backtest réaliste
 
-### 1.7 R&D rolling — features multi-résolution et efficacité
-
-Fait (PR #91) : `multi_resolution`, `granger_causality`, `IncrementalMoments`
-(Welford O(1)) dans `features/engineering.py`.
-
-- [ ] **Fenêtres adaptatives** : `window` variable selon le régime de vol
-  (dépend de §1.3 détection de régime).
-
-### 1.8 Backtest réaliste
-
-Fait (PR #87) : `portfolio/sizing.py` (`kelly_fraction`, causal `vol_target`,
+Fait : `portfolio/sizing.py` (`kelly_fraction`, causal `vol_target`,
 `transaction_cost` turnover-based) ; métriques `percent_positive`, `tail_ratio`.
 Reste optionnel :
 
-- [ ] Slippage / impact de marché non-linéaire au-delà du coût proportionnel.
+- [ ] **Slippage / impact de marché non-linéaire** au-delà du coût proportionnel.


### PR DESCRIPTION
## Why

The agent-facing dev docs (`doc/dev/`) had drifted: `06-status` / `01-overview` / `05-testing` still claimed **v2.1.1** and **501 tests**, and the roadmap listed the **OBJ / ObjectiveModel** epic as active — all shipped through **v2.8.0**.

## What

**Drift fixed**
- Version **v2.1.1 → v2.8.0**; test count **501 → 518 unit / 593 collected** (`01-overview`, `05-testing`, `06-status`).
- Surfaced the shipped research line: **`ObjectiveModel`** (objective-aligned, net-of-cost, mini-batch), **anti-churn signal mappers** (`ema_smooth`/`deadband`/`min_hold`), and harness **provenance** — in `06-status`, `04-subpackages`, `02-architecture`.
- New dated snapshot in `06-status` summarising the v2.2→v2.8 line.

**Roadmap re-scoped**
- Dropped the shipped **OBJ** epic.
- **Real-data strategy research** (empirical loss/architecture/normalisation benchmarks, OOS Sharpe, online regimes) moved out to the private `fynance-research` repo, with an explicit "out of scope here" note.
- Public roadmap now keeps only data-agnostic **library bricks**: multi-series OHLCV indicators (ATR/ADX/OBV/VWAP) + GARCH-as-feature, regime-conditioned architecture (MoE), adaptive windows, non-linear slippage, Streamlit ledger explorer.

`03-decisions.md` was already current — untouched. Remaining `v2.1.0` / `501` references are dated historical entries, left as-is.

Docs-only; `ruff` green, no code touched.