### PR TITLE
feat: add causal GARCH(1,1) conditional-volatility feature

### DIFF
--- a/doc/source/features.garch.rst
+++ b/doc/source/features.garch.rst
@@ -1,0 +1,22 @@
+*****************
+GARCH volatility
+*****************
+
+Conditional volatility as a **causal** feature, from a GARCH(1,1) fit. The
+parameters are estimated by maximum likelihood on a training prefix (optionally
+refit on the expanding window every ``refit`` steps), then the conditional
+volatility :math:`\sigma_t` is forward-filtered over the whole series — which is
+causal because :math:`\sigma_t` is :math:`\mathcal F_{t-1}`-measurable. The first
+``min_train`` values (the in-sample warmup) are returned as ``NaN``.
+
+The single authoritative ARMA/GARCH implementation lives in
+:mod:`fynance.models.econometric_models` (the Numba recursion) and
+:mod:`fynance.estimator` (the likelihood); this feature only wires the thin
+fit + forward-filter on top.
+
+.. currentmodule:: fynance.features.garch
+
+.. autosummary::
+   :toctree: generated/
+
+   garch_volatility

--- a/doc/source/features.rst
+++ b/doc/source/features.rst
@@ -55,6 +55,12 @@ moving standard deviations and rolling functions.
 
       Unsupervised regime labelling by clustering volatility/return features.
 
+   .. grid-item-card:: :octicon:`graph;1.2em;sd-mr-1` GARCH volatility
+      :link: features.garch
+      :link-type: doc
+
+      Causal GARCH(1,1) conditional volatility as a feature.
+
    .. grid-item-card:: :octicon:`arrow-switch;1.2em;sd-mr-1` Scale
       :link: features.scale
       :link-type: doc
@@ -94,5 +100,6 @@ Common parameters across modules:
    features.stats
    features.momentums
    features.regime
+   features.garch
    features.roll_functions
    features.scale

