### PR TITLE
feat: add MarketImpactCost non-linear market-impact cost model

### DIFF
--- a/doc/source/backtest.rst
+++ b/doc/source/backtest.rst
@@ -13,5 +13,6 @@ Vectorized backtesting engine and result. Plotting/reporting lives in
    backtest
    BacktestResult
    ProportionalCost
+   MarketImpactCost
    set_text_stats
    BacktestNeuralNet

--- a/fynance/backtest/cost.py
+++ b/fynance/backtest/cost.py
@@ -3,9 +3,10 @@
 
 """ Transaction cost models for the vectorized backtest engine.
 
-Concretizes the :class:`~fynance.core.protocols.CostModel` seam. Only the
-proportional (turnover-based) model ships in 2.0; non-linear slippage is a
-documented extension point.
+Concretizes the :class:`~fynance.core.protocols.CostModel` seam. Two models
+ship: :class:`ProportionalCost` (linear, turnover-based) and
+:class:`MarketImpactCost` (adds a convex, super-linear market-impact term — the
+square-root impact law).
 
 """
 
@@ -18,7 +19,7 @@ from numpy.typing import NDArray
 # Local packages
 from fynance.portfolio.sizing import transaction_cost
 
-__all__ = ['ProportionalCost']
+__all__ = ['ProportionalCost', 'MarketImpactCost']
 
 
 class ProportionalCost:
@@ -59,3 +60,63 @@ class ProportionalCost:
             return np.zeros(w.shape[0], dtype=np.float64)
 
         return transaction_cost(weights, fee=rate)
+
+
+class MarketImpactCost:
+    """ Non-linear market-impact cost: linear fee + convex impact term.
+
+    Charges, per step, a proportional fee plus a **super-linear** market-impact
+    term on the same turnover (the standard square-root impact law, where the
+    cost grows faster than the trade size):
+
+    .. math::
+
+        c_t = fee \\cdot \\tau_t + impact \\cdot \\tau_t^{\\,exponent}
+
+    where the turnover :math:`\\tau_t = \\sum_i |w_{t,i} - w_{t-1,i}|` is defined
+    exactly as in :class:`ProportionalCost` (the first step charges the initial
+    position). With ``exponent=1`` and ``impact=0`` it reduces to
+    :class:`ProportionalCost`. Conforms to
+    :class:`~fynance.core.protocols.CostModel`.
+
+    Parameters
+    ----------
+    fee : float
+        Proportional (linear) fee per unit traded (e.g. ``0.001`` = 10 bps).
+    impact : float
+        Coefficient of the convex impact term, in the same units as ``fee``.
+    exponent : float
+        Convexity exponent of the impact term (``> 1`` is super-linear).
+        Default ``1.5`` (the square-root impact law: cost per unit traded grows
+        as :math:`\\sqrt{\\tau}`).
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> cost = MarketImpactCost(fee=0.0, impact=0.1, exponent=2.0)
+    >>> cost(np.array([[1.0, 0.0], [0.0, 1.0], [0.0, 1.0]]))
+    array([0.1, 0.4, 0. ])
+
+    """
+
+    def __init__(
+        self,
+        fee: float = 0.0,
+        impact: float = 0.0,
+        exponent: float = 1.5,
+    ):
+        """ Store the cost rates and the impact convexity exponent. """
+        if exponent <= 0:
+
+            raise ValueError(f"exponent must be positive, got {exponent}")
+
+        self.fee = fee
+        self.impact = impact
+        self.exponent = exponent
+
+    def __call__(self, weights: NDArray) -> NDArray[np.float64]:
+        """ Return the per-step (linear + convex impact) cost of a weight book. """
+        # transaction_cost with unit fee returns the raw per-step turnover.
+        turnover = transaction_cost(weights, fee=1.0)
+
+        return self.fee * turnover + self.impact * turnover ** self.exponent

--- a/fynance/tests/backtest/test_cost.py
+++ b/fynance/tests/backtest/test_cost.py
@@ -5,11 +5,13 @@
 
 # Third-party packages
 import numpy as np
+import pytest
 
-from fynance.backtest.cost import ProportionalCost
-from fynance.core import CostModel
+from fynance.backtest.cost import MarketImpactCost, ProportionalCost
 
 # Local packages
+from fynance.backtest.engine import backtest
+from fynance.core import CostModel
 from fynance.portfolio.sizing import transaction_cost
 
 
