### PR TITLE
docs: changelog + ADRs for library-bricks epic; close roadmap §1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`fynance.core.OHLCV` — aligned multi-series value object.** A thin,
+  numpy-backed container for aligned Open/High/Low/Close/Volume series (the
+  multi-series counterpart of `PriceSeries`): `close` required, the other four
+  fields optional (accessing an absent field raises), equal length enforced at
+  construction, with `from_dict`/`from_numpy`/`from_polars` bridges and
+  `to_numpy()`. The input contract the new OHLCV indicators consume.
+- **Multi-series OHLCV indicators (`fynance.features.ohlcv`).** Five causal
+  indicators that need High/Low or Volume: `atr` (Wilder ATR), `adx` (Wilder
+  ADX), `williams_r`, `obv`, and `vwap` (cumulative or rolling). Each takes the
+  raw aligned arrays **or** a single `OHLCV` container; rolling loops are Numba
+  `@njit` kernels.
+- **Causal GARCH(1,1) volatility feature (`fynance.features.garch_volatility`).**
+  Conditional volatility as a strictly causal feature: GARCH(1,1) fit by maximum
+  likelihood on a training prefix (optionally refit on the expanding window every
+  `refit` steps), then forward-filtered over the series; the `min_train` warmup is
+  `NaN`. Reuses the single authoritative ARMA/GARCH recursion and likelihood — no
+  duplicated parameter logic.
+- **Regime-conditioned architecture (`fynance.models.RegimeMoE`).** A
+  `SignalModel` mixture-of-experts conditioned on the **causal** market regime
+  (`RegimeDetector`): `routing="soft"` concatenates a learned regime embedding to
+  the features through a shared trunk (default), `routing="hard"` uses one expert
+  per regime. The regime label is produced by a detector fit on the training slice
+  only and assigned online. Reuses `ObjectiveModel` for the training loop.
+- **Regime-adaptive rolling windows (`fynance.features.adaptive_roll` /
+  `adaptive_volatility`).** Apply a trailing-window feature with a per-bar window
+  chosen by the current causal regime label (short window in one regime, longer in
+  another); a single regime with a constant window reduces exactly to the
+  fixed-window statistic.
+- **Non-linear market-impact cost (`fynance.backtest.MarketImpactCost`).** A
+  `CostModel` adding a convex, super-linear market-impact term on top of the
+  linear fee — `fee*turnover + impact*turnover**exponent` (default `exponent=1.5`,
+  the square-root impact law). `exponent=1, impact=0` reduces exactly to
+  `ProportionalCost`.
+
 ### Changed
+
+- **Roadmap re-scoped to data-agnostic library bricks.** Strategy research on
+  real data (empirical loss/architecture/normalization benchmarks, out-of-sample
+  Sharpe, online regimes) moved to the private `fynance-research` repo; the public
+  roadmap and dev docs now track only reusable, data-agnostic library work. The
+  shipped `ObjectiveModel` epic and the §1 "library bricks" epic were removed from
+  the roadmap.
 
 ### Fixed
 

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -72,6 +72,86 @@ Template:
 
 <!-- new entries below, newest first -->
 