--- a/fynance/features/__init__.py
+++ b/fynance/features/__init__.py
@@ -28,6 +28,7 @@ features.
 from . import (
     engineering,
     filters,
+    garch,
     indicators,
     momentums,
     money_management,
@@ -38,6 +39,7 @@ from . import (
 )
 from .engineering import *
 from .filters import *
+from .garch import *
 from .indicators import *
 from .momentums import *
 from .money_management import *
@@ -49,6 +51,7 @@ from .stats import *
 __all__ = engineering.__all__
 __all__ += regime.__all__
 __all__ += filters.__all__
+__all__ += garch.__all__
 __all__ += momentums.__all__
 __all__ += indicators.__all__
 __all__ += money_management.__all__

--- a/fynance/features/garch.py
+++ b/fynance/features/garch.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" GARCH(1,1) conditional volatility as a causal feature.
+
+Exposes :func:`garch_volatility` — a strictly **causal** conditional-volatility
+series derived from a GARCH(1,1) fit. The single authoritative ARMA/GARCH
+implementation lives in :mod:`fynance.models.econometric_models` (the Numba
+recursion) and :mod:`fynance.estimator` (the likelihood); this module only adds
+the thin maximum-likelihood fit + forward-filter scheme, it does **not**
+re-derive the recursion or the parameter layout.
+
+Causality
+---------
+Two things could leak the future into the feature:
+
+- the **parameters** — fit once on a training prefix (expanding-fit), optionally
+  refit on the expanding window every ``refit`` steps; never on the whole series;
+- the **filtered volatility** — :math:`\\sigma_t` in GARCH is
+  :math:`\\mathcal F_{t-1}`-measurable (it depends on
+  :math:`u_{t-1}, \\sigma_{t-1}`, not on :math:`u_t`), so running the recursion
+  forward is causal given fixed parameters.
+
+The first ``min_train`` points (the warmup whose parameters would be in-sample)
+are returned as ``NaN``.
+
+"""
+
+from __future__ import annotations
+
+# Third-party packages
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+from scipy.optimize import minimize
+
+# Local packages
+from fynance.estimator.estimator import target_function
+from fynance.models.econometric_models import ARMA_GARCH, get_parameters
+
+__all__ = ['garch_volatility']
+
+# GARCH(1,1) model order: zero-mean-constant ARMA part, GARCH(1, 1) variance.
+_P, _Q, _AR, _MA = 1, 1, 0, 0
+
+
+def _fit_garch11(y: NDArray[np.float64]) -> NDArray[np.float64]:
+    """ Maximum-likelihood fit of a GARCH(1,1) on ``y``.
+
+    Minimizes the negative log-likelihood (:func:`fynance.estimator.estimator.\
+target_function`) over the flat parameter vector ``[c, omega, alpha, beta]``,
+    under positivity and stationarity (``alpha + beta < 1``) constraints.
+
+    Returns
+    -------
+    numpy.ndarray
+        The fitted ``[c, omega, alpha, beta]`` vector.
+
+    """
+    var = float(np.var(y))
+
+    if var <= 0.0:
+        var = 1e-8
+
+    x0 = np.array([float(np.mean(y)), var * 0.1, 0.05, 0.90])
+    bounds = [(None, None), (1e-12, None), (0.0, 1.0), (0.0, 1.0)]
+    # Stationarity: alpha + beta <= 1 - eps.
+    constraints = ({
+        'type': 'ineq',
+        'fun': lambda p: 0.999 - p[2] - p[3],
+    },)
+
+    res = minimize(
+        target_function,
+        x0,
+        args=(y, _AR, _MA, _Q, _P, True, 'garch'),
+        method='SLSQP',
+        bounds=bounds,
+        constraints=constraints,
+        options={'maxiter': 200, 'ftol': 1e-8},
+    )
+
+    return np.asarray(res.x, dtype=np.float64)
+
+
+def _filter_sigma(
+    y: NDArray[np.float64], params: NDArray[np.float64],
+) -> NDArray[np.float64]:
+    """ Forward-filter the conditional volatility on ``y`` with ``params``. """
+    phi, theta, alpha, beta, c, omega = get_parameters(
+        params, _AR, _MA, _Q, _P, cons=True,
+    )
+    _, h = ARMA_GARCH(
+        y, phi, theta, alpha, beta, c, omega, _AR, _MA, _Q, _P,
+    )
+
+    return np.asarray(h, dtype=np.float64)
+
+
+def garch_volatility(
+    returns: ArrayLike,
+    refit: int | None = None,
+    min_train: int = 250,
+) -> NDArray[np.float64]:
+    r""" Causal GARCH(1,1) conditional-volatility feature.
+
+    Fits a GARCH(1,1) on a training prefix and forward-filters the conditional
+    volatility :math:`\sigma_t` over the whole series. The first ``min_train``
+    values are ``NaN`` (the warmup whose parameters would be in-sample).
+
+    Parameters
+    ----------
+    returns : array-like
+        One-dimensional return series.
+    refit : int, optional
+        Refit the parameters on the expanding window every ``refit`` steps
+        (each block uses parameters fit strictly on its own past). If ``None``
+        (default), the parameters are fit once on ``returns[:min_train]``.
+    min_train : int, optional
+        Length of the initial training prefix; values before it are ``NaN``.
+        Default 250.
+
+    Returns
+    -------
+    numpy.ndarray
+        Conditional volatility :math:`\sigma_t`, same length as ``returns``,
+        ``NaN`` on the warmup.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> rng = np.random.default_rng(0)
+    >>> r = rng.standard_normal(400) * 0.01
+    >>> sigma = garch_volatility(r, min_train=200)
+    >>> sigma.shape
+    (400,)
+    >>> bool(np.all(np.isnan(sigma[:200])))
+    True
+    >>> bool(np.all(sigma[200:] >= 0))
+    True
+
+    """
+    r = np.asarray(returns, dtype=np.float64).reshape(-1)
+    n = r.size
+
+    if min_train < 2 or min_train >= n:
+
+        raise ValueError(
+            f"min_train must be in [2, len(returns)), got {min_train}"
+        )
+
+    sigma = np.full(n, np.nan, dtype=np.float64)
+
+    # Block starts: where each parameter regime takes effect.
+    if refit is None or refit <= 0:
+        starts = [min_train]
+
+    else:
+        starts = list(range(min_train, n, refit))
+
+    bounds = starts + [n]
+    for k, start in enumerate(starts):
+        end = bounds[k + 1]
+        params = _fit_garch11(r[:start])
+        # sigma_t depends on the past only, so filtering the full series with
+        # these (past-fit) params and slicing [start:end] stays causal.
+        h = _filter_sigma(r, params)
+        sigma[start:end] = h[start:end]
+
+    return sigma

--- a/fynance/tests/features/test_garch.py
+++ b/fynance/tests/features/test_garch.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for the causal GARCH(1,1) volatility feature. """
+
+# Third-party packages
+import numpy as np
+import pytest
+
+# Local packages
+from fynance.features import garch_volatility
+
+
+def _simulate_garch(T=1500, omega=1e-6, alpha=0.08, beta=0.9, seed=0):
+    """ Simulate a GARCH(1,1) return path; return (returns, true_sigma). """
+    rng = np.random.default_rng(seed)
+    eps = rng.standard_normal(T)
+    r = np.zeros(T)
+    s2 = np.zeros(T)
+    s2[0] = omega / (1.0 - alpha - beta)
+
+    for t in range(1, T):
+        s2[t] = omega + alpha * r[t - 1] ** 2 + beta * s2[t - 1]
+        r[t] = np.sqrt(s2[t]) * eps[t]
+
+    return r, np.sqrt(s2)
+
+
+def test_shape_warmup_and_nonnegative():
+    r, _ = _simulate_garch()
+    sigma = garch_volatility(r, min_train=500)
+    assert sigma.shape == r.shape
+    assert np.all(np.isnan(sigma[:500]))
+    valid = sigma[500:]
+    assert np.all(valid >= 0.0)
+    assert not np.any(np.isnan(valid))
+
+
+def test_recovers_latent_volatility():
+    r, true_sigma = _simulate_garch()
+    sigma = garch_volatility(r, min_train=500)
+    mask = ~np.isnan(sigma)
+    corr = np.corrcoef(sigma[mask], true_sigma[mask])[0, 1]
+    assert corr > 0.8
+
+
+def test_no_lookahead_bitwise():
+    r, _ = _simulate_garch()
+    t = 900
+    truncated = garch_volatility(r[:t], min_train=500)[-1]
+    extended = garch_volatility(r[:t + 50], min_train=500)[t - 1]
+    assert truncated == extended
+
+
+def test_refit_is_causal_and_changes_results():
+    r, _ = _simulate_garch()
+    once = garch_volatility(r, min_train=500)
+    refit = garch_volatility(r, min_train=500, refit=200)
+    # refit produces a (generally) different series ...
+    assert not np.allclose(once[500:], refit[500:])
+    # ... but stays causal: a value is unchanged when the series is extended,
+    # as long as the truncation lands on a refit checkpoint (500 + k*200).
+    t = 900   # = 500 + 2 * 200
+    a = garch_volatility(r[:t], min_train=500, refit=200)[-1]
+    b = garch_volatility(r[:t + 50], min_train=500, refit=200)[t - 1]
+    assert a == b
+
+
+def test_bad_min_train_raises():
+    r, _ = _simulate_garch(T=100)
+    with pytest.raises(ValueError, match="min_train"):
+        garch_volatility(r, min_train=100)
+    with pytest.raises(ValueError, match="min_train"):
+        garch_volatility(r, min_train=1)


### PR DESCRIPTION
## Why

Roadmap §1.1 (library bricks): a GARCH(1,1) conditional-volatility column is a classic, information-rich feature. The challenge is making it **causal** (no future leaking through the fitted parameters or the filter).

## What

`fynance.features.garch_volatility(returns, refit=None, min_train=250)`:

- **Expanding-fit** the GARCH(1,1) parameters by maximum likelihood on a training prefix; optionally **refit** on the expanding window every `refit` steps (each block uses parameters fit strictly on its own past).
- **Forward-filter** the conditional volatility σ_t over the whole series — causal because σ_t is 𝓕ₜ₋₁-measurable (depends on uₜ₋₁, σₜ₋₁, not uₜ).
- The first `min_train` values (the in-sample warmup) are `NaN`.
- **Single implementation**: reuses the authoritative ARMA/GARCH recursion (`models.econometric_models`) and likelihood (`estimator`) — no duplicated parameter logic (per the estimator policy). The MLE fit is a thin scipy `SLSQP` wrapper (positivity + stationarity α+β<1).

## Tests / gates

- On simulated GARCH(1,1): `corr(σ̂, σ_true) ≈ 0.997` (threshold 0.8).
- **No-lookahead** holds **bitwise** (truncating the series doesn't change earlier σ); refit variant is causal at checkpoints and changes results; warmup is NaN; σ ≥ 0; `min_train` guard.
- Full suite **598 passed / 1 skipped**; `ruff` clean; `interrogate` 100%; `mypy` clean; Sphinx `-W` builds (new `features.garch` page).

Part of the roadmap §1 "library bricks" epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)