### PR TITLE
feat: add regime-adaptive rolling windows (adaptive_roll/adaptive_volatility)

### DIFF
--- a/doc/source/features.engineering.rst
+++ b/doc/source/features.engineering.rst
@@ -2,7 +2,7 @@
 Feature engineering
 *******************
 
-Feature-engineering and selection research tools: multi-resolution feature stacking (:func:`~fynance.features.engineering.multi_resolution`), a Granger-causality test (:func:`~fynance.features.engineering.granger_causality`) and incremental moments (:func:`~fynance.features.engineering.IncrementalMoments`).
+Feature-engineering and selection research tools: multi-resolution feature stacking (:func:`~fynance.features.engineering.multi_resolution`), regime-adaptive windows (:func:`~fynance.features.engineering.adaptive_roll` / :func:`~fynance.features.engineering.adaptive_volatility`), a Granger-causality test (:func:`~fynance.features.engineering.granger_causality`) and incremental moments (:func:`~fynance.features.engineering.IncrementalMoments`).
 
 .. currentmodule:: fynance.features.engineering
 
@@ -10,5 +10,7 @@ Feature-engineering and selection research tools: multi-resolution feature stack
    :toctree: generated/
 
    multi_resolution
+   adaptive_roll
+   adaptive_volatility
    granger_causality
    IncrementalMoments

--- a/fynance/features/engineering.py
+++ b/fynance/features/engineering.py
@@ -10,14 +10,21 @@ Granger-causality test for filtering candidate features.
 from __future__ import annotations
 
 # Built-in packages
-from typing import Callable
+from collections.abc import Mapping
+from typing import Any, Callable
 
 # Third-party packages
 import numpy as np
 from numpy.typing import NDArray
 from scipy import stats as _sp_stats
 
