### PR TITLE
feat: add RegimeMoE regime-conditioned architecture (mixture-of-experts)

### DIFF
--- a/doc/source/models.neural_network.rst
+++ b/doc/source/models.neural_network.rst
@@ -43,6 +43,17 @@ high-frequency settings (use the same value as the backtest's
 Feed it through the research harness via the ``X`` path with ``y`` = returns; see
 :doc:`research_workflow`.
 
+.. rubric:: Regime-conditioned architecture
+
+:class:`~fynance.models.regime_model.RegimeMoE` conditions an objective-aligned
+network on the **causal** market regime (:class:`~fynance.features.RegimeDetector`):
+the prediction depends on which volatility regime the market is in. ``routing="soft"``
+(default) concatenates a learned regime **embedding** to the features through a
+shared trunk; ``routing="hard"`` uses one **expert** per regime. The regime label
+is produced by a detector fit on the **training** slice only and assigned online,
+from a designated positive price/level column of ``X`` (``regime_col``). It reuses
+``ObjectiveModel`` for training, so it is a ``SignalModel`` like the above.
+
 .. rubric:: Inheritance
 
 ``BaseNeuralNet`` → ``MultiLayerPerceptron``
@@ -60,3 +71,4 @@ Feed it through the research harness via the ``X`` path with ``y`` = returns; se
    _base.BaseNeuralNet
    mlp.MultiLayerPerceptron
    objective.ObjectiveModel
+   regime_model.RegimeMoE

--- a/fynance/models/__init__.py
+++ b/fynance/models/__init__.py
@@ -56,6 +56,7 @@ from .loss import (
 from .lstm import LongShortTermMemory, LSTMCell
 from .mlp import MultiLayerPerceptron
 from .objective import ObjectiveModel
+from .regime_model import RegimeMoE
 from .rnn import RecurrentNeuralNetwork
 from .rolling import CVResult, RollMultiLayerPerceptron, _RollingBasis
 from .tcn import TemporalConvNet
@@ -82,6 +83,8 @@ __all__ = [
     'MultiLayerPerceptron',
     # objective-aligned training
     'ObjectiveModel',
+    # regime-conditioned architecture
+    'RegimeMoE',
     # rnn / gru / lstm
     'GRUCell',
     'GatedRecurrentUnit',

--- a/fynance/models/regime_model.py
+++ b/fynance/models/regime_model.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Regime-conditioned architecture (mixture-of-experts).
+
+:class:`RegimeMoE` conditions an objective-aligned network on the **causal**
+market regime (:class:`~fynance.features.RegimeDetector`): the network's
+prediction depends not only on the features but on which volatility regime the
+market is currently in. Two routings are available — a learned **regime
+embedding** concatenated to the features (``routing="soft"``, the differentiable
+default) and one **expert head per regime** (``routing="hard"``).
+
+It conforms to the ``SignalModel`` protocol (``fit``/``predict``) and reuses
+:class:`~fynance.models.ObjectiveModel` for the training loop (differentiable
+financial objective, mini-batching, net-of-cost penalty, seeding), so it plugs
+into the harness via the precomputed ``X`` path exactly like ``ObjectiveModel``.
+
+Causality
+---------
+The regime label is produced by a :class:`RegimeDetector` **fit on the training
+slice only** and assigned **online** (nearest training centroid), so no future
+information leaks into a label. The regime is derived from one designated column
+of ``X`` (``regime_col``), which must be a **positive price / level** series (the
+detector clusters its trailing volatility and mean return).
+
+"""
+
+# Built-in
+from __future__ import annotations
+
+from typing import Any
+
+# Third-party
+import numpy as np
+import torch
+from numpy.typing import NDArray
+
+# Local
+from fynance.features.regime import RegimeDetector
+from fynance.models.objective import ObjectiveModel
+
+__all__ = ['RegimeMoE']
+
+
+def _mlp(n_in: int, hidden: tuple[int, ...]) -> torch.nn.Module:
+    """ Feed-forward trunk with ReLU hidden layers and a linear (1-d) head. """
+    mods: list[torch.nn.Module] = []
+    dim = n_in
+    for h in hidden:
+        mods += [torch.nn.Linear(dim, h), torch.nn.ReLU()]
+        dim = h
+    mods += [torch.nn.Linear(dim, 1)]
+
+    return torch.nn.Sequential(*mods)
+
+
+class _RegimeMoENet(torch.nn.Module):
+    """ Net taking augmented input ``[features | regime_label]`` -> ``(T, 1)``.
+
+    The last input column carries the integer regime label; the rest are the
+    features. ``soft`` routing embeds the regime and concatenates it to the
+    features through a shared trunk; ``hard`` routing runs one expert MLP per
+    regime, selected per row.
+    """
+
+    def __init__(
+        self,
+        n_features: int,
+        n_regimes: int,
+        emb_dim: int,
+        hidden: tuple[int, ...],
+        routing: str,
+    ):
+        super().__init__()
+        self.n_features = n_features
+        self.routing = routing
+
+        if routing == 'soft':
+            self.emb = torch.nn.Embedding(n_regimes, emb_dim)
+            self.trunk = _mlp(n_features + emb_dim, hidden)
+
+        elif routing == 'hard':
+            self.experts = torch.nn.ModuleList(
+                [_mlp(n_features, hidden) for _ in range(n_regimes)]
+            )
+
+        else:
+
+            raise ValueError(f"unknown routing: {routing!r}")
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """ Split the regime label off the last column and route accordingly. """
+        feats = x[:, :self.n_features]
+        regime = x[:, self.n_features].long()
+
+        if self.routing == 'soft':
+            emb = self.emb(regime)
+
+            return self.trunk(torch.cat([feats, emb], dim=1))
+
+        out = torch.zeros(feats.shape[0], 1, dtype=feats.dtype)
+        for k, expert in enumerate(self.experts):
+            mask = regime == k
+
+            if bool(mask.any()):
+                out[mask] = expert(feats[mask])
+
+        return out
+
+
+class RegimeMoE:
+    """ Regime-conditioned mixture-of-experts ``SignalModel``.
+
+    Parameters
+    ----------
+    n_regimes : int
+        Number of market regimes (clusters). Default 3.
+    regime_col : int
+        Index of the column in ``X`` used as the **positive price / level**
+        series the :class:`RegimeDetector` clusters on. Default 0.
+    regime_w : int
+        Rolling window for the regime features. Default 21.
+    regime_period : int
+        Annualization factor for the regime volatility feature. Default 252.
+    routing : {"soft", "hard"}
+        ``soft`` (default) concatenates a learned regime **embedding** to the
+        features through a shared trunk (differentiable end-to-end); ``hard``
+        uses one **expert** MLP per regime, selected by the regime label.
+    emb_dim : int
+        Embedding size for ``soft`` routing (ignored for ``hard``). Default 4.
+    hidden : tuple of int
+        Hidden layer sizes of the trunk / experts. Default ``(16, 8)``.
+    loss : BaseLoss, optional
+        Differentiable financial loss (default :class:`SharpeLoss`).
+    lr, epochs, batch_size, cost, seed
+        Forwarded to :class:`~fynance.models.ObjectiveModel`.
+
+    Notes
+    -----
+    Reproducible: the net is seeded (``torch.manual_seed``) **before** it is
+    built, then handed to :class:`ObjectiveModel` (which would otherwise skip
+    seeding a caller-provided net).
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> rng = np.random.default_rng(0)
+    >>> level = 100 * np.exp(np.cumsum(rng.standard_normal(400) * 0.01))
+    >>> sig = rng.choice([-1.0, 1.0], size=400)
+    >>> X = np.column_stack([level, sig]).astype(np.float32)
+    >>> y = (sig * 0.01).astype(np.float32)
+    >>> model = RegimeMoE(n_regimes=2, regime_w=10, epochs=5).fit(X, y)
+    >>> model.predict(X).shape
+    (400, 1)
+
+    """
+
+    def __init__(
+        self,
+        n_regimes: int = 3,
+        regime_col: int = 0,
+        regime_w: int = 21,
+        regime_period: int = 252,
+        routing: str = 'soft',
+        emb_dim: int = 4,
+        hidden: tuple[int, ...] = (16, 8),
+        loss: Any = None,
+        lr: float = 1e-3,
+        epochs: int = 80,
+        batch_size: int | None = None,
+        cost: float = 0.0,
+        seed: int = 0,
+    ):
+        self.n_regimes = n_regimes
+        self.regime_col = regime_col
+        self.regime_w = regime_w
+        self.regime_period = regime_period
+        self.routing = routing
+        self.emb_dim = emb_dim
+        self.hidden = tuple(hidden)
+        self.loss = loss
+        self.lr = lr
+        self.epochs = epochs
+        self.batch_size = batch_size
+        self.cost = cost
+        self.seed = seed
+        self.detector: RegimeDetector | None = None
+        self._obj: ObjectiveModel | None = None
+
+    def _regime_series(self, X: NDArray) -> NDArray:
+        """ Extract the level column used for regime detection. """
+        return np.asarray(X, dtype=np.float64)[:, self.regime_col]
+
+    def _augment(self, X: NDArray, labels: NDArray) -> NDArray:
+        """ Append the regime label as the last column of ``X``. """
+        return np.column_stack(
+            [np.asarray(X, dtype=np.float32), labels.astype(np.float32)]
+        )
+
+    def fit(self, X: NDArray, y: NDArray) -> RegimeMoE:
+        """ Fit the causal regime detector (on train) then train the MoE net.
+
+        Parameters
+        ----------
+        X : array-like, shape (T, F)
+            Feature matrix; column ``regime_col`` is the positive price/level
+            series used for regime detection.
+        y : array-like, shape (T,)
+            Realized per-bar returns aligned with ``X``.
+
+        Returns
+        -------
+        RegimeMoE
+            ``self``.
+
+        """
+        X = np.asarray(X)
+        n_features = X.shape[1]
+
+        # Causal regime: fit the detector on the training slice only.
+        self.detector = RegimeDetector(
+            n_regimes=self.n_regimes, w=self.regime_w,
+            period=self.regime_period, seed=self.seed,
+        ).fit(self._regime_series(X))
+        labels = self.detector.predict(self._regime_series(X))
+
+        # Seed before building the net (ObjectiveModel skips seeding a given net).
+        torch.manual_seed(self.seed)
+        net = _RegimeMoENet(
+            n_features, self.n_regimes, self.emb_dim, self.hidden, self.routing,
+        )
+        self._obj = ObjectiveModel(
+            net=net, loss=self.loss, lr=self.lr, epochs=self.epochs,
+            batch_size=self.batch_size, cost=self.cost, seed=self.seed,
+        )
+        self._obj.fit(self._augment(X, labels), y)
+
+        return self
+
+    def predict(self, X: NDArray) -> NDArray:
+        """ Assign the regime online and return positions in ``[-1, 1]``. """
+        if self.detector is None or self._obj is None:
+
+            raise RuntimeError("RegimeMoE must be fit before predict")
+
+        X = np.asarray(X)
+        labels = self.detector.predict(self._regime_series(X))
+
+        return self._obj.predict(self._augment(X, labels))

--- a/fynance/tests/models/test_regime_model.py
+++ b/fynance/tests/models/test_regime_model.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Regime-conditioned architecture: RegimeMoE conditions on the causal regime. """
+
+# Third-party
+import numpy as np
+import pytest
+
+# Local
+from fynance.core import SignalModel
+from fynance.metrics import sharpe
+from fynance.models import ObjectiveModel, RegimeMoE
+
+
+def _regime_edge_data(n=2000, block=100, seed=0):
+    """ A *regime-dependent* edge: the profitable sign of feature ``s`` flips
+    between two volatility regimes, so a model must know the regime to profit.
+
+    Returns ``X = [level, s]`` (level is the positive price column the detector
+    clusters on) and the realized returns.
+    """
+    rng = np.random.default_rng(seed)
+    regime = (np.arange(n) // block) % 2          # 0,1 alternating blocks
+    vol = np.where(regime == 0, 0.004, 0.03)      # distinct vol per regime
+    level = 100 * np.exp(np.cumsum(rng.standard_normal(n) * vol))
+
+    s = rng.choice([-1.0, 1.0], size=n)
+    flip = np.where(regime == 0, 1.0, -1.0)       # edge sign flips by regime
+    returns = (flip * s * 0.01 + rng.standard_normal(n) * 0.003).astype(np.float32)
+    X = np.column_stack([level, s]).astype(np.float32)
+
+    return X, returns
+
+
+def test_conforms_to_signalmodel():
+    assert isinstance(RegimeMoE(), SignalModel)
+
+
+def test_predict_shape_and_bounds():
+    X, y = _regime_edge_data(n=400, block=50)
+    model = RegimeMoE(n_regimes=2, regime_w=10, epochs=10).fit(X, y)
+    pos = np.asarray(model.predict(X))
+    assert pos.shape == (400, 1)
+    assert np.all(np.abs(pos) <= 1.0 + 1e-6)
+
+
+def test_reproducible_with_seed():
+    X, y = _regime_edge_data(n=600, block=50)
+    a = RegimeMoE(n_regimes=2, regime_w=10, epochs=15, seed=7).fit(X, y).predict(X)
+    b = RegimeMoE(n_regimes=2, regime_w=10, epochs=15, seed=7).fit(X, y).predict(X)
+    assert np.allclose(a, b)
+
+
+def test_predict_before_fit_raises():
+    with pytest.raises(RuntimeError, match="fit"):
+        RegimeMoE().predict(np.zeros((5, 2)))
+
+
+def test_detector_fit_on_train_only_is_causal():
+    # Labels on the train region must not change when more data is appended.
+    X, y = _regime_edge_data(n=1200, block=100)
+    model = RegimeMoE(n_regimes=2, regime_w=20).fit(X[:800], y[:800])
+    train_labels = model.detector.predict(X[:800, 0])
+    extended_labels = model.detector.predict(X[:, 0])
+    assert np.array_equal(train_labels, extended_labels[:800])
+
+
+def test_beats_regime_blind_model_on_regime_edge():
+    # The edge is only exploitable if you know the regime: RegimeMoE should beat
+    # a regime-blind ObjectiveModel given the exact same features.
+    X, y = _regime_edge_data(n=2000, block=100)
+
+    moe = RegimeMoE(
+        n_regimes=2, regime_w=20, hidden=(16, 8), epochs=200, lr=5e-3, seed=0,
+    ).fit(X, y)
+    blind = ObjectiveModel(layers=(16, 8), epochs=200, lr=5e-3, seed=0).fit(X, y)
+
+    moe_ret = np.asarray(moe.predict(X)).reshape(-1) * y
+    blind_ret = np.asarray(blind.predict(X)).reshape(-1) * y
+
+    moe_sharpe = sharpe(np.cumprod(1 + moe_ret), period=252)
+    blind_sharpe = sharpe(np.cumprod(1 + blind_ret), period=252)
+
+    assert moe_sharpe > blind_sharpe
+    assert moe_sharpe > 1.0
+
+
+def test_hard_routing_runs():
+    X, y = _regime_edge_data(n=400, block=50)
+    model = RegimeMoE(
+        n_regimes=2, regime_w=10, routing='hard', epochs=10,
+    ).fit(X, y)
+    pos = np.asarray(model.predict(X))
+    assert pos.shape == (400, 1)
+
+
+def test_bad_routing_raises():
+    X, y = _regime_edge_data(n=200, block=50)
+    with pytest.raises(ValueError, match="routing"):
+        RegimeMoE(routing='nope', regime_w=10).fit(X, y)


### PR DESCRIPTION
## Why

Roadmap §1.2 (library bricks): condition the architecture on the **market regime**. The causal `RegimeDetector` already exists; this turns it into a usable model that routes its prediction by regime.

## What

`fynance.models.RegimeMoE`, a `SignalModel` (`fit`/`predict`):

- **Soft routing** (default): a learned regime **embedding** (`nn.Embedding`) concatenated to the features through a shared trunk — differentiable end-to-end.
- **Hard routing**: one **expert** MLP per regime, selected by the regime label.
- **Causal regime**: a `RegimeDetector` fit on the **train** slice only, assigned online (nearest centroid), from a designated positive price/level column of `X` (`regime_col`). No future leaks into a label.
- **Reuses `ObjectiveModel`** for the training loop (differentiable objective, mini-batching, net-of-cost penalty, seeding) — no duplicated training code. Seeds `torch.manual_seed` **before** building the net (the ObjectiveModel `net=` gotcha).

## Tests / gates

- 9 tests: protocol conformance, predict shape/bounds, reproducibility, predict-before-fit guard, **detector causality** (train labels unchanged when data is appended), **hard** routing, bad-routing guard, and the key one — on a synthetic **regime-flipping edge** (the profitable sign of a feature flips per regime), `RegimeMoE` beats a regime-blind `ObjectiveModel` given the same features (Sharpe > 1 vs blind).
- Full suite **601 passed / 1 skipped**; `ruff` clean; `interrogate` 100%; `mypy` clean; Sphinx `-W` builds (documented on the neural-network page).

Part of the roadmap §1 "library bricks" epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)