### PR TITLE
chore: release v2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [2.9.0] - 2026-06-21
+
+### Breaking Changes
+
+### Added
+
 - **`fynance.core.OHLCV` — aligned multi-series value object.** A thin,
   numpy-backed container for aligned Open/High/Low/Close/Volume series (the
   multi-series counterpart of `PriceSeries`): `close` required, the other four

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fynance"
-version = "2.8.0"
+version = "2.9.0"
 description = "Pure-Python (Numba-accelerated) machine learning, econometrics and statistical tools for financial analysis and backtesting"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Release **v2.9.0** — the data-agnostic *library bricks* (roadmap §1).

## Added

- **`fynance.core.OHLCV`** — aligned multi-series Open/High/Low/Close/Volume value object (the input contract for the OHLCV indicators).
- **OHLCV indicators** (`fynance.features.ohlcv`) — `atr`, `adx`, `williams_r`, `obv`, `vwap`; raw arrays or an `OHLCV`; Numba `@njit` kernels; causal.
- **Causal GARCH(1,1) volatility feature** (`fynance.features.garch_volatility`) — expanding-fit + forward-filter; reuses the authoritative ARMA/GARCH recursion.
- **`fynance.models.RegimeMoE`** — regime-conditioned mixture-of-experts on the causal `RegimeDetector` (soft embedding / hard experts); reuses `ObjectiveModel`.
- **Regime-adaptive windows** (`fynance.features.adaptive_roll` / `adaptive_volatility`).
- **`fynance.backtest.MarketImpactCost`** — convex square-root market-impact cost (`exponent=1,impact=0` ≡ `ProportionalCost`).

## Changed

- Roadmap re-scoped to data-agnostic library bricks; real-data strategy research moved to the private `fynance-research` repo.

## Test plan

All four gates verified locally on the integrated `develop`: **pytest 658 passed / 1 skipped**, `ruff` clean, `mypy` clean (168 files), `interrogate` 94.7%, Sphinx `-W` builds. (The PR-level `ci.yml` does not auto-run on develop PRs in this repo; the only red mark is the non-blocking "Update badges" commit step.)