### PR TITLE
Release v2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`fynance.core.OHLCV` — aligned multi-series value object.** A thin,
+  numpy-backed container for aligned Open/High/Low/Close/Volume series (the
+  multi-series counterpart of `PriceSeries`): `close` required, the other four
+  fields optional (accessing an absent field raises), equal length enforced at
+  construction, with `from_dict`/`from_numpy`/`from_polars` bridges and
+  `to_numpy()`. The input contract the new OHLCV indicators consume.
+- **Multi-series OHLCV indicators (`fynance.features.ohlcv`).** Five causal
+  indicators that need High/Low or Volume: `atr` (Wilder ATR), `adx` (Wilder
+  ADX), `williams_r`, `obv`, and `vwap` (cumulative or rolling). Each takes the
+  raw aligned arrays **or** a single `OHLCV` container; rolling loops are Numba
+  `@njit` kernels.
+- **Causal GARCH(1,1) volatility feature (`fynance.features.garch_volatility`).**
+  Conditional volatility as a strictly causal feature: GARCH(1,1) fit by maximum
+  likelihood on a training prefix (optionally refit on the expanding window every
+  `refit` steps), then forward-filtered over the series; the `min_train` warmup is
+  `NaN`. Reuses the single authoritative ARMA/GARCH recursion and likelihood — no
+  duplicated parameter logic.
+- **Regime-conditioned architecture (`fynance.models.RegimeMoE`).** A
+  `SignalModel` mixture-of-experts conditioned on the **causal** market regime
+  (`RegimeDetector`): `routing="soft"` concatenates a learned regime embedding to
+  the features through a shared trunk (default), `routing="hard"` uses one expert
+  per regime. The regime label is produced by a detector fit on the training slice
+  only and assigned online. Reuses `ObjectiveModel` for the training loop.
+- **Regime-adaptive rolling windows (`fynance.features.adaptive_roll` /
+  `adaptive_volatility`).** Apply a trailing-window feature with a per-bar window
+  chosen by the current causal regime label (short window in one regime, longer in
+  another); a single regime with a constant window reduces exactly to the
+  fixed-window statistic.
+- **Non-linear market-impact cost (`fynance.backtest.MarketImpactCost`).** A
+  `CostModel` adding a convex, super-linear market-impact term on top of the
+  linear fee — `fee*turnover + impact*turnover**exponent` (default `exponent=1.5`,
+  the square-root impact law). `exponent=1, impact=0` reduces exactly to
+  `ProportionalCost`.
+
 ### Changed
+
+- **Roadmap re-scoped to data-agnostic library bricks.** Strategy research on
+  real data (empirical loss/architecture/normalization benchmarks, out-of-sample
+  Sharpe, online regimes) moved to the private `fynance-research` repo; the public
+  roadmap and dev docs now track only reusable, data-agnostic library work. The
+  shipped `ObjectiveModel` epic and the §1 "library bricks" epic were removed from
+  the roadmap.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [2.9.0] - 2026-06-21
+
+### Breaking Changes
+
+### Added
+
 - **`fynance.core.OHLCV` — aligned multi-series value object.** A thin,
   numpy-backed container for aligned Open/High/Low/Close/Volume series (the
   multi-series counterpart of `PriceSeries`): `close` required, the other four

--- a/badges/interrogate_badge.svg
+++ b/badges/interrogate_badge.svg
@@ -1,5 +1,5 @@
 <svg width="140" height="20" viewBox="0 0 140 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <title>interrogate: 94.3%</title>
+    <title>interrogate: 94.7%</title>
     <g transform="matrix(1,0,0,1,22,0)">
         <g id="backgrounds" transform="matrix(1.32789,0,0,1,-22.3892,0)">
             <rect x="0" y="0" width="71" height="20" style="fill:rgb(85,85,85);"/>
@@ -12,8 +12,8 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
         <text x="590" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="610">interrogate</text>
         <text x="590" y="140" transform="scale(.1)" textLength="610">interrogate</text>
-        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">94.3%</text>
-        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">94.3%</text>
+        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">94.7%</text>
+        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">94.7%</text>
     </g>
     <g id="logo-shadow" serif:id="logo shadow" transform="matrix(0.854876,0,0,0.854876,-6.73514,1.732)">
         <g transform="matrix(0.299012,0,0,0.299012,9.70229,-6.68582)">

--- a/doc/dev/01-overview.md
+++ b/doc/dev/01-overview.md
@@ -33,11 +33,11 @@ library's core invariant, enforced in tests.
 
 ## Current state (snapshot)
 
-- **Version `2.1.1`** (in `pyproject.toml`, static), released on `master` and
+- **Version `2.8.0`** (in `pyproject.toml`, static), released on `master` and
   published to PyPI; `Development Status :: 5 - Production/Stable`.
 - **Python 3.10–3.13** (CI matrix). Build is **pure-Python** (setuptools, no
   compile step) — numerical kernels are Numba `@njit`. No Cython.
-- **501 tests** under `fynance/tests/` (mirrors the package), **plus doctests**
+- **518 tests** under `fynance/tests/` (mirrors the package), **plus doctests**
   run on every module via `--doctest-modules` — docstring examples are part of
   the suite and must stay runnable.
 - **Four CI gates**: pytest (3.10–3.13), `ruff`, `interrogate` (docstring

--- a/doc/dev/02-architecture.md
+++ b/doc/dev/02-architecture.md
@@ -39,12 +39,14 @@ stability policy per package.)
   `_metrics_helpers` (the Numba metric kernels), `money_management`.
 - **`metrics/`** — performance/evaluation metrics split by concern: `ratios`
   (Sharpe/Sortino/Calmar/…), `drawdown`, `returns`, `summary` (one-call panel).
-- **`signal/` · `portfolio/`** — `sign`/`threshold`/`rank`/vol-target mappers +
-  `SignalPipeline`; `allocation.py` (ERC/HRP/IVP/MDP/MVP + `rolling_allocation()`,
-  stable public API) and `sizing.py`.
+- **`signal/` · `portfolio/`** — `sign`/`threshold`/`rank`/vol-target +
+  anti-churn (`ema_smooth`/`deadband`/`min_hold`) mappers + `SignalPipeline`;
+  `allocation.py` (ERC/HRP/IVP/MDP/MVP + `rolling_allocation()`, stable public
+  API) and `sizing.py`.
 - **`models/`** — econometric (`econometric_models.py`, Numba ARMA/GARCH) and
   neural (`mlp`, `rnn`, `gru`, `lstm`, `attention`, `tcn`, `transformer`) on a
-  rolling/walk-forward base; `loss/` (torch losses), `training.py`, `ensemble.py`.
+  rolling/walk-forward base; `loss/` (torch losses), `objective.py`
+  (objective-aligned training), `training.py`, `ensemble.py`.
 - **`backtest/`** — vectorized `engine` + `cost` + `result`; the legacy live-viz
   plot stack (`plot_backtest`/`dynamic_plot_backtest`/`backtest_neural_net`) is
   kept for `RollMultiLayerPerceptron` but off the eager public surface.

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -72,6 +72,86 @@ Template:
 
 <!-- new entries below, newest first -->
 
+### 2026-06-21 — Library-bricks epic: roadmap §1 shipped (PRs #177–#182)  [accepted]
+- **Choice**: ship the data-agnostic "library bricks" (roadmap §1) as six atomic
+  PRs and **re-scope** the roadmap — real-data strategy research moves to the
+  private `fynance-research` repo; the public roadmap keeps only reusable,
+  data-agnostic library work. Bricks: `core.OHLCV`, OHLCV indicators, causal
+  GARCH feature, `RegimeMoE`, adaptive windows, non-linear cost (each entry below).
+- **Why**: most remaining roadmap items were blocked on real data, not on missing
+  code; separating the *library* (here) from the *research* (private repo) lets the
+  public package stay data-agnostic and result-free while still gaining the bricks
+  the research needs. One PR per concern keeps each disposable and reviewable.
+- **Rejected alternatives**: one fourre-tout branch (against the one-PR-one-concern
+  rule); keeping the data-blocked research items on the public roadmap (drift —
+  they never move without data that lives elsewhere).
+
+### 2026-06-21 — `core.OHLCV` value object for the multi-series input (PR #177)  [accepted]
+- **Choice**: introduce a thin numpy-backed `OHLCV` value object (composition, not
+  `ndarray` subclassing — mirroring `PriceSeries`) as the input contract for the
+  multi-series indicators, rather than passing loose `high`/`low`/`close`/`volume`
+  arrays everywhere. `close` required, others optional (absent-field access raises),
+  equal length enforced at construction.
+- **Why**: a typed, validated, reusable container catches misaligned/missing series
+  once at the edge instead of in every indicator; the indicators still accept raw
+  arrays too, so the object is an *option*, not a tax.
+- **Rejected alternatives**: a pandas/polars DataFrame as the contract (heavier,
+  re-introduces a frame dependency at the core); subclassing `ndarray` (the
+  fragility `PriceSeries` already avoids).
+
+### 2026-06-21 — OHLCV indicators: raw-arrays-first API with an OHLCV overload (PR #182)  [accepted]
+- **Choice**: implement `atr`/`adx`/`williams_r`/`obv`/`vwap` as functions taking
+  the **raw aligned arrays** as the primary signature, with a thin dispatch that
+  also accepts a single `OHLCV` as the first argument. Rolling loops are Numba
+  `@njit` kernels; ATR/ADX use Wilder smoothing.
+- **Why**: raw-arrays-first matches the existing `features` idiom (every other
+  indicator takes arrays), keeps the functions usable without constructing a
+  container, and the overload gives the typed path for free.
+- **Rejected alternatives**: OHLCV-only signatures (forces object construction,
+  breaks the array idiom); methods on `OHLCV` (couples the container to the whole
+  indicator library).
+
+### 2026-06-21 — Causal GARCH feature = expanding-fit + forward-filter (PR #179)  [accepted]
+- **Choice**: expose GARCH(1,1) conditional volatility as a feature by fitting the
+  parameters on a training prefix (optionally refit on the expanding window) and
+  **forward-filtering** σ over the series; the `min_train` warmup is `NaN`. Reuse
+  the authoritative `models.econometric_models` recursion + `estimator` likelihood;
+  the MLE fit is a thin scipy `SLSQP` wrapper.
+- **Why**: σ_t in GARCH is 𝓕ₜ₋₁-measurable, so filtering forward with past-fit
+  parameters is strictly causal — the only leak risks are the parameters (handled
+  by expanding-fit) and the warmup (NaN'd). Reusing the single recursion respects
+  the estimator no-duplication policy.
+- **Rejected alternatives**: a single in-sample fit over the whole series (peeks —
+  leaky); re-implementing the GARCH recursion in `features` (duplicates parameter
+  logic the policy forbids).
+
+### 2026-06-21 — Regime-conditioned architecture: causal detector + MoE (PR #180)  [accepted]
+- **Choice**: `RegimeMoE` routes an objective-aligned net by the **causal** regime
+  (`RegimeDetector` fit-on-train / assign-online, from a designated price/level
+  column of `X`). Default `routing="soft"` (a learned regime embedding concatenated
+  to the features through a shared trunk, differentiable end-to-end); `routing="hard"`
+  offers one expert per regime. Reuses `ObjectiveModel` for training (objective /
+  mini-batch / cost / seed).
+- **Why**: conditioning needs a *causal* regime to be backtest-honest; the
+  in-sample `detect_regimes` would leak. Soft routing trains end-to-end and shares
+  data across regimes (more sample-efficient than fully separate experts) while
+  hard routing stays available when regimes are believed truly disjoint. Composing
+  `ObjectiveModel` avoids duplicating the training loop.
+- **Rejected alternatives**: routing on in-sample `detect_regimes` (leaky); a
+  bespoke training loop (duplicates `ObjectiveModel`); hard routing as the default
+  (less sample-efficient, non-differentiable gate).
+
+### 2026-06-21 — Non-linear cost = square-root market-impact law (PR #178)  [accepted]
+- **Choice**: model convex execution cost as `fee*turnover + impact*turnover**1.5`
+  (square-root impact law) in `MarketImpactCost`, reusing the `ProportionalCost`
+  turnover definition so `exponent=1, impact=0` collapses exactly to the linear model.
+- **Why**: real impact grows super-linearly with trade size; the √-law is the
+  standard, single-parameter convex form, and making the linear case an exact
+  special case keeps it a drop-in extension of the existing cost model.
+- **Rejected alternatives**: a full order-book / market-impact simulator (out of
+  scope for a vectorized backtest); a fixed quadratic only (√-law is the empirically
+  standard default; `exponent` stays tunable).
+
 ### 2026-06-18 — Mini-batch training for ObjectiveModel (PR #173)  [accepted]
 - **Choice**: add contiguous mini-batch SGD (`batch_size`/`shuffle`) to
   `ObjectiveModel`; a `fit` now does `epochs * ceil(T/batch_size)` steps instead of

--- a/doc/dev/04-subpackages.md
+++ b/doc/dev/04-subpackages.md
@@ -31,14 +31,15 @@ modernisation).
   `annual_return`/`annual_volatility`, `drawdown`/`mdd`, `perf_*`, `roll_*`
   variants, plus one-call `summary`.
 - **`signal` / `portfolio`** — `sign`/`threshold`/`rank`/vol-target mappers +
-  `SignalPipeline`; allocation (`ERC`/`HRP`/`IVP`/`MDP`/`MVP`,
-  `rolling_allocation()`) and sizing (`kelly_fraction`/`vol_target`/
-  `transaction_cost`).
+  anti-churn `ema_smooth`/`deadband`/`min_hold` + `SignalPipeline`; allocation
+  (`ERC`/`HRP`/`IVP`/`MDP`/`MVP`, `rolling_allocation()`) and sizing
+  (`kelly_fraction`/`vol_target`/`transaction_cost`).
 - **`models`** — econometric (`ARMA`/`GARCH` family via `get_parameters`) and
   neural (`MultiLayerPerceptron`, `RollMultiLayerPerceptron`, RNN/`GRU`/`LSTM`,
   attention, `TemporalConvNet`, `Transformer`), `StackingEnsemble`; custom losses