@@ -34,3 +36,65 @@ def test_parity_with_transaction_cost():
 
 def test_conforms_to_protocol():
     assert isinstance(ProportionalCost(), CostModel)
+
+
+# -- MarketImpactCost -----------------------------------------------------
+
+
+def test_impact_conforms_to_protocol():
+    assert isinstance(MarketImpactCost(), CostModel)
+
+
+def test_impact_linear_limit_equals_proportional():
+    # exponent=1, impact=0 reduces to ProportionalCost(fee)
+    w = np.array([[1.0, 0.0], [0.5, 0.5], [0.0, 1.0]])
+    lin = MarketImpactCost(fee=0.003, impact=0.0, exponent=1.0)
+    prop = ProportionalCost(fee=0.003)
+    assert np.allclose(lin(w), prop(w), atol=1e-12)
+
+
+def test_impact_convex_in_turnover():
+    # Doubling a single-step turnover more-than-doubles its impact cost.
+    small = np.array([[0.0], [0.25], [0.25]])   # step-1 turnover 0.25
+    big = np.array([[0.0], [0.5], [0.5]])       # step-1 turnover 0.5 (doubled)
+    cost = MarketImpactCost(fee=0.0, impact=0.1, exponent=1.5)
+    c_small = cost(small)[1]
+    c_big = cost(big)[1]
+    assert c_big > 2.0 * c_small
+
+
+def test_impact_zero_turnover_zero_cost():
+    w = np.array([[0.5, 0.5], [0.5, 0.5], [0.5, 0.5]])
+    cost = MarketImpactCost(fee=0.01, impact=0.1)
+    # only the initial position is charged; steps 2-3 have zero turnover
+    assert np.allclose(cost(w)[1:], [0.0, 0.0])
+
+
+def test_impact_shape_and_first_step_charged():
+    w = np.array([[1.0, 0.0], [0.0, 1.0], [0.0, 1.0]])
+    cost = MarketImpactCost(fee=0.001, impact=0.05)
+    out = cost(w)
+    assert out.shape == (3,)
+    assert out[0] > 0.0   # initial position charged like ProportionalCost
+
+
+def test_impact_bad_exponent_raises():
+    with pytest.raises(ValueError, match="exponent"):
+        MarketImpactCost(exponent=0.0)
+
+
+def test_impact_lowers_net_equity_in_backtest():
+    rng = np.random.default_rng(0)
+    T = 300
+    returns = rng.standard_normal((T, 3)) * 0.01
+    pos = rng.standard_normal((T, 3))
+    pos = pos / np.abs(pos).sum(axis=1, keepdims=True)   # normalized weights
+
+    base = backtest(returns, pos, cost=ProportionalCost(fee=0.001))
+    impacted = backtest(
+        returns, pos, cost=MarketImpactCost(fee=0.001, impact=0.05),
+    )
+    # impact adds a strictly positive convex term -> higher total cost,
+    # lower final equity.
+    assert impacted.costs.sum() > base.costs.sum()
+    assert impacted.equity[-1] < base.equity[-1]


### PR DESCRIPTION
## Why

Roadmap §1.4 (realistic backtest): the engine only had a linear `ProportionalCost`. Real execution cost is **convex** in trade size — large trades move the market against you super-linearly.

## What

`fynance.backtest.MarketImpactCost`, conforming to the `CostModel` protocol:

```
c_t = fee * turnover_t + impact * turnover_t ** exponent
```

- `exponent` default **1.5** (the square-root impact law: cost per unit traded grows as √turnover).
- Turnover defined exactly as in `ProportionalCost` (reuses `transaction_cost`), first step charges the initial position.
- `exponent=1, impact=0` reduces **exactly** to `ProportionalCost(fee)` (tested to 1e-12).
- Added to the `backtest` Sphinx page (exported via `fynance.backtest`).

## Tests / gates

- 7 new tests: protocol conformance, linear-limit equality, convexity (doubling turnover more-than-doubles impact), zero-turnover→zero-cost, first-step charge, bad-exponent guard, and an end-to-end `backtest()` check (impact lowers net equity vs proportional).
- Full suite **600 passed / 1 skipped**; `ruff` clean; `interrogate` 100% on `cost.py`; `mypy` clean; Sphinx `-W` builds.

Part of the roadmap §1 "library bricks" epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)