-__all__ = ['IncrementalMoments', 'granger_causality', 'multi_resolution']
+# Local packages
+from fynance.features.indicators import realized_volatility
+
+__all__ = [
+    'IncrementalMoments', 'adaptive_roll', 'adaptive_volatility',
+    'granger_causality', 'multi_resolution',
+]
 
 
 def multi_resolution(
@@ -154,3 +161,119 @@ class IncrementalMoments:
     def std(self) -> float:
         """ Population standard deviation. """
         return self.var ** 0.5
+
+
+def adaptive_roll(
+    X: NDArray,
+    func: Callable[..., NDArray],
+    windows: Mapping[int, int],
+    regimes: NDArray,
+    **kwargs: Any,
+) -> NDArray:
+    r""" Apply a window-based feature with a **regime-dependent** window.
+
+    At each bar ``t`` the output is ``func(X, windows[regimes[t]])[t]`` — a short
+    window in one regime, a longer one in another. Causal as long as both inputs
+    are: ``func`` must be a trailing-window feature (value at ``t`` uses
+    ``X[..t]``) and ``regimes`` a causal label (e.g. from
+    :class:`~fynance.features.RegimeDetector`, fit-on-train / assign-online).
+
+    Parameters
+    ----------
+    X : np.ndarray
+        One-dimensional input series.
+    func : callable
+        A trailing-window feature taking ``(X, w, **kwargs)`` and returning an
+        array aligned with ``X`` (e.g.
+        :func:`~fynance.features.momentums.sma`,
+        :func:`~fynance.features.indicators.realized_volatility`).
+    windows : mapping of int to int
+        Window size for each regime label. Must cover every label present in
+        ``regimes``.
+    regimes : np.ndarray
+        Causal integer regime label per bar, aligned with ``X``.
+    **kwargs
+        Extra keyword arguments forwarded to ``func``.
+
+    Returns
+    -------
+    np.ndarray
+        The regime-adaptive feature, shape ``(len(X),)``.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from fynance.features.momentums import sma
+    >>> X = np.arange(1., 7.)
+    >>> regimes = np.array([0, 0, 0, 1, 1, 1])
+    >>> adaptive_roll(X, sma, {0: 1, 1: 3}, regimes)
+    array([1., 2., 3., 3., 4., 5.])
+
+    """
+    x = np.asarray(X, dtype=np.float64).reshape(-1)
+    reg = np.asarray(regimes).reshape(-1)
+
+    if reg.size != x.size:
+
+        raise ValueError(
+            f"regimes length {reg.size} != X length {x.size}"
+        )
+
+    present = set(int(r) for r in np.unique(reg))
+    missing = present - set(windows)
+
+    if missing:
+
+        raise ValueError(f"windows has no entry for regime(s) {sorted(missing)}")
+
+    # Compute the feature once per distinct window, then select per bar.
+    out = np.empty(x.size, dtype=np.float64)
+    for w in set(windows.values()):
+        col = np.asarray(func(x, w, **kwargs)).reshape(-1)
+        labels_with_w = [lab for lab, win in windows.items() if win == w]
+        mask = np.isin(reg, labels_with_w)
+        out[mask] = col[mask]
+
+    return out
+
+
+def adaptive_volatility(
+    X: NDArray,
+    windows: Mapping[int, int],
+    regimes: NDArray,
+    period: int = 252,
+) -> NDArray:
+    r""" Regime-adaptive realized volatility (worked example of :func:`adaptive_roll`).
+
+    Uses a short volatility window in some regimes and a longer one in others, so
+    the estimate reacts fast in turbulent regimes and stays smooth in calm ones.
+
+    Parameters
+    ----------
+    X : np.ndarray
+        One-dimensional price/level series.
+    windows : mapping of int to int
+        Volatility window for each regime label.
+    regimes : np.ndarray
+        Causal integer regime label per bar, aligned with ``X``.
+    period : int, optional
+        Annualization factor. Default 252.
+
+    Returns
+    -------
+    np.ndarray
+        Regime-adaptive annualized volatility, shape ``(len(X),)``.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> rng = np.random.default_rng(0)
+    >>> X = 100 * np.exp(np.cumsum(rng.standard_normal(100) * 0.01))
+    >>> regimes = (np.arange(100) // 50)   # two regimes
+    >>> adaptive_volatility(X, {0: 5, 1: 20}, regimes).shape
+    (100,)
+
+    """
+    return adaptive_roll(
+        X, realized_volatility, windows, regimes, period=period,
+    )

--- a/fynance/tests/features/test_adaptive_windows.py
+++ b/fynance/tests/features/test_adaptive_windows.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for regime-adaptive rolling windows. """
+
+# Third-party packages
+import numpy as np
+import pytest
+
+# Local packages
+from fynance.features.engineering import adaptive_roll, adaptive_volatility
+from fynance.features.indicators import realized_volatility
+from fynance.features.momentums import sma
+
+
+def test_single_regime_constant_window_equals_fixed():
+    X = np.arange(1.0, 21.0)
+    regimes = np.zeros(X.size, dtype=int)
+    out = adaptive_roll(X, sma, {0: 3}, regimes)
+    assert np.allclose(out, np.asarray(sma(X, 3)).reshape(-1))
+
+
+def test_output_length_and_known_values():
+    X = np.arange(1.0, 7.0)
+    regimes = np.array([0, 0, 0, 1, 1, 1])
+    out = adaptive_roll(X, sma, {0: 1, 1: 3}, regimes)
+    assert out.shape == (6,)
+    # regime 0 -> sma window 1 (= X); regime 1 -> sma window 3
+    assert np.allclose(out, [1.0, 2.0, 3.0, 3.0, 4.0, 5.0])
+
+
+def test_missing_window_for_regime_raises():
+    X = np.arange(1.0, 7.0)
+    regimes = np.array([0, 0, 0, 1, 1, 1])
+    with pytest.raises(ValueError, match="no entry for regime"):
+        adaptive_roll(X, sma, {0: 2}, regimes)
+
+
+def test_length_mismatch_raises():
+    X = np.arange(1.0, 7.0)
+    with pytest.raises(ValueError, match="length"):
+        adaptive_roll(X, sma, {0: 2}, np.zeros(3, dtype=int))
+
+
+def test_no_lookahead():
+    rng = np.random.default_rng(0)
+    X = 100 * np.exp(np.cumsum(rng.standard_normal(200) * 0.01))
+    regimes = (np.arange(200) // 50) % 2
+    full = adaptive_volatility(X, {0: 5, 1: 20}, regimes)
+    t = 120
+    truncated = adaptive_volatility(X[:t], {0: 5, 1: 20}, regimes[:t])
+    assert np.allclose(full[:t], truncated, equal_nan=True)
+
+
+def test_window_varies_with_regime():
+    # Calm segment then turbulent segment; a short window in the turbulent regime
+    # tracks the vol jump faster than the long calm-window baseline.
+    rng = np.random.default_rng(1)
+    n = 400
+    calm = rng.standard_normal(n // 2) * 0.003
+    turbulent = rng.standard_normal(n // 2) * 0.03
+    log_ret = np.concatenate([calm, turbulent])
+    X = 100 * np.exp(np.cumsum(log_ret))
+    regimes = (np.arange(n) >= n // 2).astype(int)   # 0 calm, 1 turbulent
+
+    # short window (5) in the turbulent regime, long (50) in calm
+    adaptive = adaptive_volatility(X, {0: 50, 1: 5}, regimes)
+    # baseline: the long window everywhere
+    baseline = np.asarray(realized_volatility(X, w=50, period=252)).reshape(-1)
+
+    # just after the regime switch, the adaptive estimate (short window) has
+    # risen more than the slow baseline.
+    probe = n // 2 + 10
+    assert adaptive[probe] > baseline[probe]
+
+
+def test_adaptive_volatility_matches_manual_roll():
+    rng = np.random.default_rng(2)
+    X = 100 * np.exp(np.cumsum(rng.standard_normal(120) * 0.01))
+    regimes = (np.arange(120) // 40) % 2
+    auto = adaptive_volatility(X, {0: 7, 1: 21}, regimes, period=252)
+    manual = adaptive_roll(
+        X, realized_volatility, {0: 7, 1: 21}, regimes, period=252,
+    )
+    assert np.allclose(auto, manual, equal_nan=True)


### PR DESCRIPTION
## Why

Roadmap §1.3 (library bricks): a rolling feature whose **window adapts to the volatility regime** — short/reactive in turbulent regimes, long/smooth in calm ones.

## What

Two functions in `fynance.features.engineering`:

- `adaptive_roll(X, func, windows, regimes, **kwargs)` — applies a trailing-window feature `func` with a per-bar window chosen by the current regime label (`windows` maps regime → window).
- `adaptive_volatility(X, windows, regimes, period=252)` — the worked example on `realized_volatility`.

**Causal** as long as both inputs are: `func` is a trailing-window feature (value at `t` uses `X[..t]`) and `regimes` is a causal label (e.g. `RegimeDetector` fit-on-train / assign-online). Computed once per distinct window then selected per bar (efficient).

## Tests / gates

- 7 tests: single-regime/constant-window reduces **exactly** to the fixed-window stat; known-value check; missing-window and length-mismatch guards; **no-lookahead** (truncation doesn't change earlier values); window actually varies with regime (short window tracks a vol jump faster than the long baseline); `adaptive_volatility` == manual `adaptive_roll`.
- Full suite **601 passed / 1 skipped**; `ruff` clean; `interrogate` 100%; `mypy` clean; Sphinx `-W` builds.

Part of the roadmap §1 "library bricks" epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)