-  under `models/loss/` (Sharpe/Sortino/Calmar/Omega/directional/hybrid); training
-  utils in `models/training.py`.
+  under `models/loss/` (Sharpe/Sortino/Calmar/Omega/directional/hybrid);
+  `ObjectiveModel` (objective-aligned training — net-of-cost, mini-batch) in
+  `models/objective.py`; training utils in `models/training.py`.
 - **`backtest` / `plot` / `strategy`** — `backtest()` + `BacktestResult` +
   `ProportionalCost`; `tearsheet`/`tearsheet_text`; `Strategy` +
   `run_walk_forward`. (The legacy live-viz objects `PlotBackTest`/

--- a/doc/dev/05-testing.md
+++ b/doc/dev/05-testing.md
@@ -4,7 +4,7 @@
 
 | Layer | Command | Catches |
 |-------|---------|---------|
-| **Unit** | `pytest` | logic, shapes, regressions (501 tests under `fynance/tests/`) |
+| **Unit** | `pytest` | logic, shapes, regressions (518 tests under `fynance/tests/`) |
 | **Doctests** | `pytest --doctest-modules` (on by default in `pyproject.toml`) | every docstring `>>>` example — they are part of the suite |
 | **Benchmarks** | `pytest-benchmark` (e.g. `test_filters_benchmark.py`) | perf regressions on hot paths |
 | **Coverage** | `pytest --cov=fynance --cov-report=term-missing` | untested branches |

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -27,16 +27,26 @@ so an agent doesn't re-investigate settled ground or assume a known stub is a bu
   hybrid) in `models/loss/`; robust-training utils (purged CV, early stopping,
   sample weighting) in `models/training.py`. All NN models conform to
   `SignalModel` (`fit`/`predict`).
+- **Objective-aligned training** (`models/objective.py`): `ObjectiveModel` trains
+  any `nn.Module` (MLP by default) **directly on a differentiable financial
+  objective** (`SharpeLoss`/`SortinoLoss`/…) — the net outputs positions, the loss
+  is computed on `positions * returns`. **Net-of-cost** (`cost=` penalizes
+  turnover so the net learns to *hold*) and **mini-batch** (`batch_size`/`shuffle`,
+  contiguous chunks — what makes it converge on long minute-resolution series).
+  Plugs into the harness via the `X` path with `signal=identity`, `y=returns`.
 - **Signal / Portfolio**: `signal/` mappers (`sign`/`threshold`/`rank`/
-  vol-targeting + `SignalPipeline`); `portfolio/` allocation (ERC/HRP/IVP/MDP/MVP)
-  + sizing (fractional Kelly, vol-targeting, transaction costs).
+  vol-targeting + **anti-churn** `ema_smooth`/`deadband`/`min_hold` +
+  `SignalPipeline`); `portfolio/` allocation (ERC/HRP/IVP/MDP/MVP) + sizing
+  (fractional Kelly, vol-targeting, transaction costs).
 - **Backtest / Plot**: vectorized `backtest()` engine → `BacktestResult`,
   `ProportionalCost`; reporting via `fynance.plot` (`tearsheet`, composable
   figures, lazy matplotlib so `import fynance` stays matplotlib-free).
 - **Research harness** (`fynance.research`, S1–S3 complete): `Experiment`
   (serializable spec + code + seed + metrics + curves), `run_experiment` (seeded,
-  cost-aware, walk-forward; no-lookahead probe), `write_report` (portable markdown +
-  tearsheet PNG + notebook), `gbm`/`regime_switching` synthetic generators,
+  cost-aware, walk-forward; no-lookahead probe; records a **provenance** block —
+  data/features/model/run config — into the spec), `write_report` (portable
+  markdown with a Provenance table + tearsheet PNG + notebook),
+  `gbm`/`regime_switching` synthetic generators,
   **guardrails** (`permutation_test`, `probabilistic_sharpe_ratio`,
   `deflated_sharpe_ratio`), comparison report (`compare_report`/`leaderboard`) and a
   persistent `Ledger` (append/load/leaderboard, `n_trials`, deflated-Sharpe vs
@@ -50,23 +60,26 @@ so an agent doesn't re-investigate settled ground or assume a known stub is a bu
 - **Numerical kernels on Numba `@njit`** — no Cython anywhere; the build is
   pure-Python (no `setup.py`, no compile step). Every kernel has a golden-value
   parity test (1e-9/1e-10) captured from the former Cython.
-- **Quality gates (all 4 enforced in CI)**: 501 unit tests + doctests on every
-  module (`--doctest-modules`), incl. property tests (kernel parity + no-lookahead);
+- **Quality gates (all 4 enforced in CI)**: 593 tests collected (unit + doctests
+  on every module via `--doctest-modules`), incl. property tests (kernel parity + no-lookahead);
   `ruff`; `interrogate` (docstring coverage ≥ 80%, currently ~93.6%); Sphinx
   build `-W`; **`mypy` clean (0 errors)**.
-- **Released**: `v2.1.1` on `master` + PyPI; `Production/Stable`. CI matrix
+- **Released**: `v2.8.0` on `master` + PyPI; `Production/Stable`. CI matrix
   3.10–3.13; release builds a pure-Python universal wheel + sdist and creates the
   GitHub Release from the CHANGELOG on tag.
 
 ## In progress / active surface
 
-- **R&D** (`models/`): empirical comparison of losses / architectures / feature
-  normalization on real out-of-sample data, market-regime conditioning, and
-  multi-series OHLCV indicators — see the roadmap (§1). Most items are blocked on
-  having a real dataset / orchestration rather than on missing code.
-- **Research harness** (roadmap §2): S1–S3 shipped (above). Optional next: a
-  Streamlit explorer over the ledger; real-data adapters + result storage live in
-  the separate private research repo, not here.
+Nothing is currently in flight (`develop` is clean). The 2.x library is
+feature-complete for its current scope; remaining open work is **library bricks**
+only — multi-series OHLCV indicators, regime-conditioned architecture, adaptive
+windows, a richer backtest, and an optional Streamlit ledger explorer. See the
+roadmap (§1–§2) and the **Deferred** section below.
+
+**Out of scope here**: strategy research on **real data** (empirical loss /
+architecture / normalization benchmarks, out-of-sample Sharpe, online regimes,
+feature selection) lives in the separate **private repo** `fynance-research`,
+which depends on fynance. This public repo stays data-agnostic and result-free.
 
 ## Known gaps / sharp edges (by design or deferred)
 
@@ -101,6 +114,20 @@ Larger axes parked for later: realistic backtesting beyond proportional cost
 (non-linear slippage / market impact), market-regime conditioning of the
 architecture, adaptive windows, and multi-series OHLCV indicators (ATR/ADX/OBV/
 VWAP) requiring a multi-series input API. Tracked in the roadmap; not bugs.
+
+## 2026-06-21 — research line shipped (v2.2 → v2.8); roadmap re-scoped
+
+Since 2.1.1 the **R&D enablement line** shipped end-to-end: the `fynance.research`
+harness (S1–S3 — `Experiment`/`run_experiment`/`write_report`, synthetic
+generators, permutation / deflated-Sharpe guardrails, `Ledger`/leaderboard,
+multi-input `X`/`y`, causal `RegimeDetector`, self-describing provenance) and the
+**objective-aligned training brick** `ObjectiveModel` (v2.5 differentiable
+objective → v2.7 net-of-cost turnover penalty + anti-churn signal mappers → v2.8
+mini-batch training that makes it converge on long series). The roadmap was
+**re-scoped**: strategy research on real data moves to the private
+`fynance-research` repo; the public roadmap keeps only data-agnostic library
+bricks (multi-series OHLCV indicators, regime-conditioned architecture, adaptive
+windows, realistic backtest, Streamlit explorer). Latest release **v2.8.0**.
 
 ## 2026-06-16 — fynance 2.1.x shipped; post-release audit clean
 

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -12,109 +12,61 @@ shipped, `03-decisions.md` for *why*. Keep it short and true.
 > Loop : `/pick-task` → `/plan` (arbre dans `plans/`) → `/execute-leaf` →
 > `/finish-task`. Release : `/release` quand `[Unreleased]` est suffisamment rempli.
 
-> **fynance 2.0 + 2.1 livrés** (v2.1.1 sur `master`/PyPI). Le refactor en couches,
-> le port Cython→Numba (build pure-Python) et la passe perf sont terminés — voir
-> `CHANGELOG.md` / `03-decisions.md`. Reste l'axe R&D ci-dessous, majoritairement
-> bloqué sur la disponibilité de données réelles plutôt que sur du code manquant.
+> **fynance 2.x livré** (v2.8.0 sur `master`/PyPI). Le refactor en couches, le port
+> Cython→Numba (build pure-Python), le harnais R&D `fynance.research` (S1–S3) et la
+> brique d'entraînement aligné-objectif (`ObjectiveModel` : objectif différentiable,
+> net de coûts, mini-batch) sont **terminés** — voir `CHANGELOG.md` / `03-decisions.md`.
+> Reste, ci-dessous, des **bricks de librairie** non bloquées par la donnée.
+
+> ⚠️ **Hors scope ici** : la recherche de stratégie sur **vraie data** (benchmarks
+> empiriques loss / architecture / normalisation, évaluation Sharpe out-of-sample,
+> régimes en ligne, sélection de features) vit dans le **repo privé**
+> `fynance-research` qui dépend de fynance. La roadmap publique ne tient que du
+> code de librairie réutilisable, data-agnostique.
 
 ---
 
-## 3. Entraînement aligné-objectif (`ObjectiveModel`)  ⭐ active
+## 2. Research harness — extension optionnelle
 
-Brique **générique** fynance débloquant la stratégie B (repo privé) : entraîner un
-réseau directement sur un **objectif risque-ajusté** (`SharpeLoss`/`SortinoLoss`…)
-plutôt qu'en MSE sur une cible. Le réseau sort des **positions** ; la loss porte sur
-`positions × returns`. Se branche sur le harnais I1 (`X`=features, `y`=returns,
-`signal=identity`).
-
-- [ ] **OBJ** `ObjectiveModel` — un `SignalModel` (`fit(X, returns)`/`predict→positions`)
-  qui entraîne un `nn.Module` quelconque (MLP par défaut, tête linéaire ;
-  TCN/LSTM passables) sur une loss financière différentiable. Reproductible (seed),
-  testé sur data synthétique à edge connu (apprend des positions à Sharpe > 0).
-
-> Les stratégies (B objectif-aligné, A multi-venue) vivent dans le repo privé.
-
-## 2. Research harness — extensions optionnelles
-
-Le harnais R&D `fynance.research` est **livré** (S1–S3) : `Experiment`,
+Le harnais `fynance.research` est **livré** (S1–S3) : `Experiment`,
 `run_experiment`, `write_report`, générateurs synthétiques, garde-fous
-(`permutation_test`, `deflated_sharpe_ratio`) et `Ledger`/`leaderboard` — piloté
-par la skill `/run-strategy`. Voir `CHANGELOG.md`. Data-agnostique et sans
-stockage de résultats (tout vers un `output_dir`). Restent optionnels :
+(`permutation_test`, `deflated_sharpe_ratio`), `Ledger`/`leaderboard`, multi-input
+`X`/`y` et provenance auto-descriptive. Reste optionnel :
 
-- [ ] Explorateur **Streamlit** au-dessus du ledger (parcourir/filtrer/comparer les
-  runs persistés) — interactif, plus tardif.
-- [ ] (**hors fynance**) adaptateurs de vraie data (dccd…) + stockage des
-  résultats : dans le **repo privé** de recherche qui dépend de fynance.
+- [ ] Explorateur **Streamlit** au-dessus du Ledger (parcourir / filtrer / comparer
+  les runs persistés) — interactif, plus tardif.
 
-## 1. R&D — Loss, architecture, données
+## 1. Bricks library (non bloquées par la donnée)
 
-Objectif : identifier empiriquement la meilleure combinaison loss / architecture / features
-pour les séries temporelles financières. Chaque sous-tâche est exploratoire :
-elle peut déboucher sur du code dans `fynance/models/` ou rester à l'état de
-notebook/rapport.
+Travail de librairie pur, testable sur data synthétique. Exploratoire : peut
+déboucher sur du code dans `fynance/` ou rester à l'état de rapport.
 
-### 1.1 Nouvelles loss functions
+### 1.1 Indicateurs OHLCV multi-séries
 
