### PR TITLE
fix: guard windows and correct docs in fynance.features

### DIFF
--- a/fynance/features/garch.py
+++ b/fynance/features/garch.py
@@ -125,6 +125,11 @@ def garch_volatility(
         Conditional volatility :math:`\sigma_t`, same length as ``returns``,
         ``NaN`` on the warmup.
 
+    Raises
+    ------
+    ValueError
+        If ``min_train`` is not in ``[2, len(returns))``.
+
     Examples
     --------
     >>> import numpy as np

--- a/fynance/features/indicators.py
+++ b/fynance/features/indicators.py
@@ -28,8 +28,6 @@ Main entry points
 from __future__ import annotations
 
 # Built-in packages
-from warnings import warn
-
 # External packages
 import numpy as np
 from numpy.typing import NDArray
@@ -118,11 +116,8 @@ def bollinger_band(
 
     Examples
     --------
-    >>> import warnings
     >>> X = np.array([60, 100, 80, 120, 160, 80]).astype(np.float64)
-    >>> with warnings.catch_warnings():
-    ...     warnings.simplefilter("ignore", DeprecationWarning)
-    ...     upper_band, lower_band = bollinger_band(X, w=3, n=2)
+    >>> upper_band, lower_band = bollinger_band(X, w=3, n=2)
     >>> upper_band
     array([ 60.        , 120.        , 112.65986324, 132.65986324,
            185.31972647, 185.31972647])
@@ -143,14 +138,6 @@ def bollinger_band(
 
     if kind == 'e':
         w = 1 - 2 / (1 + w)  # type: ignore[assignment]
-
-    warn(
-        'Since version 1.1.0, bollinger_band returns upper and lower bands. '
-        'The single-array return path is deprecated and will be removed in '
-        'fynance 2.0.',
-        category=DeprecationWarning,
-        stacklevel=2,
-    )
 
     if axis == 1:
         avg = _handler_ma[kind.lower()](X.T, w).T

--- a/fynance/features/money_management.py
+++ b/fynance/features/money_management.py
@@ -48,18 +48,19 @@ def iso_vol(series, target_vol=0.20, leverage=1., period=252, half_life=11):
     --------
     >>> series = np.array([95, 100, 85, 105, 110, 90]).astype(np.float64)
     >>> iso_vol(series, target_vol=0.5, leverage=2, period=12, half_life=3)
-    array([1.        , 1.        , 2.        , 1.11289534, 0.88580571,
-           1.20664917])
+    array([1.        , 1.        , 2.        , 1.28407693, 0.78278978,
+           1.07186485])
 
     """
     # Set iso-vol vector
     iv = np.ones([series.size])
-    # Compute squared daily return vector
-    ret2 = np.square(series[:-1] / series[1:] - 1)
+    # Compute squared daily return vector (standard return s_t / s_{t-1} - 1)
+    ret2 = np.square(series[1:] / series[:-1] - 1)
     # Compute volatility vector
     vol = np.sqrt(period * ema(ret2, w=half_life))
     vol[vol <= 0.] = 1e-8
-    # Compute iso-vol coefficient
+    # Compute iso-vol coefficient (iv[t] uses only vol[t - 2], i.e. data up to
+    # series[t - 1] -- strictly causal w.r.t. the signal applied at t)
     iv[2:] = target_vol / vol[:-1]
     # Cap with the max leverage available
     iv[iv > leverage] = leverage

--- a/fynance/features/ohlcv.py
+++ b/fynance/features/ohlcv.py
@@ -44,6 +44,24 @@ def _unpack_hlc(high, low, close):
     return _as1d(high), _as1d(low), _as1d(close)
 
 
+def _check_window(w: int) -> int:
+    """ Validate a smoothing/look-back window and return it as an ``int``.
+
+    Raises
+    ------
+    ValueError
+        If ``w < 1`` (a window of ``0`` would divide by zero in the Wilder
+        recursion and a negative window is meaningless).
+    """
+    w = int(w)
+
+    if w < 1:
+
+        raise ValueError(f"w must be >= 1, got {w}")
+
+    return w
+
+
 # =========================================================================== #
 #                              Numba kernels                                  #
 # =========================================================================== #
@@ -202,6 +220,12 @@ def atr(high, low=None, close=None, w: int = 14) -> NDArray[np.float64]:
     numpy.ndarray
         ATR series, ``>= 0``, aligned with the input.
 
+    Raises
+    ------
+    ValueError
+        If ``w < 1``, or if ``low`` / ``close`` are missing without an
+        ``OHLCV`` first argument.
+
     Examples
     --------
     >>> import numpy as np
@@ -212,9 +236,10 @@ def atr(high, low=None, close=None, w: int = 14) -> NDArray[np.float64]:
     array([1.    , 1.25  , 1.375 , 1.1875])
 
     """
+    w = _check_window(w)
     high, low, close = _unpack_hlc(high, low, close)
 
-    return _atr_kernel(high, low, close, int(w))
+    return _atr_kernel(high, low, close, w)
 
 
 def adx(high, low=None, close=None, w: int = 14) -> NDArray[np.float64]:
@@ -235,6 +260,12 @@ def adx(high, low=None, close=None, w: int = 14) -> NDArray[np.float64]:
     numpy.ndarray
         ADX series in ``[0, 100]``, aligned with the input.
 
+    Raises
+    ------
+    ValueError
+        If ``w < 1``, or if ``low`` / ``close`` are missing without an
+        ``OHLCV`` first argument.
+
     Examples
     --------
     >>> import numpy as np
@@ -248,16 +279,17 @@ def adx(high, low=None, close=None, w: int = 14) -> NDArray[np.float64]:
     True
 
     """
+    w = _check_window(w)
     high, low, close = _unpack_hlc(high, low, close)
 
-    return _adx_kernel(high, low, close, int(w))
+    return _adx_kernel(high, low, close, w)
 
 
 def williams_r(high, low=None, close=None, w: int = 14) -> NDArray[np.float64]:
     r""" Williams %R over a trailing window, causal.
 
     :math:`\%R_t = -100 \cdot (HH_t - C_t) / (HH_t - LL_t)`, where ``HH``/``LL``
-    are the rolling high/low of window ``w``. Bounded in ``[-100, 0]``.
+    are the rolling high/low of window ``w``.
 
     Parameters
     ----------
@@ -269,7 +301,23 @@ def williams_r(high, low=None, close=None, w: int = 14) -> NDArray[np.float64]:
     Returns
     -------
     numpy.ndarray
-        Williams %R in ``[-100, 0]``, aligned with the input.
+        Williams %R, aligned with the input.
+
+    Raises
+    ------
+    ValueError
+        If ``w < 1``, or if ``low`` / ``close`` are missing without an
+        ``OHLCV`` first argument.
+
+    Notes
+    -----
+    %R is bounded in ``[-100, 0]`` **only when the bars are valid OHLC**, i.e.
+    each close lies within its window's high/low range
+    (:math:`LL_t \le C_t \le HH_t`). The raw values are returned unclamped, so a
+    close outside ``[LL_t, HH_t]`` — e.g. corrupt or mismatched series — yields
+    values outside ``[-100, 0]`` (a close above the rolling high gives ``%R > 0``,
+    below the rolling low gives ``%R < -100``). This is intentional: clamping
+    would silently mask such data issues.
 
     Examples
     --------
@@ -281,9 +329,10 @@ def williams_r(high, low=None, close=None, w: int = 14) -> NDArray[np.float64]:
     array([-50.  , -25.  , -16.67, -75.  ])
 
     """
+    w = _check_window(w)
     high, low, close = _unpack_hlc(high, low, close)
 
-    return _williams_kernel(high, low, close, int(w))
+    return _williams_kernel(high, low, close, w)
 
 
 def obv(close, volume=None) -> NDArray[np.float64]:

--- a/fynance/features/regime.py
+++ b/fynance/features/regime.py
@@ -11,6 +11,9 @@ embedding) — see the notes on causality.
 
 from __future__ import annotations
 
+# Built-in packages
+import warnings
+
 # Third-party packages
 import numpy as np
 from numpy.typing import NDArray
@@ -20,6 +23,27 @@ from scipy.cluster.vq import kmeans2
 from fynance.features.indicators import realized_volatility
 
 __all__ = ['detect_regimes', 'regime_features', 'RegimeDetector']
+
+
+def _vol_order(vol: NDArray, labels: NDArray, n_regimes: int) -> NDArray:
+    """ Order cluster labels by increasing mean volatility, empty-safe.
+
+    An empty cluster has a ``nan`` mean; treat it as ``+inf`` so it sorts last
+    instead of corrupting the ordering (``argsort`` places ``nan`` last but its
+    relative order is undefined). Empty clusters are unreachable through the
+    ``kmeans2(..., missing='raise')`` path, but this keeps the ordering robust
+    if that guard is ever relaxed.
+    """
+    with np.errstate(invalid='ignore'), warnings.catch_warnings():
+        # An empty cluster triggers a "Mean of empty slice" warning; expected.
+        warnings.simplefilter('ignore', category=RuntimeWarning)
+        means = np.array(
+            [vol[labels == k].mean() for k in range(n_regimes)]
+        )
+
+    means[np.isnan(means)] = np.inf
+
+    return np.argsort(means)
 
 
 def regime_features(X: NDArray, w: int = 21, period: int = 252) -> NDArray:
@@ -41,6 +65,14 @@ def regime_features(X: NDArray, w: int = 21, period: int = 252) -> NDArray:
     -------
     np.ndarray
         Shape ``(len(X), 2)`` — ``[realized_volatility, rolling_mean_log_return]``.
+
+    Notes
+    -----
+    Row ``0`` is a deterministic warmup point: there is no prior observation, so
+    both the realized volatility and the mean log-return are ``0`` (an
+    artificially "ultra-calm" point). It is kept so the matrix stays aligned with
+    ``X``; callers fitting a clustering on the matrix may wish to drop or mask
+    this row.
 
     """
     X = np.asarray(X, dtype=np.float64).reshape(-1)
@@ -108,7 +140,7 @@ class RegimeDetector:
 
         # Order clusters by mean (unstandardized) volatility for stable labels.
         vol = feats[:, 0]
-        order = np.argsort([vol[labels == k].mean() for k in range(self.n_regimes)])
+        order = _vol_order(vol, labels, self.n_regimes)
         remap = np.empty(self.n_regimes, dtype=int)
         remap[order] = np.arange(self.n_regimes)
         self._remap = remap
@@ -175,7 +207,7 @@ def detect_regimes(
     _, labels = kmeans2(z, n_regimes, seed=seed, minit='++', missing='raise')
 
     # Re-order labels by increasing mean volatility for stable interpretation.
-    order = np.argsort([vol[labels == k].mean() for k in range(n_regimes)])
+    order = _vol_order(vol, labels, n_regimes)
     remap = np.empty(n_regimes, dtype=int)
     remap[order] = np.arange(n_regimes)
 

--- a/fynance/features/roll_functions.py
+++ b/fynance/features/roll_functions.py
@@ -112,7 +112,7 @@ def roll_min(X: NDArray, w: int | None = None, axis: int = 0, dtype=None) -> NDA
 
     .. math::
 
-        roll\_min^w_t(X) = min(X_{t - w}, ..., X_t)
+        roll\_min^w_t(X) = min(X_{t - w + 1}, ..., X_t)
 
     Parameters
     ----------
@@ -177,7 +177,7 @@ def roll_max(X: NDArray, w: int | None = None, axis: int = 0, dtype=None) -> NDA
 
     .. math::
 
-        roll\_max^w_t(X) = max(X_{t - w}, ..., X_t)
+        roll\_max^w_t(X) = max(X_{t - w + 1}, ..., X_t)
 
     Parameters
     ----------
@@ -222,7 +222,7 @@ def roll_max(X: NDArray, w: int | None = None, axis: int = 0, dtype=None) -> NDA
 
     See Also
     --------
-    roll_max
+    roll_min
 
     """
     return _roll_max(X, w)

--- a/fynance/tests/features/test_engineering.py
+++ b/fynance/tests/features/test_engineering.py
@@ -41,6 +41,24 @@ def test_granger_too_short_raises():
         granger_causality(np.arange(3.0), np.arange(3.0), lag=1)
 
 
+def test_granger_detects_causality_lag2():
+    # y_t driven by x_{t-2}: lag=2 must pick up the two-step-ahead causality.
+    rng = np.random.RandomState(5)
+    x = rng.standard_normal(400)
+    y = np.r_[0.0, 0.0, 0.7 * x[:-2]] + 0.1 * rng.standard_normal(400)
+    f, p = granger_causality(x, y, lag=2)
+    assert f > 0.0
+    assert p < 0.01
+
+
+def test_granger_independent_not_significant_lag2():
+    rng = np.random.RandomState(0)
+    _, p = granger_causality(
+        rng.standard_normal(400), rng.standard_normal(400), lag=2
+    )
+    assert p > 0.05
+
+
 def test_incremental_moments_matches_numpy():
     rng = np.random.RandomState(2)
     data = rng.standard_normal(100)
@@ -56,3 +74,23 @@ def test_incremental_moments_matches_numpy():
 def test_incremental_update_returns_self():
     im = IncrementalMoments()
     assert im.update(1.0) is im
+
+
+def test_incremental_single_observation_zero_variance():
+    # After a single observation the variance/std are well-defined and zero (no
+    # division-by-zero, no nan), and the mean equals that observation.
+    im = IncrementalMoments()
+    im.update(3.5)
+    assert im.n == 1
+    assert im.mean == 3.5
+    assert im.var == 0.0
+    assert im.std == 0.0
+
+
+def test_incremental_empty_is_zero():
+    # Before any observation, the moments default to zero rather than raising.
+    im = IncrementalMoments()
+    assert im.n == 0
+    assert im.mean == 0.0
+    assert im.var == 0.0
+    assert im.std == 0.0

--- a/fynance/tests/features/test_filters.py
+++ b/fynance/tests/features/test_filters.py
@@ -139,3 +139,46 @@ class TestFitKalman:
         assert result['success']
         np.testing.assert_allclose(result['W'], W_TRUE)
         np.testing.assert_allclose(result['V'], V_TRUE)
+
+
+class TestMultivariate:
+    """ State-dimension n > 1: filter, smoother and fit on a 2-D state. """
+
+    N2 = 2
+    T2 = 150
+
+    def _data(self):
+        rng = np.random.default_rng(7)
+        n, T = self.N2, self.T2
+        G2 = F2 = np.eye(n)
+        W2 = np.diag([0.3, 0.8])
+        V2 = np.diag([1.0, 0.5])
+        x = np.cumsum(rng.multivariate_normal(np.zeros(n), W2, T), axis=0)
+        y = x + rng.multivariate_normal(np.zeros(n), V2, T)
+
+        return y, G2, F2, W2, V2
+
+    def test_filter_smoother_shapes_n2(self):
+        y, G2, F2, W2, V2 = self._data()
+        m, C, a, R, e, S = kalman_filter(y, G2, F2, W2, V2)
+        assert m.shape == (self.T2, self.N2)
+        assert C.shape == (self.T2, self.N2, self.N2)
+        ms, Cs = rts_smoother(m, C, a, R, G2)
+        assert ms.shape == (self.T2, self.N2)
+        assert Cs.shape == (self.T2, self.N2, self.N2)
+
+    def test_fit_n2_converges_and_shapes(self):
+        y, G2, F2, _, _ = self._data()
+        result = fit_kalman(y, G2, F2)
+        assert result['success']
+        assert result['W'].shape == (self.N2, self.N2)
+        assert result['V'].shape == (self.N2, self.N2)
+
+    def test_fit_n2_beats_identity(self):
+        y, G2, F2, _, _ = self._data()
+        result = fit_kalman(y, G2, F2)
+        _, _, _, _, e_id, S_id = kalman_filter(
+            y, G2, F2, np.eye(self.N2), np.eye(self.N2)
+        )
+        ll_id = kalman_loglikelihood(e_id, S_id)
+        assert result['loglik'] >= ll_id - 1e-6

--- a/fynance/tests/features/test_garch.py
+++ b/fynance/tests/features/test_garch.py
@@ -58,12 +58,25 @@ def test_refit_is_causal_and_changes_results():
     refit = garch_volatility(r, min_train=500, refit=200)
     # refit produces a (generally) different series ...
     assert not np.allclose(once[500:], refit[500:])
-    # ... but stays causal: a value is unchanged when the series is extended,
-    # as long as the truncation lands on a refit checkpoint (500 + k*200).
-    t = 900   # = 500 + 2 * 200
+    # ... but stays causal at EVERY index, not only on refit checkpoints: within
+    # the block [start, end) the value sigma_t is filtered with params fit on
+    # r[:start] (start <= t), so it never sees r[t:]. A value is therefore
+    # unchanged when the series is extended, regardless of where we truncate.
+    t = 850   # mid-block (500 + 2*200 = 900 is the next checkpoint)
     a = garch_volatility(r[:t], min_train=500, refit=200)[-1]
     b = garch_volatility(r[:t + 50], min_train=500, refit=200)[t - 1]
     assert a == b
+
+
+def test_per_index_causality_sweep_with_refit():
+    # The strong causality guarantee: sigma_t is F_{t-1}-measurable at *every* t,
+    # including between refit checkpoints. Truncating the series just after t
+    # leaves sigma_t bit-identical -- no future leakage anywhere.
+    r, _ = _simulate_garch(T=900)
+    full = garch_volatility(r, min_train=500, refit=150)
+    for t in range(500, r.size):
+        trunc = garch_volatility(r[:t + 1], min_train=500, refit=150)
+        assert trunc[t] == full[t], t
 
 
 def test_bad_min_train_raises():

--- a/fynance/tests/features/test_indicators.py
+++ b/fynance/tests/features/test_indicators.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 # coding: utf-8
 
+import warnings
+
 import numpy as np
-import pytest
 
 from fynance.features.indicators import (
     bollinger_band,
@@ -12,13 +13,6 @@ from fynance.features.indicators import (
     macd_line,
     rsi,
     signal_line,
-)
-
-# bollinger_band keeps a 1.1.0-era DeprecationWarning until v2.0; silence it
-# locally so the strict `error::DeprecationWarning` filter (pyproject.toml)
-# stays effective for genuinely new deprecations.
-pytestmark = pytest.mark.filterwarnings(
-    "ignore:Since version 1.1.0, bollinger_band:DeprecationWarning"
 )
 
 N = 100
@@ -46,6 +40,16 @@ def test_bollinger_band_no_nan_after_warmup():
     upper, lower = bollinger_band(X, w=10)
     assert not np.any(np.isnan(upper[10:]))
     assert not np.any(np.isnan(lower[10:]))
+
+
+def test_bollinger_band_emits_no_warning():
+    # The dead 1.1.0-era DeprecationWarning was removed: a normal two-tuple call
+    # must not warn at all.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        upper, lower = bollinger_band(X, w=20)
+    assert upper.shape == (N,)
+    assert lower.shape == (N,)
 
 
 # =========================================================================== #

--- a/fynance/tests/features/test_money_management.py
+++ b/fynance/tests/features/test_money_management.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for the iso-vol money-management coefficient. """
+
+# Third-party packages
+import numpy as np
+
+# Local packages
+from fynance.features.momentums import ema
+from fynance.features.money_management import iso_vol
+
+
+def test_iso_vol_uses_standard_returns():
+    # iso_vol must use the standard return s_t / s_{t-1} - 1, not the reciprocal
+    # s_{t-1} / s_t - 1 that the function used before the fix.
+    series = np.array([95, 100, 85, 105, 110, 90]).astype(np.float64)
+    target_vol, leverage, period, half_life = 0.5, 2.0, 12, 3
+
+    out = iso_vol(series, target_vol=target_vol, leverage=leverage,
+                  period=period, half_life=half_life)
+
+    ret2 = np.square(series[1:] / series[:-1] - 1)
+    vol = np.sqrt(period * ema(ret2, w=half_life))
+    vol[vol <= 0.0] = 1e-8
+    expected = np.ones(series.size)
+    expected[2:] = target_vol / vol[:-1]
+    expected[expected > leverage] = leverage
+
+    assert np.allclose(out, expected)
+
+
+def test_iso_vol_causality():
+    # iv[t] must depend only on series[:t+1] (in fact series[:t]): truncating the
+    # series at t+1 leaves iv[t] unchanged -- no future leakage into the signal.
+    rng = np.random.default_rng(0)
+    series = 100 * np.cumprod(1 + rng.standard_normal(60) * 0.02)
+    full = iso_vol(series, target_vol=0.2, leverage=3.0, period=252, half_life=11)
+
+    for t in range(2, series.size):
+        trunc = iso_vol(series[:t + 1], target_vol=0.2, leverage=3.0,
+                        period=252, half_life=11)
+        assert np.isclose(trunc[t], full[t]), (t, trunc[t], full[t])
+
+
+def test_iso_vol_leverage_cap():
+    # A near-flat (ultra-low-vol) series would demand huge leverage; the output
+    # must be capped at `leverage`.
+    flat = np.full(20, 100.0)
+    leverage = 2.5
+    out = iso_vol(flat, target_vol=0.2, leverage=leverage)
+
+    assert np.all(out <= leverage + 1e-12)
+    assert out.max() == leverage
+
+
+def test_iso_vol_volatility_floor():
+    # The 1e-8 floor on `vol` keeps the coefficient finite (no division by zero)
+    # even when the series has zero realized volatility.
+    flat = np.full(10, 50.0)
+    out = iso_vol(flat, target_vol=0.2, leverage=1.5)
+
+    assert np.all(np.isfinite(out))
+    assert not np.any(np.isnan(out))
+
+
+def test_iso_vol_warmup_is_one():
+    # The first two coefficients are seeded to 1 (no return / vol yet).
+    rng = np.random.default_rng(1)
+    series = 100 * np.cumprod(1 + rng.standard_normal(30) * 0.01)
+    out = iso_vol(series)
+
+    assert out[0] == 1.0
+    assert out[1] == 1.0

--- a/fynance/tests/features/test_ohlcv.py
+++ b/fynance/tests/features/test_ohlcv.py
@@ -102,6 +102,29 @@ def test_missing_args_raise():
         vwap(np.array([1.0, 2.0]))
 
 
+@pytest.mark.parametrize("fn", [atr, adx, williams_r])
+@pytest.mark.parametrize("w", [0, -1])
+def test_window_below_one_raises(fn, w):
+    # w=0 used to raise an uncaught ZeroDivisionError (atr/adx) or produce inf;
+    # it must now raise a clear ValueError, and so must any negative window.
+    h, low, c, _ = _synthetic(n=20)
+    with pytest.raises(ValueError, match="w must be >= 1"):
+        fn(h, low, c, w=w)
+
+
+def test_williams_r_out_of_range_on_invalid_ohlc():
+    # %R is bounded in [-100, 0] only for valid OHLC (low <= close <= high).
+    # A close above the rolling high yields %R > 0; below the rolling low yields
+    # %R < -100. The kernel does NOT clamp -- it surfaces the data issue.
+    h = np.array([10.0, 10.0, 10.0])
+    low = np.array([9.0, 9.0, 9.0])
+    # Close above high at t=1 -> %R > 0; close below low at t=2 -> %R < -100.
+    c = np.array([9.5, 20.0, 0.0])
+    out = williams_r(h, low, c, w=2)
+    assert out[1] > 0.0
+    assert out[2] < -100.0
+
+
 # -- No-lookahead ---------------------------------------------------------
 
 

--- a/fynance/tests/features/test_regime.py
+++ b/fynance/tests/features/test_regime.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 
-from fynance.features.regime import detect_regimes
+from fynance.features.regime import _vol_order, detect_regimes, regime_features
 
 
 def _two_regime_series(seed=0):
@@ -33,3 +33,30 @@ def test_deterministic_with_seed():
     a = detect_regimes(X, n_regimes=2, w=15, seed=42)
     b = detect_regimes(X, n_regimes=2, w=15, seed=42)
     assert np.array_equal(a, b)
+
+
+def test_vol_order_empty_cluster_safe():
+    # An empty cluster yields a nan mean; it must sort last (treated as +inf),
+    # never corrupt the order of the populated clusters.
+    vol = np.array([0.1, 0.5, 0.3, 0.2])
+    labels = np.array([0, 2, 0, 2])  # cluster 1 is empty
+    order = _vol_order(vol, labels, n_regimes=3)
+    # Populated means: 0 -> 0.2, 2 -> 0.35; empty 1 -> +inf -> last.
+    assert order.tolist() == [0, 2, 1]
+
+
+def test_vol_order_matches_naive_when_all_populated():
+    rng = np.random.RandomState(7)
+    vol = rng.rand(50)
+    labels = rng.randint(0, 3, 50)
+    order = _vol_order(vol, labels, n_regimes=3)
+    naive = np.argsort([vol[labels == k].mean() for k in range(3)])
+    assert order.tolist() == naive.tolist()
+
+
+def test_regime_features_warmup_row_is_zero():
+    # Row 0 is the documented deterministic warmup: (vol, mean log-return) = (0, 0).
+    X = _two_regime_series()
+    f = regime_features(X, w=15)
+    assert f[0, 0] == 0.0
+    assert f[0, 1] == 0.0


### PR DESCRIPTION
Roadmap 1.B audit fixes for `fynance.features`. Surgical, ENGLISH-only, numpydoc.

## MEDIUM
- **ohlcv `atr`/`adx`/`williams_r`** — add a `w >= 1` `ValueError` guard (`w=0` previously raised an uncaught `ZeroDivisionError` / produced `inf` in the Wilder recursion). New `_check_window` helper; `Raises` sections added. `vwap` is intentionally left alone — its `w <= 0` path is documented anchored/cumulative VWAP, not an error.
- **ohlcv `williams_r` docstring** — the `[-100, 0]` bound now documented as conditional on valid OHLC (`low <= close <= high`); values are returned **unclamped** on purpose (a close outside the window range yields e.g. `+1000`) so corrupt data surfaces rather than being silently masked. `Notes` section added.
- **indicators `bollinger_band`** — removed the dead/false `DeprecationWarning` (claimed removal "in fynance 2.0"; package is 2.9 and the function already returns a 2-tuple). Removed the now-unused `warn` import and the doctest's `catch_warnings` wrapper.
- **roll_functions** — documented window corrected to `X_{t-w+1}..X_t` (trailing size `w`) for `roll_min`/`roll_max`; `roll_max`'s self-referential `See Also` changed to `roll_min`.
- **money_management `iso_vol`** — now uses the standard return `s_t/s_{t-1}-1` instead of the reciprocal `s_{t-1}/s_t-1`; doctest re-blessed to real values.

## LOW
- **regime** — empty-cluster-safe volatility ordering (`nan` mean -> `+inf`, sorts last) via new `_vol_order` helper used by both `RegimeDetector.fit` and `detect_regimes`; warmup row `0 = (0, 0)` documented in `regime_features`. Train-only standardization unchanged.
- **garch** — `Raises` section added (no behavior change).
- **tests/docstrings** — garch per-index causality sweep (σ_t is 𝓕_{t-1}-measurable at *every* t, including between refit checkpoints; corrected the understated `test_garch.py` comment); granger `lag=2` detection + null tests; `IncrementalMoments` single-observation (`var=0`) test; multivariate (state-dim `n>1`) Kalman filter/smoother/fit test.

## Causality
All causal invariants preserved and tested (iso_vol, garch per-index sweep, regime fit-on-train).

## Gates
- `ruff check fynance/` — clean
- `mypy fynance/` — clean (169 files)
- `pytest fynance/features/ fynance/tests/features/ --doctest-modules` — 218 passed
- full suite — 682 passed, 1 skipped

`fynance/features/__init__.py` exports untouched. `CHANGELOG.md` / roadmap untouched.