+### 2026-06-21 — Library-bricks epic: roadmap §1 shipped (PRs #177–#182)  [accepted]
+- **Choice**: ship the data-agnostic "library bricks" (roadmap §1) as six atomic
+  PRs and **re-scope** the roadmap — real-data strategy research moves to the
+  private `fynance-research` repo; the public roadmap keeps only reusable,
+  data-agnostic library work. Bricks: `core.OHLCV`, OHLCV indicators, causal
+  GARCH feature, `RegimeMoE`, adaptive windows, non-linear cost (each entry below).
+- **Why**: most remaining roadmap items were blocked on real data, not on missing
+  code; separating the *library* (here) from the *research* (private repo) lets the
+  public package stay data-agnostic and result-free while still gaining the bricks
+  the research needs. One PR per concern keeps each disposable and reviewable.
+- **Rejected alternatives**: one fourre-tout branch (against the one-PR-one-concern
+  rule); keeping the data-blocked research items on the public roadmap (drift —
+  they never move without data that lives elsewhere).
+
+### 2026-06-21 — `core.OHLCV` value object for the multi-series input (PR #177)  [accepted]
+- **Choice**: introduce a thin numpy-backed `OHLCV` value object (composition, not
+  `ndarray` subclassing — mirroring `PriceSeries`) as the input contract for the
+  multi-series indicators, rather than passing loose `high`/`low`/`close`/`volume`
+  arrays everywhere. `close` required, others optional (absent-field access raises),
+  equal length enforced at construction.
+- **Why**: a typed, validated, reusable container catches misaligned/missing series
+  once at the edge instead of in every indicator; the indicators still accept raw
+  arrays too, so the object is an *option*, not a tax.
+- **Rejected alternatives**: a pandas/polars DataFrame as the contract (heavier,
+  re-introduces a frame dependency at the core); subclassing `ndarray` (the
+  fragility `PriceSeries` already avoids).
+
+### 2026-06-21 — OHLCV indicators: raw-arrays-first API with an OHLCV overload (PR #182)  [accepted]
+- **Choice**: implement `atr`/`adx`/`williams_r`/`obv`/`vwap` as functions taking
+  the **raw aligned arrays** as the primary signature, with a thin dispatch that
+  also accepts a single `OHLCV` as the first argument. Rolling loops are Numba
+  `@njit` kernels; ATR/ADX use Wilder smoothing.
+- **Why**: raw-arrays-first matches the existing `features` idiom (every other
+  indicator takes arrays), keeps the functions usable without constructing a
+  container, and the overload gives the typed path for free.
+- **Rejected alternatives**: OHLCV-only signatures (forces object construction,
+  breaks the array idiom); methods on `OHLCV` (couples the container to the whole
+  indicator library).
+
+### 2026-06-21 — Causal GARCH feature = expanding-fit + forward-filter (PR #179)  [accepted]
+- **Choice**: expose GARCH(1,1) conditional volatility as a feature by fitting the
+  parameters on a training prefix (optionally refit on the expanding window) and
+  **forward-filtering** σ over the series; the `min_train` warmup is `NaN`. Reuse
+  the authoritative `models.econometric_models` recursion + `estimator` likelihood;
+  the MLE fit is a thin scipy `SLSQP` wrapper.
+- **Why**: σ_t in GARCH is 𝓕ₜ₋₁-measurable, so filtering forward with past-fit
+  parameters is strictly causal — the only leak risks are the parameters (handled
+  by expanding-fit) and the warmup (NaN'd). Reusing the single recursion respects
+  the estimator no-duplication policy.
+- **Rejected alternatives**: a single in-sample fit over the whole series (peeks —
+  leaky); re-implementing the GARCH recursion in `features` (duplicates parameter
+  logic the policy forbids).
+
+### 2026-06-21 — Regime-conditioned architecture: causal detector + MoE (PR #180)  [accepted]
+- **Choice**: `RegimeMoE` routes an objective-aligned net by the **causal** regime
+  (`RegimeDetector` fit-on-train / assign-online, from a designated price/level
+  column of `X`). Default `routing="soft"` (a learned regime embedding concatenated
+  to the features through a shared trunk, differentiable end-to-end); `routing="hard"`
+  offers one expert per regime. Reuses `ObjectiveModel` for training (objective /
+  mini-batch / cost / seed).
+- **Why**: conditioning needs a *causal* regime to be backtest-honest; the
+  in-sample `detect_regimes` would leak. Soft routing trains end-to-end and shares
+  data across regimes (more sample-efficient than fully separate experts) while
+  hard routing stays available when regimes are believed truly disjoint. Composing
+  `ObjectiveModel` avoids duplicating the training loop.
+- **Rejected alternatives**: routing on in-sample `detect_regimes` (leaky); a
+  bespoke training loop (duplicates `ObjectiveModel`); hard routing as the default
+  (less sample-efficient, non-differentiable gate).
+
+### 2026-06-21 — Non-linear cost = square-root market-impact law (PR #178)  [accepted]
+- **Choice**: model convex execution cost as `fee*turnover + impact*turnover**1.5`
+  (square-root impact law) in `MarketImpactCost`, reusing the `ProportionalCost`
+  turnover definition so `exponent=1, impact=0` collapses exactly to the linear model.
+- **Why**: real impact grows super-linearly with trade size; the √-law is the
+  standard, single-parameter convex form, and making the linear case an exact
+  special case keeps it a drop-in extension of the existing cost model.
+- **Rejected alternatives**: a full order-book / market-impact simulator (out of
+  scope for a vectorized backtest); a fixed quadratic only (√-law is the empirically
+  standard default; `exponent` stays tunable).
+
 ### 2026-06-18 — Mini-batch training for ObjectiveModel (PR #173)  [accepted]
 - **Choice**: add contiguous mini-batch SGD (`batch_size`/`shuffle`) to
   `ObjectiveModel`; a `fit` now does `epochs * ceil(T/batch_size)` steps instead of

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -13,10 +13,12 @@ shipped, `03-decisions.md` for *why*. Keep it short and true.
 > `/finish-task`. Release : `/release` quand `[Unreleased]` est suffisamment rempli.
 
 > **fynance 2.x livré** (v2.8.0 sur `master`/PyPI). Le refactor en couches, le port
-> Cython→Numba (build pure-Python), le harnais R&D `fynance.research` (S1–S3) et la
-> brique d'entraînement aligné-objectif (`ObjectiveModel` : objectif différentiable,
-> net de coûts, mini-batch) sont **terminés** — voir `CHANGELOG.md` / `03-decisions.md`.
-> Reste, ci-dessous, des **bricks de librairie** non bloquées par la donnée.
+> Cython→Numba (build pure-Python), le harnais R&D `fynance.research` (S1–S3), la
+> brique d'entraînement aligné-objectif (`ObjectiveModel`) et les **bricks de
+> librairie** (conteneur `OHLCV` + indicateurs ATR/ADX/Williams %R/OBV/VWAP, feature
+> GARCH causale, `RegimeMoE`, fenêtres adaptatives, coût market-impact non-linéaire)
+> sont **terminés** — voir `CHANGELOG.md` / `03-decisions.md`. Il ne reste qu'un
+> item optionnel ci-dessous.
 
 > ⚠️ **Hors scope ici** : la recherche de stratégie sur **vraie data** (benchmarks
 > empiriques loss / architecture / normalisation, évaluation Sharpe out-of-sample,
@@ -35,38 +37,3 @@ Le harnais `fynance.research` est **livré** (S1–S3) : `Experiment`,
 
 - [ ] Explorateur **Streamlit** au-dessus du Ledger (parcourir / filtrer / comparer
   les runs persistés) — interactif, plus tardif.
-
-## 1. Bricks library (non bloquées par la donnée)
-
-Travail de librairie pur, testable sur data synthétique. Exploratoire : peut
-déboucher sur du code dans `fynance/` ou rester à l'état de rapport.
-
-### 1.1 Indicateurs OHLCV multi-séries
-
-Single-série & causaux déjà présents : EMA/MACD/RSI/Bollinger/CCI/HMA, `roc`,
-`realized_volatility`, `rolling_skewness`/`kurtosis`/`autocorr`. Manquent les
-indicateurs exigeant plusieurs séries :
-
-- [ ] Concevoir une **API multi-séries OHLCV** d'abord, puis **ATR / ADX /
-  Williams %R** (High/Low) et **OBV / VWAP** (Volume).
-- [ ] **GARCH(1,1) comme feature** (via `fynance.estimator`).
-
-### 1.2 Architecture conditionnée par le régime
-
-`RegimeDetector` causal (fit-on-train / assign-online) est déjà livré ; reste à
-s'en servir pour piloter l'architecture :
-
-- [ ] Conditionner le modèle sur le régime — **mixture-of-experts** /
-  embedding de régime.
-
-### 1.3 Fenêtres adaptatives (dépend de §1.2)
-
-- [ ] `window` variable selon le régime de volatilité.
-
-### 1.4 Backtest réaliste
-
-Fait : `portfolio/sizing.py` (`kelly_fraction`, causal `vol_target`,
-`transaction_cost` turnover-based) ; métriques `percent_positive`, `tail_ratio`.
-Reste optionnel :
-
-- [ ] **Slippage / impact de marché non-linéaire** au-delà du coût proportionnel.


### PR DESCRIPTION
## Why

The six library-bricks PRs (#177–#182) shipped in a batch without per-leaf `/finish-task`, so the CHANGELOG and the ADR journal were silent on them. This catches them up and closes the epic.

## What

- **CHANGELOG `[Unreleased]`** — one `Added` entry per brick (`core.OHLCV`, OHLCV indicators, causal GARCH feature, `RegimeMoE`, adaptive windows, `MarketImpactCost`) + a `Changed` note on the roadmap re-scope.
- **`doc/dev/03-decisions.md`** — one ADR per design decision (value-object OHLCV input, raw-arrays-first indicator API, causal GARCH expanding-fit + forward-filter, causal-detector MoE with soft/hard routing, √-impact cost law) plus the epic/re-scope entry.
- **`doc/dev/07-roadmap.md`** — removed the completed §1 "library bricks" section; only the optional Streamlit ledger explorer (§2) remains.

Docs only — no code touched. Precedes the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)