-Fait (PR #88) : `CalmarLoss`, `OmegaLoss`, `HybridLoss` (α fixe ou learnable).
+Single-série & causaux déjà présents : EMA/MACD/RSI/Bollinger/CCI/HMA, `roc`,
+`realized_volatility`, `rolling_skewness`/`kurtosis`/`autocorr`. Manquent les
+indicateurs exigeant plusieurs séries :
 
-- [ ] 🟡 **Benchmark empirique** : comparer les loss sur un jeu de données réel
-  (out-of-sample Sharpe/Sortino/Calmar/accuracy/drawdown) — nécessite des données.
-
-### 1.2 Architecture : ensemble direction + magnitude avec meta-modèle
-
-Fait (PR #93) : `StackingEnsemble` — bases direction/magnitude + méta-modèle
-entraîné sur les prédictions **out-of-fold** (leak-free).
-
-- [ ] 🟡 Comparer empiriquement vs modèle unique `SharpeLoss` (besoin de données).
-
-### 1.3 Régimes de marché
-
-Fait (PR #92) : `detect_regimes` (k-means in-sample sur vol/return, labels
-ordonnés par vol). Reste 🟡 (besoin de données / orchestration) :
-
-- [ ] Conditionner l'architecture (mixture-of-experts / embedding de régime).
-- [ ] Assignation online causale + évaluer l'impact sur le Sharpe out-of-sample.
-
-### 1.4 Features / indicateurs techniques
-
-Fait (single-série, causaux) : `roc`, `realized_volatility`, `rolling_skewness`,
-`rolling_kurtosis`, `rolling_autocorr` (PR #86) ; déjà présents : EMA/MACD/RSI/
-Bollinger/CCI/HMA. Reste **différé** (nécessite une API multi-séries OHLCV) :
-
-- [ ] **ATR / ADX / Williams %R** (High/Low) et **OBV / VWAP** (Volume) — exigent
-  des entrées OHLCV ; concevoir une API multi-séries d'abord.
+- [ ] Concevoir une **API multi-séries OHLCV** d'abord, puis **ATR / ADX /
+  Williams %R** (High/Low) et **OBV / VWAP** (Volume).
 - [ ] **GARCH(1,1) comme feature** (via `fynance.estimator`).
 
-### 1.5 Normalisation des features
+### 1.2 Architecture conditionnée par le régime
 
-Couvert : rolling z-score (`roll_standardize`/`roll_z_score`), vol-targeting
-(`sizing.vol_target`), rank-based (`scale.roll_rank`, PR #89).
+`RegimeDetector` causal (fit-on-train / assign-online) est déjà livré ; reste à
+s'en servir pour piloter l'architecture :
 
-- [ ] 🟡 Comparer empiriquement les trois approches sur le Sharpe out-of-sample
-  (nécessite des données).
+- [ ] Conditionner le modèle sur le régime — **mixture-of-experts** /
+  embedding de régime.
 
-### 1.6 Protocole d'entraînement robuste
+### 1.3 Fenêtres adaptatives (dépend de §1.2)
 
-Fait (PR #90) : purged walk-forward CV (`cross_validate(..., purge=)`),
-`exp_sample_weights` (décroissance exponentielle), `EarlyStopping` (sur métrique).
-La construction causale des features reste garantie par les property tests
-(parité + non-lookahead) — convention continue, pas de code dédié.
+- [ ] `window` variable selon le régime de volatilité.
 
-- [ ] (optionnel) down-weight basse vol dans `exp_sample_weights` (variante).
+### 1.4 Backtest réaliste
 
-### 1.7 R&D rolling — features multi-résolution et efficacité
-
-Fait (PR #91) : `multi_resolution`, `granger_causality`, `IncrementalMoments`
-(Welford O(1)) dans `features/engineering.py`.
-
-- [ ] **Fenêtres adaptatives** : `window` variable selon le régime de vol
-  (dépend de §1.3 détection de régime).
-
-### 1.8 Backtest réaliste
-
-Fait (PR #87) : `portfolio/sizing.py` (`kelly_fraction`, causal `vol_target`,
+Fait : `portfolio/sizing.py` (`kelly_fraction`, causal `vol_target`,
 `transaction_cost` turnover-based) ; métriques `percent_positive`, `tail_ratio`.
 Reste optionnel :
 
-- [ ] Slippage / impact de marché non-linéaire au-delà du coût proportionnel.
+- [ ] **Slippage / impact de marché non-linéaire** au-delà du coût proportionnel.

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -13,10 +13,12 @@ shipped, `03-decisions.md` for *why*. Keep it short and true.
 > `/finish-task`. Release : `/release` quand `[Unreleased]` est suffisamment rempli.
 
 > **fynance 2.x livré** (v2.8.0 sur `master`/PyPI). Le refactor en couches, le port
-> Cython→Numba (build pure-Python), le harnais R&D `fynance.research` (S1–S3) et la
-> brique d'entraînement aligné-objectif (`ObjectiveModel` : objectif différentiable,
-> net de coûts, mini-batch) sont **terminés** — voir `CHANGELOG.md` / `03-decisions.md`.
-> Reste, ci-dessous, des **bricks de librairie** non bloquées par la donnée.
+> Cython→Numba (build pure-Python), le harnais R&D `fynance.research` (S1–S3), la
+> brique d'entraînement aligné-objectif (`ObjectiveModel`) et les **bricks de
+> librairie** (conteneur `OHLCV` + indicateurs ATR/ADX/Williams %R/OBV/VWAP, feature
+> GARCH causale, `RegimeMoE`, fenêtres adaptatives, coût market-impact non-linéaire)
+> sont **terminés** — voir `CHANGELOG.md` / `03-decisions.md`. Il ne reste qu'un
+> item optionnel ci-dessous.
 
 > ⚠️ **Hors scope ici** : la recherche de stratégie sur **vraie data** (benchmarks
 > empiriques loss / architecture / normalisation, évaluation Sharpe out-of-sample,
@@ -35,38 +37,3 @@ Le harnais `fynance.research` est **livré** (S1–S3) : `Experiment`,
 
 - [ ] Explorateur **Streamlit** au-dessus du Ledger (parcourir / filtrer / comparer
   les runs persistés) — interactif, plus tardif.
-
-## 1. Bricks library (non bloquées par la donnée)
-
-Travail de librairie pur, testable sur data synthétique. Exploratoire : peut
-déboucher sur du code dans `fynance/` ou rester à l'état de rapport.
-
-### 1.1 Indicateurs OHLCV multi-séries
-
-Single-série & causaux déjà présents : EMA/MACD/RSI/Bollinger/CCI/HMA, `roc`,
-`realized_volatility`, `rolling_skewness`/`kurtosis`/`autocorr`. Manquent les
-indicateurs exigeant plusieurs séries :
-
-- [ ] Concevoir une **API multi-séries OHLCV** d'abord, puis **ATR / ADX /
-  Williams %R** (High/Low) et **OBV / VWAP** (Volume).
-- [ ] **GARCH(1,1) comme feature** (via `fynance.estimator`).
-
-### 1.2 Architecture conditionnée par le régime
-
-`RegimeDetector` causal (fit-on-train / assign-online) est déjà livré ; reste à
-s'en servir pour piloter l'architecture :
-
-- [ ] Conditionner le modèle sur le régime — **mixture-of-experts** /
-  embedding de régime.
-
-### 1.3 Fenêtres adaptatives (dépend de §1.2)
-
-- [ ] `window` variable selon le régime de volatilité.
-
-### 1.4 Backtest réaliste
-
-Fait : `portfolio/sizing.py` (`kelly_fraction`, causal `vol_target`,
-`transaction_cost` turnover-based) ; métriques `percent_positive`, `tail_ratio`.
-Reste optionnel :
-
-- [ ] **Slippage / impact de marché non-linéaire** au-delà du coût proportionnel.

--- a/doc/source/backtest.rst
+++ b/doc/source/backtest.rst
@@ -13,5 +13,6 @@ Vectorized backtesting engine and result. Plotting/reporting lives in
    backtest
    BacktestResult
    ProportionalCost
+   MarketImpactCost
    set_text_stats
    BacktestNeuralNet

--- a/doc/source/core.rst
+++ b/doc/source/core.rst
@@ -2,8 +2,9 @@
  Core (:mod:`fynance.core`)
 -------------------------------
 
-The spine of the library: the :class:`~fynance.core.PriceSeries` value object
-and the :mod:`typing.Protocol` seams the pipeline composes through.
+The spine of the library: the :class:`~fynance.core.PriceSeries` value object,
+the :class:`~fynance.core.OHLCV` aligned multi-series container, and the
+:mod:`typing.Protocol` seams the pipeline composes through.
 
 .. currentmodule:: fynance.core
 
@@ -11,6 +12,7 @@ and the :mod:`typing.Protocol` seams the pipeline composes through.
    :toctree: generated/
 
    PriceSeries
+   OHLCV
    DataSource
    FeatureTransform
    SignalModel

--- a/doc/source/features.engineering.rst
+++ b/doc/source/features.engineering.rst
@@ -2,7 +2,7 @@
 Feature engineering
 *******************
 
-Feature-engineering and selection research tools: multi-resolution feature stacking (:func:`~fynance.features.engineering.multi_resolution`), a Granger-causality test (:func:`~fynance.features.engineering.granger_causality`) and incremental moments (:func:`~fynance.features.engineering.IncrementalMoments`).
+Feature-engineering and selection research tools: multi-resolution feature stacking (:func:`~fynance.features.engineering.multi_resolution`), regime-adaptive windows (:func:`~fynance.features.engineering.adaptive_roll` / :func:`~fynance.features.engineering.adaptive_volatility`), a Granger-causality test (:func:`~fynance.features.engineering.granger_causality`) and incremental moments (:func:`~fynance.features.engineering.IncrementalMoments`).
 
 .. currentmodule:: fynance.features.engineering
 
@@ -10,5 +10,7 @@ Feature-engineering and selection research tools: multi-resolution feature stack
    :toctree: generated/
 
    multi_resolution
+   adaptive_roll
+   adaptive_volatility
    granger_causality
    IncrementalMoments

--- a/doc/source/features.garch.rst
+++ b/doc/source/features.garch.rst
@@ -1,0 +1,22 @@
+*****************
+GARCH volatility
+*****************
+
+Conditional volatility as a **causal** feature, from a GARCH(1,1) fit. The
+parameters are estimated by maximum likelihood on a training prefix (optionally
+refit on the expanding window every ``refit`` steps), then the conditional
+volatility :math:`\sigma_t` is forward-filtered over the whole series — which is
+causal because :math:`\sigma_t` is :math:`\mathcal F_{t-1}`-measurable. The first
+``min_train`` values (the in-sample warmup) are returned as ``NaN``.
+
+The single authoritative ARMA/GARCH implementation lives in
+:mod:`fynance.models.econometric_models` (the Numba recursion) and
+:mod:`fynance.estimator` (the likelihood); this feature only wires the thin
+fit + forward-filter on top.
+
+.. currentmodule:: fynance.features.garch
+
+.. autosummary::
+   :toctree: generated/
+
+   garch_volatility

--- a/doc/source/features.ohlcv.rst
+++ b/doc/source/features.ohlcv.rst
@@ -1,0 +1,24 @@
+****************
+OHLCV indicators
+****************
+
+Multi-series technical indicators that need more than the close — High/Low
+(:func:`~fynance.features.ohlcv.atr`, :func:`~fynance.features.ohlcv.adx`,
+:func:`~fynance.features.ohlcv.williams_r`) or Volume
+(:func:`~fynance.features.ohlcv.obv`, :func:`~fynance.features.ohlcv.vwap`).
+
+Each takes the raw aligned arrays (the primary API) **or** a single
+:class:`~fynance.core.OHLCV` container as the first argument. All are **causal**
+(the value at ``t`` uses only ``data[..t]``); the rolling loops are Numba
+``@njit`` kernels.
+
+.. currentmodule:: fynance.features.ohlcv
+
+.. autosummary::
+   :toctree: generated/
+
+   atr
+   adx
+   williams_r
+   obv
+   vwap

--- a/doc/source/features.rst
+++ b/doc/source/features.rst
@@ -55,6 +55,12 @@ moving standard deviations and rolling functions.
 
       Unsupervised regime labelling by clustering volatility/return features.
 
+   .. grid-item-card:: :octicon:`graph;1.2em;sd-mr-1` GARCH volatility
+      :link: features.garch
+      :link-type: doc
+
+      Causal GARCH(1,1) conditional volatility as a feature.
+
    .. grid-item-card:: :octicon:`arrow-switch;1.2em;sd-mr-1` Scale
       :link: features.scale
       :link-type: doc
@@ -94,5 +100,6 @@ Common parameters across modules:
    features.stats
    features.momentums
    features.regime
+   features.garch
    features.roll_functions
    features.scale

--- a/doc/source/features.rst
+++ b/doc/source/features.rst
@@ -23,6 +23,12 @@ moving standard deviations and rolling functions.
 
       Bollinger Band, CCI, Hull Moving Average, MACD, RSI.
 
+   .. grid-item-card:: :octicon:`graph;1.2em;sd-mr-1` OHLCV indicators
+      :link: features.ohlcv
+      :link-type: doc
+
+      ATR, ADX, Williams %R (High/Low) and OBV, VWAP (Volume).
+
    .. grid-item-card:: :octicon:`meter;1.2em;sd-mr-1` Statistics
       :link: features.stats
       :link-type: doc
@@ -91,6 +97,7 @@ Common parameters across modules:
    features.engineering
    features.filters
    features.indicators
+   features.ohlcv
    features.stats
    features.momentums
    features.regime

--- a/doc/source/models.neural_network.rst
+++ b/doc/source/models.neural_network.rst
@@ -43,6 +43,17 @@ high-frequency settings (use the same value as the backtest's
 Feed it through the research harness via the ``X`` path with ``y`` = returns; see
 :doc:`research_workflow`.
 
+.. rubric:: Regime-conditioned architecture
+
+:class:`~fynance.models.regime_model.RegimeMoE` conditions an objective-aligned
+network on the **causal** market regime (:class:`~fynance.features.RegimeDetector`):
+the prediction depends on which volatility regime the market is in. ``routing="soft"``
+(default) concatenates a learned regime **embedding** to the features through a
+shared trunk; ``routing="hard"`` uses one **expert** per regime. The regime label
+is produced by a detector fit on the **training** slice only and assigned online,
+from a designated positive price/level column of ``X`` (``regime_col``). It reuses
+``ObjectiveModel`` for training, so it is a ``SignalModel`` like the above.
+
 .. rubric:: Inheritance
 
 ``BaseNeuralNet`` → ``MultiLayerPerceptron``
@@ -60,3 +71,4 @@ Feed it through the research harness via the ``X`` path with ``y`` = returns; se
    _base.BaseNeuralNet
    mlp.MultiLayerPerceptron
    objective.ObjectiveModel
+   regime_model.RegimeMoE

--- a/fynance/backtest/cost.py
+++ b/fynance/backtest/cost.py
@@ -3,9 +3,10 @@
 
 """ Transaction cost models for the vectorized backtest engine.
 
-Concretizes the :class:`~fynance.core.protocols.CostModel` seam. Only the
-proportional (turnover-based) model ships in 2.0; non-linear slippage is a
-documented extension point.
+Concretizes the :class:`~fynance.core.protocols.CostModel` seam. Two models
+ship: :class:`ProportionalCost` (linear, turnover-based) and
+:class:`MarketImpactCost` (adds a convex, super-linear market-impact term — the
+square-root impact law).
 
 """
 
@@ -18,7 +19,7 @@ from numpy.typing import NDArray
 # Local packages
 from fynance.portfolio.sizing import transaction_cost
 
-__all__ = ['ProportionalCost']
+__all__ = ['ProportionalCost', 'MarketImpactCost']
 
 
 class ProportionalCost:
@@ -59,3 +60,63 @@ class ProportionalCost:
             return np.zeros(w.shape[0], dtype=np.float64)
 
         return transaction_cost(weights, fee=rate)
+
+
+class MarketImpactCost:
+    """ Non-linear market-impact cost: linear fee + convex impact term.
+
+    Charges, per step, a proportional fee plus a **super-linear** market-impact
+    term on the same turnover (the standard square-root impact law, where the
+    cost grows faster than the trade size):
+
+    .. math::
+
+        c_t = fee \\cdot \\tau_t + impact \\cdot \\tau_t^{\\,exponent}
+
+    where the turnover :math:`\\tau_t = \\sum_i |w_{t,i} - w_{t-1,i}|` is defined
+    exactly as in :class:`ProportionalCost` (the first step charges the initial
+    position). With ``exponent=1`` and ``impact=0`` it reduces to
+    :class:`ProportionalCost`. Conforms to
+    :class:`~fynance.core.protocols.CostModel`.
+
+    Parameters
+    ----------
+    fee : float
+        Proportional (linear) fee per unit traded (e.g. ``0.001`` = 10 bps).
+    impact : float
+        Coefficient of the convex impact term, in the same units as ``fee``.
+    exponent : float
+        Convexity exponent of the impact term (``> 1`` is super-linear).
+        Default ``1.5`` (the square-root impact law: cost per unit traded grows
+        as :math:`\\sqrt{\\tau}`).
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> cost = MarketImpactCost(fee=0.0, impact=0.1, exponent=2.0)
+    >>> cost(np.array([[1.0, 0.0], [0.0, 1.0], [0.0, 1.0]]))
+    array([0.1, 0.4, 0. ])
+
+    """
+
+    def __init__(
+        self,
+        fee: float = 0.0,
+        impact: float = 0.0,
+        exponent: float = 1.5,
+    ):
+        """ Store the cost rates and the impact convexity exponent. """
+        if exponent <= 0:
+
+            raise ValueError(f"exponent must be positive, got {exponent}")
+
+        self.fee = fee
+        self.impact = impact
+        self.exponent = exponent
+
+    def __call__(self, weights: NDArray) -> NDArray[np.float64]:
+        """ Return the per-step (linear + convex impact) cost of a weight book. """
+        # transaction_cost with unit fee returns the raw per-step turnover.
+        turnover = transaction_cost(weights, fee=1.0)
+
+        return self.fee * turnover + self.impact * turnover ** self.exponent

--- a/fynance/core/__init__.py
+++ b/fynance/core/__init__.py
@@ -5,12 +5,14 @@
 
 .. currentmodule:: fynance.core
 
-Exposes :class:`PriceSeries` (the central numpy-backed financial time-series)
+Exposes :class:`PriceSeries` (the central numpy-backed financial time-series),
+:class:`OHLCV` (the aligned multi-series Open/High/Low/Close/Volume container)
 and the :mod:`typing.Protocol` seams the pipeline composes through.
 
 """
 
 # Local packages
+from .ohlcv import OHLCV
 from .price_series import PriceSeries
 from .protocols import (
     Allocator,
@@ -23,6 +25,7 @@ from .protocols import (
 
 __all__ = [
     'PriceSeries',
+    'OHLCV',
     'DataSource',
     'FeatureTransform',
     'SignalModel',

--- a/fynance/core/ohlcv.py
+++ b/fynance/core/ohlcv.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Multi-series OHLCV value object.
+
+Defines :class:`OHLCV`, a thin numpy-backed container for **aligned**
+Open/High/Low/Close/Volume series. It is the multi-series counterpart of
+:class:`~fynance.core.price_series.PriceSeries` and the input contract the
+multi-series technical indicators (ATR, ADX, Williams %R, OBV, VWAP) consume.
+
+Design invariants
+-----------------
+- **Composition, never subclassing** of :class:`numpy.ndarray`: each present
+  field is stored as a contiguous, read-only ``float64`` array.
+- **Aligned & validated**: every present field shares the same length; a
+  mismatch raises at construction.
+- **Sparse by design**: ``close`` is required, the other four fields are
+  optional. Accessing an absent field raises a clear error rather than guessing.
+
+"""
+
+from __future__ import annotations
+
+# Built-in packages
+from collections.abc import Mapping
+from typing import Any
+
+# Third-party packages
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+
+__all__ = ['OHLCV']
+
+#: Canonical field order for stacking / iteration.
+_FIELDS = ('open', 'high', 'low', 'close', 'volume')
+
+
+def _coerce_1d(values: ArrayLike) -> NDArray[np.float64]:
+    """ Coerce an array-like to a read-only 1-D ``float64`` array.
+
+    Mirrors the coercion used by :class:`~fynance.core.price_series.PriceSeries`
+    (numpy / torch / polars array-likes are accepted via ``np.asarray``).
+    """
+    v = np.asarray(values, dtype=np.float64).reshape(-1).copy()
+    v.flags.writeable = False
+
+    return v
+
+
+class OHLCV:
+    """ Thin, numpy-backed container of aligned OHLCV series.
+
+    Holds up to five aligned 1-D ``float64`` arrays — ``open``, ``high``,
+    ``low``, ``close``, ``volume`` — sharing a common length. ``close`` is
+    required; the others are optional and raise an informative error when
+    accessed while absent. Composes numpy arrays rather than subclassing them.
+
+    Parameters
+    ----------
+    close : array-like
+        Close series (required, defines the length).
+    open, high, low, volume : array-like, optional
+        Other OHLCV fields; each, when given, must match ``close`` in length.
+
+    Attributes
+    ----------
+    open, high, low, close, volume : numpy.ndarray
+        Read-only ``float64`` 1-D arrays. Accessing an absent field raises
+        :class:`ValueError`.
+
+    Examples
+    --------
+    >>> bars = OHLCV(close=[10., 11., 12.], high=[10.5, 11.5, 12.5],
+    ...              low=[9.5, 10.5, 11.5])
+    >>> len(bars)
+    3
+    >>> bars.high
+    array([10.5, 11.5, 12.5])
+    >>> bars.columns
+    ('high', 'low', 'close')
+    >>> bars.volume
+    Traceback (most recent call last):
+        ...
+    ValueError: OHLCV has no 'volume' field
+
+    """
+
+    def __init__(
+        self,
+        close: ArrayLike,
+        open: ArrayLike | None = None,   # noqa: A002  (OHLCV domain name)
+        high: ArrayLike | None = None,
+        low: ArrayLike | None = None,
+        volume: ArrayLike | None = None,
+    ):
+        """ Initialize the container, coercing and length-checking each field. """
+        raw = {
+            'open': open, 'high': high, 'low': low,
+            'close': close, 'volume': volume,
+        }
+        self._data: dict[str, NDArray[np.float64]] = {}
+
+        n: int | None = None
+        for field in _FIELDS:
+            arr = raw[field]
+
+            if arr is None:
+
+                continue
+
+            coerced = _coerce_1d(arr)
+
+            if n is None:
+                n = coerced.size
+
+            elif coerced.size != n:
+
+                raise ValueError(
+                    f"field {field!r} length {coerced.size} != length {n}"
+                )
+
+            self._data[field] = coerced
+
+        self._n = int(n) if n is not None else 0
+
+    # -- Constructors -----------------------------------------------------
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, ArrayLike]) -> OHLCV:
+        """ Build from a mapping of field name -> array-like.
+
+        Only the canonical keys (``open``/``high``/``low``/``close``/``volume``)
+        are read; ``close`` must be present.
+
+        Examples
+        --------
+        >>> OHLCV.from_dict({"close": [1., 2.], "volume": [10., 20.]}).columns
+        ('close', 'volume')
+
+        """
+        if 'close' not in data:
+
+            raise ValueError("from_dict requires at least a 'close' field")
+
+        kwargs = {f: data[f] for f in _FIELDS if f in data}
+
+        return cls(**kwargs)  # type: ignore[arg-type]
+
+    @classmethod
+    def from_numpy(
+        cls,
+        array: NDArray,
+        columns: tuple[str, ...] = _FIELDS,
+    ) -> OHLCV:
+        """ Build from a 2-D array whose columns are named by ``columns``.
+
+        Parameters
+        ----------
+        array : numpy.ndarray
+            Shape ``(N, k)`` with ``k == len(columns)``.
+        columns : tuple of str
+            Field name of each column, in order. Defaults to the full
+            ``(open, high, low, close, volume)``.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> a = np.array([[9., 11., 8., 10.], [10., 12., 9., 11.]])
+        >>> OHLCV.from_numpy(a, columns=("open", "high", "low", "close")).columns
+        ('open', 'high', 'low', 'close')
+
+        """
+        a = np.asarray(array, dtype=np.float64)
+
+        if a.ndim != 2 or a.shape[1] != len(columns):
+
+            raise ValueError(
+                f"array shape {a.shape} incompatible with columns {columns}"
+            )
+
+        return cls.from_dict({c: a[:, i] for i, c in enumerate(columns)})
+
+    @classmethod
+    def from_polars(cls, data: Any) -> OHLCV:
+        """ Build from a polars DataFrame (columns matched case-insensitively).
+
+        Any column whose lower-cased name is one of ``open``/``high``/``low``/
+        ``close``/``volume`` is mapped to the matching field.
+        """
+        import polars as pl
+
+        if not isinstance(data, pl.DataFrame):
+
+            raise TypeError(f"unsupported polars input: {type(data)!r}")
+
+        mapping = {}
+        for col in data.columns:
+            key = col.lower()
+
+            if key in _FIELDS:
+                mapping[key] = data[col].to_numpy()
+
+        return cls.from_dict(mapping)
+
+    # -- Field access -----------------------------------------------------
+
+    def _get(self, field: str) -> NDArray[np.float64]:
+        """ Return a present field or raise an informative error. """
+        try:
+
+            return self._data[field]
+
+        except KeyError:
+
+            raise ValueError(f"OHLCV has no {field!r} field") from None
+
+    @property
+    def open(self) -> NDArray[np.float64]:    # noqa: A003
+        """ Open series (raises if absent). """
+        return self._get('open')
+
+    @property
+    def high(self) -> NDArray[np.float64]:
+        """ High series (raises if absent). """
+        return self._get('high')
+
+    @property
+    def low(self) -> NDArray[np.float64]:
+        """ Low series (raises if absent). """
+        return self._get('low')
+
+    @property
+    def close(self) -> NDArray[np.float64]:
+        """ Close series (always present). """
+        return self._get('close')
+
+    @property
+    def volume(self) -> NDArray[np.float64]:
+        """ Volume series (raises if absent). """
+        return self._get('volume')
+
+    @property
+    def columns(self) -> tuple[str, ...]:
+        """ Present fields, in canonical OHLCV order. """
+        return tuple(f for f in _FIELDS if f in self._data)
+
+    def has(self, field: str) -> bool:
+        """ Whether ``field`` is present. """
+        return field in self._data
+
+    # -- Bridges ----------------------------------------------------------
+
+    def to_numpy(self) -> NDArray[np.float64]:
+        """ Column-stack the present fields into a ``(N, k)`` array.
+
+        Columns follow :attr:`columns` (canonical OHLCV order).
+
+        Examples
+        --------
+        >>> OHLCV(close=[1., 2., 3.], high=[2., 3., 4.]).to_numpy().shape
+        (3, 2)
+
+        """
+        if not self._data:
+
+            return np.empty((0, 0), dtype=np.float64)
+
+        return np.column_stack([self._data[f] for f in self.columns])
+
+    # -- Dunders ----------------------------------------------------------
+
+    def __len__(self) -> int:
+        """ Number of bars. """
+        return self._n
+
+    def __eq__(self, other: object) -> bool:
+        """ Equality by present fields and their values. """
+        if not isinstance(other, OHLCV):
+
+            return NotImplemented
+
+        if self.columns != other.columns:
+
+            return False
+
+        return all(
+            np.array_equal(self._data[f], other._data[f], equal_nan=True)
+            for f in self.columns
+        )
+
+    __hash__ = None  # type: ignore[assignment]
+
+    def __repr__(self) -> str:
+        """ Short representation: length and present fields. """
+        return f"OHLCV(len={self._n}, fields={list(self.columns)})"

--- a/fynance/features/__init__.py
+++ b/fynance/features/__init__.py
@@ -31,6 +31,7 @@ from . import (
     indicators,
     momentums,
     money_management,
+    ohlcv,
     regime,
     roll_functions,
     scale,
@@ -41,6 +42,7 @@ from .filters import *
 from .indicators import *
 from .momentums import *
 from .money_management import *
+from .ohlcv import *
 from .regime import *
 from .roll_functions import *
 from .scale import *
@@ -52,6 +54,7 @@ __all__ += filters.__all__
 __all__ += momentums.__all__
 __all__ += indicators.__all__
 __all__ += money_management.__all__
+__all__ += ohlcv.__all__
 __all__ += roll_functions.__all__
 __all__ += scale.__all__
 __all__ += stats.__all__

--- a/fynance/features/__init__.py
+++ b/fynance/features/__init__.py
@@ -28,6 +28,7 @@ features.
 from . import (
     engineering,
     filters,
+    garch,
     indicators,
     momentums,
     money_management,
@@ -38,6 +39,7 @@ from . import (
 )
 from .engineering import *
 from .filters import *
+from .garch import *
 from .indicators import *
 from .momentums import *
 from .money_management import *
@@ -49,6 +51,7 @@ from .stats import *
 __all__ = engineering.__all__
 __all__ += regime.__all__
 __all__ += filters.__all__
+__all__ += garch.__all__
 __all__ += momentums.__all__
 __all__ += indicators.__all__
 __all__ += money_management.__all__

--- a/fynance/features/engineering.py
+++ b/fynance/features/engineering.py
@@ -10,14 +10,21 @@ Granger-causality test for filtering candidate features.
 from __future__ import annotations
 
 # Built-in packages
-from typing import Callable
+from collections.abc import Mapping
+from typing import Any, Callable
 
 # Third-party packages
 import numpy as np
 from numpy.typing import NDArray
 from scipy import stats as _sp_stats
 
-__all__ = ['IncrementalMoments', 'granger_causality', 'multi_resolution']
+# Local packages
+from fynance.features.indicators import realized_volatility
+
+__all__ = [
+    'IncrementalMoments', 'adaptive_roll', 'adaptive_volatility',
+    'granger_causality', 'multi_resolution',
+]
 
 
 def multi_resolution(
@@ -154,3 +161,119 @@ class IncrementalMoments:
     def std(self) -> float:
         """ Population standard deviation. """
         return self.var ** 0.5
+
+
+def adaptive_roll(
+    X: NDArray,
+    func: Callable[..., NDArray],
+    windows: Mapping[int, int],
+    regimes: NDArray,
+    **kwargs: Any,
+) -> NDArray:
+    r""" Apply a window-based feature with a **regime-dependent** window.
+
+    At each bar ``t`` the output is ``func(X, windows[regimes[t]])[t]`` — a short
+    window in one regime, a longer one in another. Causal as long as both inputs
+    are: ``func`` must be a trailing-window feature (value at ``t`` uses
+    ``X[..t]``) and ``regimes`` a causal label (e.g. from
+    :class:`~fynance.features.RegimeDetector`, fit-on-train / assign-online).
+
+    Parameters
+    ----------
+    X : np.ndarray
+        One-dimensional input series.
+    func : callable
+        A trailing-window feature taking ``(X, w, **kwargs)`` and returning an
+        array aligned with ``X`` (e.g.
+        :func:`~fynance.features.momentums.sma`,
+        :func:`~fynance.features.indicators.realized_volatility`).
+    windows : mapping of int to int
+        Window size for each regime label. Must cover every label present in
+        ``regimes``.
+    regimes : np.ndarray
+        Causal integer regime label per bar, aligned with ``X``.
+    **kwargs
+        Extra keyword arguments forwarded to ``func``.
+
+    Returns
+    -------
+    np.ndarray
+        The regime-adaptive feature, shape ``(len(X),)``.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from fynance.features.momentums import sma
+    >>> X = np.arange(1., 7.)
+    >>> regimes = np.array([0, 0, 0, 1, 1, 1])
+    >>> adaptive_roll(X, sma, {0: 1, 1: 3}, regimes)
+    array([1., 2., 3., 3., 4., 5.])
+
+    """
+    x = np.asarray(X, dtype=np.float64).reshape(-1)
+    reg = np.asarray(regimes).reshape(-1)
+
+    if reg.size != x.size:
+
+        raise ValueError(
+            f"regimes length {reg.size} != X length {x.size}"
+        )
+
+    present = set(int(r) for r in np.unique(reg))
+    missing = present - set(windows)
+
+    if missing:
+
+        raise ValueError(f"windows has no entry for regime(s) {sorted(missing)}")
+
+    # Compute the feature once per distinct window, then select per bar.
+    out = np.empty(x.size, dtype=np.float64)
+    for w in set(windows.values()):
+        col = np.asarray(func(x, w, **kwargs)).reshape(-1)
+        labels_with_w = [lab for lab, win in windows.items() if win == w]
+        mask = np.isin(reg, labels_with_w)
+        out[mask] = col[mask]
+
+    return out
+
+
+def adaptive_volatility(
+    X: NDArray,
+    windows: Mapping[int, int],
+    regimes: NDArray,
+    period: int = 252,
+) -> NDArray:
+    r""" Regime-adaptive realized volatility (worked example of :func:`adaptive_roll`).
+
+    Uses a short volatility window in some regimes and a longer one in others, so
+    the estimate reacts fast in turbulent regimes and stays smooth in calm ones.
+
+    Parameters
+    ----------
+    X : np.ndarray
+        One-dimensional price/level series.
+    windows : mapping of int to int
+        Volatility window for each regime label.
+    regimes : np.ndarray
+        Causal integer regime label per bar, aligned with ``X``.
+    period : int, optional
+        Annualization factor. Default 252.
+
+    Returns
+    -------
+    np.ndarray
+        Regime-adaptive annualized volatility, shape ``(len(X),)``.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> rng = np.random.default_rng(0)
+    >>> X = 100 * np.exp(np.cumsum(rng.standard_normal(100) * 0.01))
+    >>> regimes = (np.arange(100) // 50)   # two regimes
+    >>> adaptive_volatility(X, {0: 5, 1: 20}, regimes).shape
+    (100,)
+
+    """
+    return adaptive_roll(
+        X, realized_volatility, windows, regimes, period=period,
+    )

--- a/fynance/features/garch.py
+++ b/fynance/features/garch.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" GARCH(1,1) conditional volatility as a causal feature.
+
+Exposes :func:`garch_volatility` — a strictly **causal** conditional-volatility
+series derived from a GARCH(1,1) fit. The single authoritative ARMA/GARCH
+implementation lives in :mod:`fynance.models.econometric_models` (the Numba
+recursion) and :mod:`fynance.estimator` (the likelihood); this module only adds
+the thin maximum-likelihood fit + forward-filter scheme, it does **not**
+re-derive the recursion or the parameter layout.
+
+Causality
+---------
+Two things could leak the future into the feature:
+
+- the **parameters** — fit once on a training prefix (expanding-fit), optionally
+  refit on the expanding window every ``refit`` steps; never on the whole series;
+- the **filtered volatility** — :math:`\\sigma_t` in GARCH is
+  :math:`\\mathcal F_{t-1}`-measurable (it depends on
+  :math:`u_{t-1}, \\sigma_{t-1}`, not on :math:`u_t`), so running the recursion
+  forward is causal given fixed parameters.
+
+The first ``min_train`` points (the warmup whose parameters would be in-sample)
+are returned as ``NaN``.
+
+"""
+
+from __future__ import annotations
+
+# Third-party packages
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+from scipy.optimize import minimize
+
+# Local packages
+from fynance.estimator.estimator import target_function
+from fynance.models.econometric_models import ARMA_GARCH, get_parameters
+
+__all__ = ['garch_volatility']
+
+# GARCH(1,1) model order: zero-mean-constant ARMA part, GARCH(1, 1) variance.
+_P, _Q, _AR, _MA = 1, 1, 0, 0
+
+
+def _fit_garch11(y: NDArray[np.float64]) -> NDArray[np.float64]:
+    """ Maximum-likelihood fit of a GARCH(1,1) on ``y``.
+
+    Minimizes the negative log-likelihood (:func:`fynance.estimator.estimator.\
+target_function`) over the flat parameter vector ``[c, omega, alpha, beta]``,
+    under positivity and stationarity (``alpha + beta < 1``) constraints.
+
+    Returns
+    -------
+    numpy.ndarray
+        The fitted ``[c, omega, alpha, beta]`` vector.
+
+    """
+    var = float(np.var(y))
+
+    if var <= 0.0:
+        var = 1e-8
+
+    x0 = np.array([float(np.mean(y)), var * 0.1, 0.05, 0.90])
+    bounds = [(None, None), (1e-12, None), (0.0, 1.0), (0.0, 1.0)]
+    # Stationarity: alpha + beta <= 1 - eps.
+    constraints = ({
+        'type': 'ineq',
+        'fun': lambda p: 0.999 - p[2] - p[3],
+    },)
+
+    res = minimize(
+        target_function,
+        x0,
+        args=(y, _AR, _MA, _Q, _P, True, 'garch'),
+        method='SLSQP',
+        bounds=bounds,
+        constraints=constraints,
+        options={'maxiter': 200, 'ftol': 1e-8},
+    )
+
+    return np.asarray(res.x, dtype=np.float64)
+
+
+def _filter_sigma(
+    y: NDArray[np.float64], params: NDArray[np.float64],
+) -> NDArray[np.float64]:
+    """ Forward-filter the conditional volatility on ``y`` with ``params``. """
+    phi, theta, alpha, beta, c, omega = get_parameters(
+        params, _AR, _MA, _Q, _P, cons=True,
+    )
+    _, h = ARMA_GARCH(
+        y, phi, theta, alpha, beta, c, omega, _AR, _MA, _Q, _P,
+    )
+
+    return np.asarray(h, dtype=np.float64)
+
+
+def garch_volatility(
+    returns: ArrayLike,
+    refit: int | None = None,
+    min_train: int = 250,
+) -> NDArray[np.float64]:
+    r""" Causal GARCH(1,1) conditional-volatility feature.
+
+    Fits a GARCH(1,1) on a training prefix and forward-filters the conditional
+    volatility :math:`\sigma_t` over the whole series. The first ``min_train``
+    values are ``NaN`` (the warmup whose parameters would be in-sample).
+
+    Parameters
+    ----------
+    returns : array-like
+        One-dimensional return series.
+    refit : int, optional
+        Refit the parameters on the expanding window every ``refit`` steps
+        (each block uses parameters fit strictly on its own past). If ``None``
+        (default), the parameters are fit once on ``returns[:min_train]``.
+    min_train : int, optional
+        Length of the initial training prefix; values before it are ``NaN``.
+        Default 250.
+
+    Returns
+    -------
+    numpy.ndarray
+        Conditional volatility :math:`\sigma_t`, same length as ``returns``,
+        ``NaN`` on the warmup.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> rng = np.random.default_rng(0)
+    >>> r = rng.standard_normal(400) * 0.01
+    >>> sigma = garch_volatility(r, min_train=200)
+    >>> sigma.shape
+    (400,)
+    >>> bool(np.all(np.isnan(sigma[:200])))
+    True
+    >>> bool(np.all(sigma[200:] >= 0))
+    True
+
+    """
+    r = np.asarray(returns, dtype=np.float64).reshape(-1)
+    n = r.size
+
+    if min_train < 2 or min_train >= n:
+
+        raise ValueError(
+            f"min_train must be in [2, len(returns)), got {min_train}"
+        )
+
+    sigma = np.full(n, np.nan, dtype=np.float64)
+
+    # Block starts: where each parameter regime takes effect.
+    if refit is None or refit <= 0:
+        starts = [min_train]
+
+    else:
+        starts = list(range(min_train, n, refit))
+
+    bounds = starts + [n]
+    for k, start in enumerate(starts):
+        end = bounds[k + 1]
+        params = _fit_garch11(r[:start])
+        # sigma_t depends on the past only, so filtering the full series with
+        # these (past-fit) params and slicing [start:end] stays causal.
+        h = _filter_sigma(r, params)
+        sigma[start:end] = h[start:end]
+
+    return sigma

--- a/fynance/features/ohlcv.py
+++ b/fynance/features/ohlcv.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Multi-series OHLCV technical indicators.
+
+Indicators that need more than a single price series — High/Low (``atr``,
+``adx``, ``williams_r``) or Volume (``obv``, ``vwap``). Each takes the raw
+aligned arrays (the primary, numpy-idiomatic API) and also accepts an
+:class:`~fynance.core.OHLCV` container as the first argument.
+
+All indicators are **causal**: the value at ``t`` uses only ``data[..t]``.
+Rolling loops are Numba ``@njit`` kernels living in this module.
+
+"""
+
+from __future__ import annotations
+
+# Third-party packages
+import numpy as np
+from numba import njit
+from numpy.typing import NDArray
+
+# Local packages
+from fynance.core.ohlcv import OHLCV
+
+__all__ = ['adx', 'atr', 'obv', 'vwap', 'williams_r']
+
+
+def _as1d(x) -> NDArray[np.float64]:
+    """ Coerce an array-like to a contiguous 1-D ``float64`` array. """
+    return np.ascontiguousarray(np.asarray(x, dtype=np.float64).reshape(-1))
+
+
+def _unpack_hlc(high, low, close):
+    """ Resolve (high, low, close) from raw arrays or a leading ``OHLCV``. """
+    if isinstance(high, OHLCV):
+
+        return high.high, high.low, high.close
+
+    if low is None or close is None:
+
+        raise ValueError("provide high, low and close (or a single OHLCV)")
+
+    return _as1d(high), _as1d(low), _as1d(close)
+
+
+# =========================================================================== #
+#                              Numba kernels                                  #
+# =========================================================================== #
+
+
+@njit(cache=True)
+def _atr_kernel(high, low, close, w):
+    """ True range + Wilder-smoothed ATR (causal). """
+    n = high.size
+    tr = np.empty(n)
+    tr[0] = high[0] - low[0]
+    for t in range(1, n):
+        hl = high[t] - low[t]
+        hc = abs(high[t] - close[t - 1])
+        lc = abs(low[t] - close[t - 1])
+        tr[t] = max(hl, max(hc, lc))
+
+    atr = np.empty(n)
+    atr[0] = tr[0]
+    for t in range(1, n):
+        atr[t] = (atr[t - 1] * (w - 1) + tr[t]) / w
+
+    return atr
+
+
+@njit(cache=True)
+def _adx_kernel(high, low, close, w):
+    """ Wilder ADX (causal): TR/+DM/-DM -> +DI/-DI -> DX -> ADX. """
+    n = high.size
+    tr = np.empty(n)
+    pdm = np.empty(n)
+    ndm = np.empty(n)
+    tr[0] = high[0] - low[0]
+    pdm[0] = 0.0
+    ndm[0] = 0.0
+    for t in range(1, n):
+        up = high[t] - high[t - 1]
+        dn = low[t - 1] - low[t]
+        pdm[t] = up if (up > dn and up > 0.0) else 0.0
+        ndm[t] = dn if (dn > up and dn > 0.0) else 0.0
+        hl = high[t] - low[t]
+        hc = abs(high[t] - close[t - 1])
+        lc = abs(low[t] - close[t - 1])
+        tr[t] = max(hl, max(hc, lc))
+
+    str_ = np.empty(n)
+    spdm = np.empty(n)
+    sndm = np.empty(n)
+    str_[0] = tr[0]
+    spdm[0] = pdm[0]
+    sndm[0] = ndm[0]
+    for t in range(1, n):
+        str_[t] = (str_[t - 1] * (w - 1) + tr[t]) / w
+        spdm[t] = (spdm[t - 1] * (w - 1) + pdm[t]) / w
+        sndm[t] = (sndm[t - 1] * (w - 1) + ndm[t]) / w
+
+    dx = np.empty(n)
+    for t in range(n):
+        denom = str_[t] if str_[t] != 0.0 else 1e-12
+        pdi = 100.0 * spdm[t] / denom
+        ndi = 100.0 * sndm[t] / denom
+        s = pdi + ndi
+        dx[t] = 100.0 * abs(pdi - ndi) / (s if s != 0.0 else 1e-12)
+
+    adx = np.empty(n)
+    adx[0] = dx[0]
+    for t in range(1, n):
+        adx[t] = (adx[t - 1] * (w - 1) + dx[t]) / w
+
+    return adx
+
+
+@njit(cache=True)
+def _williams_kernel(high, low, close, w):
+    """ Williams %R over a trailing window (causal). """
+    n = high.size
+    out = np.empty(n)
+    for t in range(n):
+        a = 0 if t - w + 1 < 0 else t - w + 1
+        hh = high[a]
+        ll = low[a]
+        for j in range(a + 1, t + 1):
+            if high[j] > hh:
+                hh = high[j]
+            if low[j] < ll:
+                ll = low[j]
+        denom = hh - ll
+        out[t] = 0.0 if denom == 0.0 else -100.0 * (hh - close[t]) / denom
+
+    return out
+
+
+@njit(cache=True)
+def _obv_kernel(close, volume):
+    """ On-Balance Volume (causal cumulative). """
+    n = close.size
+    out = np.empty(n)
+    out[0] = 0.0
+    for t in range(1, n):
+        if close[t] > close[t - 1]:
+            out[t] = out[t - 1] + volume[t]
+        elif close[t] < close[t - 1]:
+            out[t] = out[t - 1] - volume[t]
+        else:
+            out[t] = out[t - 1]
+
+    return out
+
+
+@njit(cache=True)
+def _vwap_kernel(tp, volume, w):
+    """ VWAP of typical price ``tp`` (cumulative if ``w <= 0``, else rolling). """
+    n = tp.size
+    out = np.empty(n)
+    if w <= 0:
+        cpv = 0.0
+        cv = 0.0
+        for t in range(n):
+            cpv += tp[t] * volume[t]
+            cv += volume[t]
+            out[t] = cpv / cv if cv != 0.0 else np.nan
+
+    else:
+        for t in range(n):
+            a = 0 if t - w + 1 < 0 else t - w + 1
+            spv = 0.0
+            sv = 0.0
+            for j in range(a, t + 1):
+                spv += tp[j] * volume[j]
+                sv += volume[j]
+            out[t] = spv / sv if sv != 0.0 else np.nan
+
+    return out
+
+
+# =========================================================================== #
+#                            Public indicators                                #
+# =========================================================================== #
+
+
+def atr(high, low=None, close=None, w: int = 14) -> NDArray[np.float64]:
+    r""" Average True Range (Wilder), causal.
+
+    The true range :math:`TR_t = \max(H_t - L_t, |H_t - C_{t-1}|, |L_t - C_{t-1}|)`
+    smoothed by a Wilder moving average of window ``w``.
+
+    Parameters
+    ----------
+    high, low, close : array-like, or high = OHLCV
+        High/Low/Close series, or a single :class:`~fynance.core.OHLCV`.
+    w : int, optional
+        Smoothing window. Default 14.
+
+    Returns
+    -------
+    numpy.ndarray
+        ATR series, ``>= 0``, aligned with the input.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> h = np.array([10., 11., 12., 11.5])
+    >>> low = np.array([9., 9.5, 11., 10.5])
+    >>> c = np.array([9.5, 10.5, 11.5, 11.])
+    >>> atr(h, low, c, w=2).round(4)
+    array([1.    , 1.25  , 1.375 , 1.1875])
+
+    """
+    high, low, close = _unpack_hlc(high, low, close)
+
+    return _atr_kernel(high, low, close, int(w))
+
+
+def adx(high, low=None, close=None, w: int = 14) -> NDArray[np.float64]:
+    r""" Average Directional Index (Wilder), causal.
+
+    Trend-strength oscillator built from the smoothed directional movement
+    (+DI / -DI) and their normalized spread (DX), itself Wilder-smoothed.
+
+    Parameters
+    ----------
+    high, low, close : array-like, or high = OHLCV
+        High/Low/Close series, or a single :class:`~fynance.core.OHLCV`.
+    w : int, optional
+        Smoothing window. Default 14.
+
+    Returns
+    -------
+    numpy.ndarray
+        ADX series in ``[0, 100]``, aligned with the input.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> rng = np.random.default_rng(0)
+    >>> n = 60
+    >>> h = 100 + np.cumsum(np.abs(rng.standard_normal(n)))
+    >>> low = h - np.abs(rng.standard_normal(n))
+    >>> c = (h + low) / 2
+    >>> out = adx(h, low, c, w=14)
+    >>> bool(np.all((out >= 0) & (out <= 100)))
+    True
+
+    """
+    high, low, close = _unpack_hlc(high, low, close)
+
+    return _adx_kernel(high, low, close, int(w))
+
+
+def williams_r(high, low=None, close=None, w: int = 14) -> NDArray[np.float64]:
+    r""" Williams %R over a trailing window, causal.
+
+    :math:`\%R_t = -100 \cdot (HH_t - C_t) / (HH_t - LL_t)`, where ``HH``/``LL``
+    are the rolling high/low of window ``w``. Bounded in ``[-100, 0]``.
+
+    Parameters
+    ----------
+    high, low, close : array-like, or high = OHLCV
+        High/Low/Close series, or a single :class:`~fynance.core.OHLCV`.
+    w : int, optional
+        Look-back window. Default 14.
+
+    Returns
+    -------
+    numpy.ndarray
+        Williams %R in ``[-100, 0]``, aligned with the input.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> h = np.array([10., 11., 12., 11.])
+    >>> low = np.array([9., 9., 10., 10.])
+    >>> c = np.array([9.5, 10.5, 11.5, 10.5])
+    >>> williams_r(h, low, c, w=2).round(2)
+    array([-50.  , -25.  , -16.67, -75.  ])
+
+    """
+    high, low, close = _unpack_hlc(high, low, close)
+
+    return _williams_kernel(high, low, close, int(w))
+
+
+def obv(close, volume=None) -> NDArray[np.float64]:
+    r""" On-Balance Volume, causal.
+
+    Signed cumulative volume: add ``volume`` on up-closes, subtract on
+    down-closes, carry on flat closes (starts at ``0``).
+
+    Parameters
+    ----------
+    close : array-like, or OHLCV
+        Close series, or a single :class:`~fynance.core.OHLCV`.
+    volume : array-like, optional
+        Volume series (required unless ``close`` is an ``OHLCV``).
+
+    Returns
+    -------
+    numpy.ndarray
+        OBV series, aligned with the input.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> c = np.array([10., 11., 10.5, 10.5, 12.])
+    >>> v = np.array([100., 150., 120., 80., 200.])
+    >>> obv(c, v)
+    array([  0., 150.,  30.,  30., 230.])
+
+    """
+    if isinstance(close, OHLCV):
+        close, volume = close.close, close.volume
+
+    elif volume is None:
+
+        raise ValueError("provide close and volume (or a single OHLCV)")
+
+    else:
+        close, volume = _as1d(close), _as1d(volume)
+
+    return _obv_kernel(close, volume)
+
+
+def vwap(high, low=None, close=None, volume=None,
+         w: int | None = None) -> NDArray[np.float64]:
+    r""" Volume-Weighted Average Price of the typical price, causal.
+
+    Typical price :math:`TP_t = (H_t + L_t + C_t) / 3`, weighted by volume.
+    With ``w=None`` it is the **anchored** (cumulative) VWAP; with an integer
+    ``w`` it is a rolling VWAP over the trailing window.
+
+    Parameters
+    ----------
+    high, low, close, volume : array-like, or high = OHLCV
+        OHLCV series, or a single :class:`~fynance.core.OHLCV` (volume required).
+    w : int, optional
+        Rolling window; ``None`` (default) = cumulative.
+
+    Returns
+    -------
+    numpy.ndarray
+        VWAP series, aligned with the input.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> h = np.array([10., 12., 11.])
+    >>> low = np.array([8., 10., 9.])
+    >>> c = np.array([9., 11., 10.])
+    >>> v = np.array([100., 100., 100.])
+    >>> vwap(h, low, c, v).round(4)
+    array([ 9., 10., 10.])
+
+    """
+    if isinstance(high, OHLCV):
+        bars = high
+        high, low, close, volume = bars.high, bars.low, bars.close, bars.volume
+
+    elif low is None or close is None or volume is None:
+
+        raise ValueError(
+            "provide high, low, close and volume (or a single OHLCV)"
+        )
+
+    else:
+        high, low = _as1d(high), _as1d(low)
+        close, volume = _as1d(close), _as1d(volume)
+
+    tp = (high + low + close) / 3.0
+    win = 0 if w is None else int(w)
+
+    return _vwap_kernel(tp, volume, win)

--- a/fynance/models/__init__.py
+++ b/fynance/models/__init__.py
@@ -56,6 +56,7 @@ from .loss import (
 from .lstm import LongShortTermMemory, LSTMCell
 from .mlp import MultiLayerPerceptron
 from .objective import ObjectiveModel
+from .regime_model import RegimeMoE
 from .rnn import RecurrentNeuralNetwork
 from .rolling import CVResult, RollMultiLayerPerceptron, _RollingBasis
 from .tcn import TemporalConvNet
@@ -82,6 +83,8 @@ __all__ = [
     'MultiLayerPerceptron',
     # objective-aligned training
     'ObjectiveModel',
+    # regime-conditioned architecture
+    'RegimeMoE',
     # rnn / gru / lstm
     'GRUCell',
     'GatedRecurrentUnit',

--- a/fynance/models/regime_model.py
+++ b/fynance/models/regime_model.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Regime-conditioned architecture (mixture-of-experts).
+
+:class:`RegimeMoE` conditions an objective-aligned network on the **causal**
+market regime (:class:`~fynance.features.RegimeDetector`): the network's
+prediction depends not only on the features but on which volatility regime the
+market is currently in. Two routings are available — a learned **regime
+embedding** concatenated to the features (``routing="soft"``, the differentiable
+default) and one **expert head per regime** (``routing="hard"``).
+
+It conforms to the ``SignalModel`` protocol (``fit``/``predict``) and reuses
+:class:`~fynance.models.ObjectiveModel` for the training loop (differentiable
+financial objective, mini-batching, net-of-cost penalty, seeding), so it plugs
+into the harness via the precomputed ``X`` path exactly like ``ObjectiveModel``.
+
+Causality
+---------
+The regime label is produced by a :class:`RegimeDetector` **fit on the training
+slice only** and assigned **online** (nearest training centroid), so no future
+information leaks into a label. The regime is derived from one designated column
+of ``X`` (``regime_col``), which must be a **positive price / level** series (the
+detector clusters its trailing volatility and mean return).
+
+"""
+
+# Built-in
+from __future__ import annotations
+
+from typing import Any
+
+# Third-party
+import numpy as np
+import torch
+from numpy.typing import NDArray
+
+# Local
+from fynance.features.regime import RegimeDetector
+from fynance.models.objective import ObjectiveModel
+
+__all__ = ['RegimeMoE']
+
+
+def _mlp(n_in: int, hidden: tuple[int, ...]) -> torch.nn.Module:
+    """ Feed-forward trunk with ReLU hidden layers and a linear (1-d) head. """
+    mods: list[torch.nn.Module] = []
+    dim = n_in
+    for h in hidden:
+        mods += [torch.nn.Linear(dim, h), torch.nn.ReLU()]
+        dim = h
+    mods += [torch.nn.Linear(dim, 1)]
+
+    return torch.nn.Sequential(*mods)
+
+
+class _RegimeMoENet(torch.nn.Module):
+    """ Net taking augmented input ``[features | regime_label]`` -> ``(T, 1)``.
+
+    The last input column carries the integer regime label; the rest are the
+    features. ``soft`` routing embeds the regime and concatenates it to the
+    features through a shared trunk; ``hard`` routing runs one expert MLP per
+    regime, selected per row.
+    """
+
+    def __init__(
+        self,
+        n_features: int,
+        n_regimes: int,
+        emb_dim: int,
+        hidden: tuple[int, ...],
+        routing: str,
+    ):
+        super().__init__()
+        self.n_features = n_features
+        self.routing = routing
+
+        if routing == 'soft':
+            self.emb = torch.nn.Embedding(n_regimes, emb_dim)
+            self.trunk = _mlp(n_features + emb_dim, hidden)
+
+        elif routing == 'hard':
+            self.experts = torch.nn.ModuleList(
+                [_mlp(n_features, hidden) for _ in range(n_regimes)]
+            )
+
+        else:
+
+            raise ValueError(f"unknown routing: {routing!r}")
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """ Split the regime label off the last column and route accordingly. """
+        feats = x[:, :self.n_features]
+        regime = x[:, self.n_features].long()
+
+        if self.routing == 'soft':
+            emb = self.emb(regime)
+
+            return self.trunk(torch.cat([feats, emb], dim=1))
+
+        out = torch.zeros(feats.shape[0], 1, dtype=feats.dtype)
+        for k, expert in enumerate(self.experts):
+            mask = regime == k
+
+            if bool(mask.any()):
+                out[mask] = expert(feats[mask])
+
+        return out
+
+
+class RegimeMoE:
+    """ Regime-conditioned mixture-of-experts ``SignalModel``.
+
+    Parameters
+    ----------
+    n_regimes : int
+        Number of market regimes (clusters). Default 3.
+    regime_col : int
+        Index of the column in ``X`` used as the **positive price / level**
+        series the :class:`RegimeDetector` clusters on. Default 0.
+    regime_w : int
+        Rolling window for the regime features. Default 21.
+    regime_period : int
+        Annualization factor for the regime volatility feature. Default 252.
+    routing : {"soft", "hard"}
+        ``soft`` (default) concatenates a learned regime **embedding** to the
+        features through a shared trunk (differentiable end-to-end); ``hard``
+        uses one **expert** MLP per regime, selected by the regime label.
+    emb_dim : int
+        Embedding size for ``soft`` routing (ignored for ``hard``). Default 4.
+    hidden : tuple of int
+        Hidden layer sizes of the trunk / experts. Default ``(16, 8)``.
+    loss : BaseLoss, optional
+        Differentiable financial loss (default :class:`SharpeLoss`).
+    lr, epochs, batch_size, cost, seed
+        Forwarded to :class:`~fynance.models.ObjectiveModel`.
+
+    Notes
+    -----
+    Reproducible: the net is seeded (``torch.manual_seed``) **before** it is
+    built, then handed to :class:`ObjectiveModel` (which would otherwise skip
+    seeding a caller-provided net).
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> rng = np.random.default_rng(0)
+    >>> level = 100 * np.exp(np.cumsum(rng.standard_normal(400) * 0.01))
+    >>> sig = rng.choice([-1.0, 1.0], size=400)
+    >>> X = np.column_stack([level, sig]).astype(np.float32)
+    >>> y = (sig * 0.01).astype(np.float32)
+    >>> model = RegimeMoE(n_regimes=2, regime_w=10, epochs=5).fit(X, y)
+    >>> model.predict(X).shape
+    (400, 1)
+
+    """
+
+    def __init__(
+        self,
+        n_regimes: int = 3,
+        regime_col: int = 0,
+        regime_w: int = 21,
+        regime_period: int = 252,
+        routing: str = 'soft',
+        emb_dim: int = 4,
+        hidden: tuple[int, ...] = (16, 8),
+        loss: Any = None,
+        lr: float = 1e-3,
+        epochs: int = 80,
+        batch_size: int | None = None,
+        cost: float = 0.0,
+        seed: int = 0,
+    ):
+        self.n_regimes = n_regimes
+        self.regime_col = regime_col
+        self.regime_w = regime_w
+        self.regime_period = regime_period
+        self.routing = routing
+        self.emb_dim = emb_dim
+        self.hidden = tuple(hidden)
+        self.loss = loss
+        self.lr = lr
+        self.epochs = epochs
+        self.batch_size = batch_size
+        self.cost = cost
+        self.seed = seed
+        self.detector: RegimeDetector | None = None
+        self._obj: ObjectiveModel | None = None
+
+    def _regime_series(self, X: NDArray) -> NDArray:
+        """ Extract the level column used for regime detection. """
+        return np.asarray(X, dtype=np.float64)[:, self.regime_col]
+
+    def _augment(self, X: NDArray, labels: NDArray) -> NDArray:
+        """ Append the regime label as the last column of ``X``. """
+        return np.column_stack(
+            [np.asarray(X, dtype=np.float32), labels.astype(np.float32)]
+        )
+
+    def fit(self, X: NDArray, y: NDArray) -> RegimeMoE:
+        """ Fit the causal regime detector (on train) then train the MoE net.
+
+        Parameters
+        ----------
+        X : array-like, shape (T, F)
+            Feature matrix; column ``regime_col`` is the positive price/level
+            series used for regime detection.
+        y : array-like, shape (T,)
+            Realized per-bar returns aligned with ``X``.
+
+        Returns
+        -------
+        RegimeMoE
+            ``self``.
+
+        """
+        X = np.asarray(X)
+        n_features = X.shape[1]
+
+        # Causal regime: fit the detector on the training slice only.
+        self.detector = RegimeDetector(
+            n_regimes=self.n_regimes, w=self.regime_w,
+            period=self.regime_period, seed=self.seed,
+        ).fit(self._regime_series(X))
+        labels = self.detector.predict(self._regime_series(X))
+
+        # Seed before building the net (ObjectiveModel skips seeding a given net).
+        torch.manual_seed(self.seed)
+        net = _RegimeMoENet(
+            n_features, self.n_regimes, self.emb_dim, self.hidden, self.routing,
+        )
+        self._obj = ObjectiveModel(
+            net=net, loss=self.loss, lr=self.lr, epochs=self.epochs,
+            batch_size=self.batch_size, cost=self.cost, seed=self.seed,
+        )
+        self._obj.fit(self._augment(X, labels), y)
+
+        return self
+
+    def predict(self, X: NDArray) -> NDArray:
+        """ Assign the regime online and return positions in ``[-1, 1]``. """
+        if self.detector is None or self._obj is None:
+
+            raise RuntimeError("RegimeMoE must be fit before predict")
+
+        X = np.asarray(X)
+        labels = self.detector.predict(self._regime_series(X))
+
+        return self._obj.predict(self._augment(X, labels))

--- a/fynance/tests/backtest/test_cost.py
+++ b/fynance/tests/backtest/test_cost.py
@@ -5,11 +5,13 @@
 
 # Third-party packages
 import numpy as np
+import pytest
 
-from fynance.backtest.cost import ProportionalCost
-from fynance.core import CostModel
+from fynance.backtest.cost import MarketImpactCost, ProportionalCost
 
 # Local packages
+from fynance.backtest.engine import backtest
+from fynance.core import CostModel
 from fynance.portfolio.sizing import transaction_cost
 
 
@@ -34,3 +36,65 @@ def test_parity_with_transaction_cost():
 
 def test_conforms_to_protocol():
     assert isinstance(ProportionalCost(), CostModel)
+
+
+# -- MarketImpactCost -----------------------------------------------------
+
+
+def test_impact_conforms_to_protocol():
+    assert isinstance(MarketImpactCost(), CostModel)
+
+
+def test_impact_linear_limit_equals_proportional():
+    # exponent=1, impact=0 reduces to ProportionalCost(fee)
+    w = np.array([[1.0, 0.0], [0.5, 0.5], [0.0, 1.0]])
+    lin = MarketImpactCost(fee=0.003, impact=0.0, exponent=1.0)
+    prop = ProportionalCost(fee=0.003)
+    assert np.allclose(lin(w), prop(w), atol=1e-12)
+
+
+def test_impact_convex_in_turnover():
+    # Doubling a single-step turnover more-than-doubles its impact cost.
+    small = np.array([[0.0], [0.25], [0.25]])   # step-1 turnover 0.25
+    big = np.array([[0.0], [0.5], [0.5]])       # step-1 turnover 0.5 (doubled)
+    cost = MarketImpactCost(fee=0.0, impact=0.1, exponent=1.5)
+    c_small = cost(small)[1]
+    c_big = cost(big)[1]
+    assert c_big > 2.0 * c_small
+
+
+def test_impact_zero_turnover_zero_cost():
+    w = np.array([[0.5, 0.5], [0.5, 0.5], [0.5, 0.5]])
+    cost = MarketImpactCost(fee=0.01, impact=0.1)
+    # only the initial position is charged; steps 2-3 have zero turnover
+    assert np.allclose(cost(w)[1:], [0.0, 0.0])
+
+
+def test_impact_shape_and_first_step_charged():
+    w = np.array([[1.0, 0.0], [0.0, 1.0], [0.0, 1.0]])
+    cost = MarketImpactCost(fee=0.001, impact=0.05)
+    out = cost(w)
+    assert out.shape == (3,)
+    assert out[0] > 0.0   # initial position charged like ProportionalCost
+
+
+def test_impact_bad_exponent_raises():
+    with pytest.raises(ValueError, match="exponent"):
+        MarketImpactCost(exponent=0.0)
+
+
+def test_impact_lowers_net_equity_in_backtest():
+    rng = np.random.default_rng(0)
+    T = 300
+    returns = rng.standard_normal((T, 3)) * 0.01
+    pos = rng.standard_normal((T, 3))
+    pos = pos / np.abs(pos).sum(axis=1, keepdims=True)   # normalized weights
+
+    base = backtest(returns, pos, cost=ProportionalCost(fee=0.001))
+    impacted = backtest(
+        returns, pos, cost=MarketImpactCost(fee=0.001, impact=0.05),
+    )
+    # impact adds a strictly positive convex term -> higher total cost,
+    # lower final equity.
+    assert impacted.costs.sum() > base.costs.sum()
+    assert impacted.equity[-1] < base.equity[-1]

--- a/fynance/tests/core/test_ohlcv.py
+++ b/fynance/tests/core/test_ohlcv.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for :class:`fynance.core.OHLCV`. """
+
+# Third-party packages
+import numpy as np
+import pytest
+
+# Local packages
+from fynance.core import OHLCV
+
+
+def _synthetic(n=50, seed=0):
+    rng = np.random.default_rng(seed)
+    c = 100 + np.cumsum(rng.standard_normal(n))
+    o = c + rng.standard_normal(n)
+    h = np.maximum(o, c) + np.abs(rng.standard_normal(n))
+    low = np.minimum(o, c) - np.abs(rng.standard_normal(n))
+    v = rng.integers(1, 100, n).astype(float)
+
+    return OHLCV(open=o, high=h, low=low, close=c, volume=v)
+
+
+def test_construction_and_accessors():
+    bars = _synthetic(50)
+    assert len(bars) == 50
+    assert bars.to_numpy().shape == (50, 5)
+    assert bars.columns == ('open', 'high', 'low', 'close', 'volume')
+    assert bars.close.dtype == np.float64
+    # fixture sanity: high >= low everywhere
+    assert np.all(bars.high >= bars.low)
+
+
+def test_close_required_others_optional():
+    bars = OHLCV(close=[1.0, 2.0, 3.0])
+    assert len(bars) == 3
+    assert bars.columns == ('close',)
+    assert bars.has('close') and not bars.has('volume')
+
+
+def test_absent_field_raises():
+    bars = OHLCV(close=[1.0, 2.0], high=[2.0, 3.0])
+    with pytest.raises(ValueError, match="no 'volume' field"):
+        _ = bars.volume
+    with pytest.raises(ValueError, match="no 'open' field"):
+        _ = bars.open
+
+
+def test_length_mismatch_raises():
+    with pytest.raises(ValueError, match="length"):
+        OHLCV(close=[1.0, 2.0, 3.0], high=[1.0, 2.0])
+
+
+def test_immutability():
+    bars = OHLCV(close=[1.0, 2.0, 3.0])
+    assert bars.close.flags.writeable is False
+    with pytest.raises(ValueError):
+        bars.close[0] = 9.0
+
+
+def test_to_numpy_columns_follow_order():
+    bars = OHLCV(close=[1.0, 2.0], high=[2.0, 3.0])
+    # canonical order keeps high before close
+    assert bars.columns == ('high', 'close')
+    assert np.array_equal(bars.to_numpy()[:, 0], [2.0, 3.0])
+    assert np.array_equal(bars.to_numpy()[:, 1], [1.0, 2.0])
+
+
+def test_from_dict_roundtrip():
+    bars = _synthetic(20)
+    rebuilt = OHLCV.from_dict(
+        {f: getattr(bars, f) for f in bars.columns}
+    )
+    assert rebuilt == bars
+
+
+def test_from_dict_requires_close():
+    with pytest.raises(ValueError, match="close"):
+        OHLCV.from_dict({"high": [1.0, 2.0]})
+
+
+def test_from_numpy_roundtrip():
+    bars = _synthetic(20)
+    cols = ('open', 'high', 'low', 'close', 'volume')
+    arr = bars.to_numpy()
+    rebuilt = OHLCV.from_numpy(arr, columns=cols)
+    assert rebuilt == bars
+
+
+def test_from_numpy_shape_guard():
+    with pytest.raises(ValueError, match="incompatible"):
+        OHLCV.from_numpy(np.zeros((5, 2)), columns=('open', 'high', 'low'))
+
+
+def test_equality_distinguishes_fields():
+    a = OHLCV(close=[1.0, 2.0], high=[3.0, 4.0])
+    b = OHLCV(close=[1.0, 2.0])
+    assert a != b
+    assert a != "not-an-ohlcv"
+
+
+def test_repr():
+    bars = OHLCV(close=[1.0, 2.0], volume=[10.0, 20.0])
+    r = repr(bars)
+    assert "len=2" in r and "close" in r and "volume" in r
+
+
+def test_coercion_from_torch():
+    torch = pytest.importorskip("torch")
+    c = torch.tensor([1.0, 2.0, 3.0])
+    bars = OHLCV(close=c)
+    assert np.array_equal(bars.close, np.array([1.0, 2.0, 3.0]))
+
+
+def test_from_polars():
+    pl = pytest.importorskip("polars")
+    df = pl.DataFrame({"Close": [1.0, 2.0], "High": [2.0, 3.0], "x": [9.0, 9.0]})
+    bars = OHLCV.from_polars(df)
+    assert bars.columns == ('high', 'close')
+    assert np.array_equal(bars.high, [2.0, 3.0])

--- a/fynance/tests/features/test_adaptive_windows.py
+++ b/fynance/tests/features/test_adaptive_windows.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for regime-adaptive rolling windows. """
+
+# Third-party packages
+import numpy as np
+import pytest
+
+# Local packages
+from fynance.features.engineering import adaptive_roll, adaptive_volatility
+from fynance.features.indicators import realized_volatility
+from fynance.features.momentums import sma
+
+
+def test_single_regime_constant_window_equals_fixed():
+    X = np.arange(1.0, 21.0)
+    regimes = np.zeros(X.size, dtype=int)
+    out = adaptive_roll(X, sma, {0: 3}, regimes)
+    assert np.allclose(out, np.asarray(sma(X, 3)).reshape(-1))
+
+
+def test_output_length_and_known_values():
+    X = np.arange(1.0, 7.0)
+    regimes = np.array([0, 0, 0, 1, 1, 1])
+    out = adaptive_roll(X, sma, {0: 1, 1: 3}, regimes)
+    assert out.shape == (6,)
+    # regime 0 -> sma window 1 (= X); regime 1 -> sma window 3
+    assert np.allclose(out, [1.0, 2.0, 3.0, 3.0, 4.0, 5.0])
+
+
+def test_missing_window_for_regime_raises():
+    X = np.arange(1.0, 7.0)
+    regimes = np.array([0, 0, 0, 1, 1, 1])
+    with pytest.raises(ValueError, match="no entry for regime"):
+        adaptive_roll(X, sma, {0: 2}, regimes)
+
+
+def test_length_mismatch_raises():
+    X = np.arange(1.0, 7.0)
+    with pytest.raises(ValueError, match="length"):
+        adaptive_roll(X, sma, {0: 2}, np.zeros(3, dtype=int))
+
+
+def test_no_lookahead():
+    rng = np.random.default_rng(0)
+    X = 100 * np.exp(np.cumsum(rng.standard_normal(200) * 0.01))
+    regimes = (np.arange(200) // 50) % 2
+    full = adaptive_volatility(X, {0: 5, 1: 20}, regimes)
+    t = 120
+    truncated = adaptive_volatility(X[:t], {0: 5, 1: 20}, regimes[:t])
+    assert np.allclose(full[:t], truncated, equal_nan=True)
+
+
+def test_window_varies_with_regime():
+    # Calm segment then turbulent segment; a short window in the turbulent regime
+    # tracks the vol jump faster than the long calm-window baseline.
+    rng = np.random.default_rng(1)
+    n = 400
+    calm = rng.standard_normal(n // 2) * 0.003
+    turbulent = rng.standard_normal(n // 2) * 0.03
+    log_ret = np.concatenate([calm, turbulent])
+    X = 100 * np.exp(np.cumsum(log_ret))
+    regimes = (np.arange(n) >= n // 2).astype(int)   # 0 calm, 1 turbulent
+
+    # short window (5) in the turbulent regime, long (50) in calm
+    adaptive = adaptive_volatility(X, {0: 50, 1: 5}, regimes)
+    # baseline: the long window everywhere
+    baseline = np.asarray(realized_volatility(X, w=50, period=252)).reshape(-1)
+
+    # just after the regime switch, the adaptive estimate (short window) has
+    # risen more than the slow baseline.
+    probe = n // 2 + 10
+    assert adaptive[probe] > baseline[probe]
+
+
+def test_adaptive_volatility_matches_manual_roll():
+    rng = np.random.default_rng(2)
+    X = 100 * np.exp(np.cumsum(rng.standard_normal(120) * 0.01))
+    regimes = (np.arange(120) // 40) % 2
+    auto = adaptive_volatility(X, {0: 7, 1: 21}, regimes, period=252)
+    manual = adaptive_roll(
+        X, realized_volatility, {0: 7, 1: 21}, regimes, period=252,
+    )
+    assert np.allclose(auto, manual, equal_nan=True)

--- a/fynance/tests/features/test_garch.py
+++ b/fynance/tests/features/test_garch.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for the causal GARCH(1,1) volatility feature. """
+
+# Third-party packages
+import numpy as np
+import pytest
+
+# Local packages
+from fynance.features import garch_volatility
+
+
+def _simulate_garch(T=1500, omega=1e-6, alpha=0.08, beta=0.9, seed=0):
+    """ Simulate a GARCH(1,1) return path; return (returns, true_sigma). """
+    rng = np.random.default_rng(seed)
+    eps = rng.standard_normal(T)
+    r = np.zeros(T)
+    s2 = np.zeros(T)
+    s2[0] = omega / (1.0 - alpha - beta)
+
+    for t in range(1, T):
+        s2[t] = omega + alpha * r[t - 1] ** 2 + beta * s2[t - 1]
+        r[t] = np.sqrt(s2[t]) * eps[t]
+
+    return r, np.sqrt(s2)
+
+
+def test_shape_warmup_and_nonnegative():
+    r, _ = _simulate_garch()
+    sigma = garch_volatility(r, min_train=500)
+    assert sigma.shape == r.shape
+    assert np.all(np.isnan(sigma[:500]))
+    valid = sigma[500:]
+    assert np.all(valid >= 0.0)
+    assert not np.any(np.isnan(valid))
+
+
+def test_recovers_latent_volatility():
+    r, true_sigma = _simulate_garch()
+    sigma = garch_volatility(r, min_train=500)
+    mask = ~np.isnan(sigma)
+    corr = np.corrcoef(sigma[mask], true_sigma[mask])[0, 1]
+    assert corr > 0.8
+
+
+def test_no_lookahead_bitwise():
+    r, _ = _simulate_garch()
+    t = 900
+    truncated = garch_volatility(r[:t], min_train=500)[-1]
+    extended = garch_volatility(r[:t + 50], min_train=500)[t - 1]
+    assert truncated == extended
+
+
+def test_refit_is_causal_and_changes_results():
+    r, _ = _simulate_garch()
+    once = garch_volatility(r, min_train=500)
+    refit = garch_volatility(r, min_train=500, refit=200)
+    # refit produces a (generally) different series ...
+    assert not np.allclose(once[500:], refit[500:])
+    # ... but stays causal: a value is unchanged when the series is extended,
+    # as long as the truncation lands on a refit checkpoint (500 + k*200).
+    t = 900   # = 500 + 2 * 200
+    a = garch_volatility(r[:t], min_train=500, refit=200)[-1]
+    b = garch_volatility(r[:t + 50], min_train=500, refit=200)[t - 1]
+    assert a == b
+
+
+def test_bad_min_train_raises():
+    r, _ = _simulate_garch(T=100)
+    with pytest.raises(ValueError, match="min_train"):
+        garch_volatility(r, min_train=100)
+    with pytest.raises(ValueError, match="min_train"):
+        garch_volatility(r, min_train=1)

--- a/fynance/tests/features/test_ohlcv.py
+++ b/fynance/tests/features/test_ohlcv.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for the multi-series OHLCV indicators. """
+
+# Third-party packages
+import numpy as np
+import pytest
+
+# Local packages
+from fynance.core import OHLCV
+from fynance.features.ohlcv import adx, atr, obv, vwap, williams_r
+
+
+def _synthetic(n=200, seed=0):
+    rng = np.random.default_rng(seed)
+    close = 100 + np.cumsum(rng.standard_normal(n))
+    high = close + np.abs(rng.standard_normal(n))
+    low = close - np.abs(rng.standard_normal(n))
+    volume = rng.integers(1, 1000, n).astype(float)
+
+    return high, low, close, volume
+
+
+# -- Golden values (hand-checkable) ---------------------------------------
+
+
+def test_atr_golden():
+    h = np.array([10., 11., 12., 11.5])
+    low = np.array([9., 9.5, 11., 10.5])
+    c = np.array([9.5, 10.5, 11.5, 11.])
+    # TR = [1, 1.5, 1.5, 1]; Wilder RMA w=2 seeded at TR[0]
+    assert np.allclose(atr(h, low, c, w=2), [1., 1.25, 1.375, 1.1875])
+
+
+def test_williams_golden_and_range():
+    h = np.array([10., 11., 12., 11.])
+    low = np.array([9., 9., 10., 10.])
+    c = np.array([9.5, 10.5, 11.5, 10.5])
+    out = williams_r(h, low, c, w=2)
+    assert np.allclose(out, [-50., -25., -100. / 6., -75.])
+    assert np.all((out >= -100.0) & (out <= 0.0))
+
+
+def test_obv_golden():
+    c = np.array([10., 11., 10.5, 10.5, 12.])
+    v = np.array([100., 150., 120., 80., 200.])
+    assert np.allclose(obv(c, v), [0., 150., 30., 30., 230.])
+
+
+def test_vwap_cumulative_golden():
+    h = np.array([10., 12., 11.])
+    low = np.array([8., 10., 9.])
+    c = np.array([9., 11., 10.])
+    v = np.array([100., 100., 100.])
+    assert np.allclose(vwap(h, low, c, v), [9., 10., 10.])
+
+
+# -- Shapes / ranges ------------------------------------------------------
+
+
+def test_shapes_match_input():
+    h, low, c, v = _synthetic()
+    n = h.size
+    for out in (atr(h, low, c), adx(h, low, c), williams_r(h, low, c),
+                obv(c, v), vwap(h, low, c, v), vwap(h, low, c, v, w=20)):
+        assert np.asarray(out).shape == (n,)
+
+
+def test_atr_nonnegative_and_adx_bounded():
+    h, low, c, _ = _synthetic()
+    assert np.all(atr(h, low, c) >= 0.0)
+    a = adx(h, low, c)
+    assert np.all((a >= 0.0) & (a <= 100.0))
+
+
+def test_williams_in_range():
+    h, low, c, _ = _synthetic()
+    out = williams_r(h, low, c)
+    assert np.all((out >= -100.0) & (out <= 0.0))
+
+
+# -- OHLCV dispatch -------------------------------------------------------
+
+
+def test_ohlcv_dispatch_matches_raw():
+    h, low, c, v = _synthetic()
+    bars = OHLCV(high=h, low=low, close=c, volume=v)
+    assert np.allclose(atr(bars), atr(h, low, c))
+    assert np.allclose(adx(bars), adx(h, low, c))
+    assert np.allclose(williams_r(bars), williams_r(h, low, c))
+    assert np.allclose(obv(bars), obv(c, v))
+    assert np.allclose(vwap(bars), vwap(h, low, c, v))
+
+
+def test_missing_args_raise():
+    with pytest.raises(ValueError, match="high, low and close"):
+        atr(np.array([1.0, 2.0]))
+    with pytest.raises(ValueError, match="close and volume"):
+        obv(np.array([1.0, 2.0]))
+    with pytest.raises(ValueError, match="high, low, close and volume"):
+        vwap(np.array([1.0, 2.0]))
+
+
+# -- No-lookahead ---------------------------------------------------------
+
+
+def test_no_lookahead():
+    h, low, c, v = _synthetic(n=200)
+    t = 120
+    for fn, args in (
+        (atr, (h, low, c)),
+        (adx, (h, low, c)),
+        (williams_r, (h, low, c)),
+        (obv, (c, v)),
+        (lambda *a: vwap(*a, w=20), (h, low, c, v)),
+    ):
+        full = np.asarray(fn(*args))
+        truncated = np.asarray(fn(*(a[:t] for a in args)))
+        assert np.allclose(full[:t], truncated, equal_nan=True), fn
+
+
+# -- Parity against a slow pure-python reference --------------------------
+
+
+def _ref_williams(h, low, c, w):
+    out = np.empty(h.size)
+    for t in range(h.size):
+        a = max(0, t - w + 1)
+        hh = h[a:t + 1].max()
+        ll = low[a:t + 1].min()
+        d = hh - ll
+        out[t] = 0.0 if d == 0 else -100.0 * (hh - c[t]) / d
+
+    return out
+
+
+def _ref_obv(c, v):
+    out = np.zeros(c.size)
+    for t in range(1, c.size):
+        if c[t] > c[t - 1]:
+            out[t] = out[t - 1] + v[t]
+        elif c[t] < c[t - 1]:
+            out[t] = out[t - 1] - v[t]
+        else:
+            out[t] = out[t - 1]
+
+    return out
+
+
+def test_parity_with_reference():
+    h, low, c, v = _synthetic(n=200, seed=3)
+    assert np.allclose(williams_r(h, low, c, w=14), _ref_williams(h, low, c, 14),
+                       atol=1e-9)
+    assert np.allclose(obv(c, v), _ref_obv(c, v), atol=1e-9)

--- a/fynance/tests/models/test_regime_model.py
+++ b/fynance/tests/models/test_regime_model.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Regime-conditioned architecture: RegimeMoE conditions on the causal regime. """
+
+# Third-party
+import numpy as np
+import pytest
+
+# Local
+from fynance.core import SignalModel
+from fynance.metrics import sharpe
+from fynance.models import ObjectiveModel, RegimeMoE
+
+
+def _regime_edge_data(n=2000, block=100, seed=0):
+    """ A *regime-dependent* edge: the profitable sign of feature ``s`` flips
+    between two volatility regimes, so a model must know the regime to profit.
+
+    Returns ``X = [level, s]`` (level is the positive price column the detector
+    clusters on) and the realized returns.
+    """
+    rng = np.random.default_rng(seed)
+    regime = (np.arange(n) // block) % 2          # 0,1 alternating blocks
+    vol = np.where(regime == 0, 0.004, 0.03)      # distinct vol per regime
+    level = 100 * np.exp(np.cumsum(rng.standard_normal(n) * vol))
+
+    s = rng.choice([-1.0, 1.0], size=n)
+    flip = np.where(regime == 0, 1.0, -1.0)       # edge sign flips by regime
+    returns = (flip * s * 0.01 + rng.standard_normal(n) * 0.003).astype(np.float32)
+    X = np.column_stack([level, s]).astype(np.float32)
+
+    return X, returns
+
+
+def test_conforms_to_signalmodel():
+    assert isinstance(RegimeMoE(), SignalModel)
+
+
+def test_predict_shape_and_bounds():
+    X, y = _regime_edge_data(n=400, block=50)
+    model = RegimeMoE(n_regimes=2, regime_w=10, epochs=10).fit(X, y)
+    pos = np.asarray(model.predict(X))
+    assert pos.shape == (400, 1)
+    assert np.all(np.abs(pos) <= 1.0 + 1e-6)
+
+
+def test_reproducible_with_seed():
+    X, y = _regime_edge_data(n=600, block=50)
+    a = RegimeMoE(n_regimes=2, regime_w=10, epochs=15, seed=7).fit(X, y).predict(X)
+    b = RegimeMoE(n_regimes=2, regime_w=10, epochs=15, seed=7).fit(X, y).predict(X)
+    assert np.allclose(a, b)
+
+
+def test_predict_before_fit_raises():
+    with pytest.raises(RuntimeError, match="fit"):
+        RegimeMoE().predict(np.zeros((5, 2)))
+
+
+def test_detector_fit_on_train_only_is_causal():
+    # Labels on the train region must not change when more data is appended.
+    X, y = _regime_edge_data(n=1200, block=100)
+    model = RegimeMoE(n_regimes=2, regime_w=20).fit(X[:800], y[:800])
+    train_labels = model.detector.predict(X[:800, 0])
+    extended_labels = model.detector.predict(X[:, 0])
+    assert np.array_equal(train_labels, extended_labels[:800])
+
+
+def test_beats_regime_blind_model_on_regime_edge():
+    # The edge is only exploitable if you know the regime: RegimeMoE should beat
+    # a regime-blind ObjectiveModel given the exact same features.
+    X, y = _regime_edge_data(n=2000, block=100)
+
+    moe = RegimeMoE(
+        n_regimes=2, regime_w=20, hidden=(16, 8), epochs=200, lr=5e-3, seed=0,
+    ).fit(X, y)
+    blind = ObjectiveModel(layers=(16, 8), epochs=200, lr=5e-3, seed=0).fit(X, y)
+
+    moe_ret = np.asarray(moe.predict(X)).reshape(-1) * y
+    blind_ret = np.asarray(blind.predict(X)).reshape(-1) * y
+
+    moe_sharpe = sharpe(np.cumprod(1 + moe_ret), period=252)
+    blind_sharpe = sharpe(np.cumprod(1 + blind_ret), period=252)
+
+    assert moe_sharpe > blind_sharpe
+    assert moe_sharpe > 1.0
+
+
+def test_hard_routing_runs():
+    X, y = _regime_edge_data(n=400, block=50)
+    model = RegimeMoE(
+        n_regimes=2, regime_w=10, routing='hard', epochs=10,
+    ).fit(X, y)
+    pos = np.asarray(model.predict(X))
+    assert pos.shape == (400, 1)
+
+
+def test_bad_routing_raises():
+    X, y = _regime_edge_data(n=200, block=50)
+    with pytest.raises(ValueError, match="routing"):
+        RegimeMoE(routing='nope', regime_w=10).fit(X, y)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fynance"
-version = "2.8.0"
+version = "2.9.0"
 description = "Pure-Python (Numba-accelerated) machine learning, econometrics and statistical tools for financial analysis and backtesting"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
> ⚠️ This rolling `develop → master` PR will be merged **after** `chore/release-2.9.0` (#184) lands in `develop`. Merging it to `master` is what enables tagging `v2.9.0`.

Release **v2.9.0** — data-agnostic *library bricks* (roadmap §1).

## Added

- **`fynance.core.OHLCV`** — aligned multi-series O/H/L/C/V value object.
- **OHLCV indicators** (`fynance.features.ohlcv`) — `atr`, `adx`, `williams_r`, `obv`, `vwap` (Numba kernels, causal; raw arrays or an `OHLCV`).
- **Causal GARCH(1,1) volatility feature** (`fynance.features.garch_volatility`).
- **`fynance.models.RegimeMoE`** — regime-conditioned mixture-of-experts (causal `RegimeDetector`).
- **Regime-adaptive windows** (`fynance.features.adaptive_roll` / `adaptive_volatility`).
- **`fynance.backtest.MarketImpactCost`** — convex square-root market-impact cost.

## Changed

- Roadmap re-scoped to data-agnostic library bricks; real-data strategy research moved to the private `fynance-research` repo.

## Test plan

All four gates verified locally on the integrated `develop`: pytest **658 passed / 1 skipped**, `ruff` clean, `mypy` clean (168 files), `interrogate` 94.7%, Sphinx `-W` builds.