### PR TITLE
fix: correct statistical guards in research harness (roadmap 1.H)

### DIFF
--- a/fynance/research/compare.py
+++ b/fynance/research/compare.py
@@ -37,7 +37,8 @@ def leaderboard(
     experiments : list of Experiment
         The runs to rank.
     sort_by : str
-        Metric key to sort on (missing values sink to the bottom).
+        Metric key to sort on. Rows missing the metric **or** holding a NaN for
+        it sink to the bottom of the ranking.
     descending : bool
         Higher is better when True.
 
@@ -51,8 +52,18 @@ def leaderboard(
         {"name": e.name, **{k: float(v) for k, v in e.metrics.items()}}
         for e in experiments
     ]
+    # NaN must rank as "worst", not float to the top: a present-but-NaN metric
+    # is treated like a missing value (the docstring's promise).
     worst = float("-inf") if descending else float("inf")
-    rows.sort(key=lambda r: r.get(sort_by, worst), reverse=descending)  # type: ignore[arg-type]
+
+    def _key(row: dict[str, float | str]) -> float:
+        value = row.get(sort_by, worst)
+        if isinstance(value, float) and np.isnan(value):
+            return worst
+
+        return value  # type: ignore[return-value]
+
+    rows.sort(key=_key, reverse=descending)
 
     return rows
 

--- a/fynance/research/experiment.py
+++ b/fynance/research/experiment.py
@@ -15,7 +15,7 @@ to a caller-provided ``output_dir``.
 from __future__ import annotations
 
 import json
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, fields
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -85,8 +85,25 @@ class Experiment:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Experiment:
-        """ Rebuild an :class:`Experiment` from a :meth:`to_dict` mapping. """
-        return cls(**data)
+        """ Rebuild an :class:`Experiment` from a :meth:`to_dict` mapping.
+
+        Unknown keys are **ignored** rather than raising, so an artifact written
+        by a newer fynance (carrying extra fields) still loads on an older one.
+
+        Parameters
+        ----------
+        data : dict
+            Mapping produced by :meth:`to_dict` (extra keys tolerated).
+
+        Returns
+        -------
+        Experiment
+            The rebuilt experiment.
+
+        """
+        known = {f.name for f in fields(cls)}
+
+        return cls(**{k: v for k, v in data.items() if k in known})
 
     def save(self, output_dir: str | Path, *, name: str | None = None) -> Path:
         """ Write ``<output_dir>/<name>/experiment.json`` and return its path.
@@ -117,7 +134,32 @@ class Experiment:
 
     @classmethod
     def load(cls, path: str | Path) -> Experiment:
-        """ Load an :class:`Experiment` from an ``experiment.json`` file. """
-        data = json.loads(Path(path).read_text(encoding="utf-8"))
+        """ Load an :class:`Experiment` from an ``experiment.json`` file.
+
+        Parameters
+        ----------
+        path : str or pathlib.Path
+            Path to the ``experiment.json`` artifact.
+
+        Returns
+        -------
+        Experiment
+            The loaded experiment.
+
+        Raises
+        ------
+        ValueError
+            If the file is not valid JSON (corrupt or truncated) — re-raised
+            with the offending path for a clear diagnostic.
+
+        """
+        path = Path(path)
+        text = path.read_text(encoding="utf-8")
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"corrupt or truncated experiment artifact at {path}: {exc}"
+            ) from exc
 
         return cls.from_dict(data)

--- a/fynance/research/guards.py
+++ b/fynance/research/guards.py
@@ -58,18 +58,28 @@ def permutation_test(
     the asset's returns (which destroys any temporal structure). If the strategy
     scores as well on shuffled data as on the real data, its edge is not real.
 
+    The price series must be strictly positive: the null is built on log-returns
+    (``np.diff(np.log(prices))``), so a non-positive price would yield ``nan`` /
+    ``-inf`` returns.
+
+    Each run is seeded with a **distinct** seed derived from ``seed`` (the
+    observed run and every permutation), so a stochastic strategy does not see
+    the *same* model RNG draws on every path — which would bias the null
+    variance. The whole test stays reproducible for a fixed ``seed``.
+
     Parameters
     ----------
     strategy : fynance.strategy.Strategy
         The strategy to evaluate.
     data : PriceSeries or array-like
-        Price series.
+        Strictly positive price series (``np.log`` is taken).
     metric : str
         Metric key from the run summary (default ``"sharpe"``).
     n_permutations : int
         Number of shuffles forming the null distribution.
     seed : int
-        Seed for the shuffles and the runs.
+        Master seed for the shuffles and the runs (per-run seeds are derived
+        from it, so the test is fully reproducible).
 
     Returns
     -------
@@ -85,8 +95,13 @@ def permutation_test(
     log_ret = np.diff(np.log(prices))
     s0 = float(prices[0])
 
+    # Draw distinct per-run seeds from the master seed so stochastic strategies
+    # do not replay identical RNG draws on every path (which biases the null).
+    seed_rng = np.random.default_rng(seed)
+    run_seeds = seed_rng.integers(0, 2**31 - 1, size=n_permutations + 1)
+
     observed = run_experiment(strategy, prices, name="observed",
-                              seed=seed).metrics[metric]
+                              seed=int(run_seeds[0])).metrics[metric]
 
     rng = np.random.default_rng(seed)
     null = np.empty(n_permutations, dtype=np.float64)
@@ -94,7 +109,7 @@ def permutation_test(
         shuffled = rng.permutation(log_ret)
         path = s0 * np.exp(np.concatenate([[0.0], np.cumsum(shuffled)]))
         null[i] = run_experiment(strategy, path, name="perm",
-                                 seed=seed).metrics[metric]
+                                 seed=int(run_seeds[i + 1])).metrics[metric]
 
     # Smoothed p-value (never exactly 0): (#{null >= observed} + 1) / (n + 1).
     p_value = float((np.sum(null >= observed) + 1) / (n_permutations + 1))
@@ -167,7 +182,9 @@ def deflated_sharpe_ratio(
     Parameters
     ----------
     sr : float
-        Observed (non-annualized) Sharpe ratio of the selected strategy.
+        Observed **per-observation** (non-annualized) Sharpe ratio of the
+        selected strategy. An annualized Sharpe must be divided by
+        ``sqrt(period)`` first, or the DSR saturates to ~1.
     n_obs : int
         Number of return observations.
     n_trials : int
@@ -175,7 +192,11 @@ def deflated_sharpe_ratio(
     skew, kurt : float
         Skewness / kurtosis of the selected strategy's returns.
     sr_variance : float
-        Variance of the Sharpe estimates **across the trials**.
+        Variance of the (per-observation) Sharpe estimates **across the
+        trials**. The default ``1.0`` is a conservative placeholder — it
+        overstates the expected-maximum benchmark and so understates the DSR;
+        pass the empirical variance of the trial Sharpes whenever available
+        (as :meth:`fynance.research.Ledger.deflated_sharpe` does).
 
     Returns
     -------

--- a/fynance/research/ledger.py
+++ b/fynance/research/ledger.py
@@ -56,8 +56,37 @@ class Ledger:
         self.root = Path(root)
 
     def append(self, experiment: Experiment) -> Path:
-        """ Persist ``experiment`` under the ledger root; return its json path. """
+        """ Persist ``experiment`` under the ledger root; return its json path.
+
+        The store is **append-only**: appending an experiment whose ``name``
+        already exists raises :class:`FileExistsError` rather than silently
+        overwriting the prior run. Overwriting would undercount
+        :attr:`n_trials` and so deflate the multiple-testing correction fed to
+        the deflated Sharpe ratio. Pick a unique ``name`` (e.g. version-suffix
+        a re-run) before appending.
+
+        Parameters
+        ----------
+        experiment : Experiment
+            The experiment to persist.
+
+        Returns
+        -------
+        pathlib.Path
+            Path to the written ``experiment.json``.
+
+        Raises
+        ------
+        FileExistsError
+            If an experiment with the same ``name`` is already stored.
+
+        """
         self.root.mkdir(parents=True, exist_ok=True)
+        if (self.root / experiment.name / "experiment.json").exists():
+            raise FileExistsError(
+                f"experiment {experiment.name!r} already in the ledger; the "
+                f"store is append-only — use a unique name for a re-run"
+            )
 
         return experiment.save(self.root)
 
@@ -89,15 +118,50 @@ class Ledger:
         Uses the ledger's :attr:`n_trials` as the number of trials and the
         dispersion of the stored Sharpe metrics as the trial variance, so a
         selected strategy is judged against the multiple testing it came from.
+
+        The stored ``sharpe`` metric is **annualized** (by the ``period`` used
+        at run time, recorded in ``spec``), whereas
+        :func:`~fynance.research.deflated_sharpe_ratio` expects a
+        **per-observation** Sharpe (it scales by ``sqrt(n_obs - 1)``
+        internally). This method therefore de-annualizes both the selected
+        strategy's Sharpe and the across-trial variance before the call:
+        ``sr_obs = sr_annual / sqrt(period)`` and ``var_obs = var_annual /
+        period``. Skipping this de-annualization saturates the DSR to ~1
+        (a modest per-period edge looks certain), defeating the guard.
+
+        Parameters
+        ----------
+        experiment : Experiment
+            The selected experiment to deflate.
+        metric : str
+            Metric key holding the (annualized) Sharpe (default ``"sharpe"``).
+
+        Returns
+        -------
+        float
+            Deflated Sharpe ratio in ``[0, 1]``.
+
         """
-        sharpes = [float(e.metrics[metric]) for e in self.load()
-                   if metric in e.metrics]
+        period = self._period(experiment)
+        sharpes = [float(e.metrics[metric]) / np.sqrt(self._period(e))
+                   for e in self.load() if metric in e.metrics]
         sr_variance = float(np.var(sharpes)) if len(sharpes) > 1 else 1.0
 
         n_obs = len(experiment.series["returns"]) if (
             experiment.series and experiment.series.get("returns")) else 0
 
         return deflated_sharpe_ratio(
-            float(experiment.metrics[metric]), n_obs, max(self.n_trials, 1),
-            sr_variance=sr_variance,
+            float(experiment.metrics[metric]) / np.sqrt(period), n_obs,
+            max(self.n_trials, 1), sr_variance=sr_variance,
         )
+
+    @staticmethod
+    def _period(experiment: Experiment) -> float:
+        """ Annualization factor used to compute ``experiment``'s Sharpe. """
+        period = experiment.spec.get("period") if experiment.spec else None
+        try:
+            value = float(period)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return 252.0
+
+        return value if value > 0.0 else 252.0

--- a/fynance/research/runner.py
+++ b/fynance/research/runner.py
@@ -63,7 +63,14 @@ def _callable_name(fn: Any) -> str | None:
 
 
 def _seed_everything(seed: int) -> None:
-    """ Seed numpy (and torch if present) for reproducibility. """
+    """ Seed the global numpy (and torch) RNGs for reproducibility.
+
+    This mutates process-global RNG state via :func:`numpy.random.seed` so that
+    legacy strategies / models drawing from the global numpy RNG run
+    deterministically. Callers that need *independent* runs (e.g.
+    :func:`permutation_test`) must pass a **distinct** ``seed`` per run rather
+    than reusing one — otherwise every run replays the same global draws.
+    """
     np.random.seed(seed)
     try:  # torch is optional at call time
         import torch
@@ -145,18 +152,27 @@ def run_experiment(
     """
     _seed_everything(seed)
 
-    if costs is not None:
-        strategy.cost = costs
-
     prices = _to_array(data)
     n = prices.shape[0]
 
-    if walk_forward is not None:
-        target = np.zeros(n) if y is None else np.asarray(y)  # preserve dtype
-        result = strategy.run_walk_forward(data, target, **walk_forward, X=X)
+    # Overriding the cost model must not leak past this run: save and restore
+    # the strategy's own cost in a ``finally`` so a later run (or a sibling
+    # iteration of a permutation loop sharing the strategy) is unaffected.
+    _sentinel = object()
+    original_cost: Any = getattr(strategy, "cost", _sentinel)
+    try:
+        if costs is not None:
+            strategy.cost = costs
 
-    else:
-        result = strategy.run(data, y, X=X)
+        if walk_forward is not None:
+            target = np.zeros(n) if y is None else np.asarray(y)  # preserve dtype
+            result = strategy.run_walk_forward(data, target, **walk_forward, X=X)
+
+        else:
+            result = strategy.run(data, y, X=X)
+    finally:
+        if costs is not None and original_cost is not _sentinel:
+            strategy.cost = original_cost
 
     metrics = result.summary(period=period)
 

--- a/fynance/research/synthetic.py
+++ b/fynance/research/synthetic.py
@@ -83,8 +83,10 @@ def regime_switching(
 ) -> PriceSeries:
     """ Markov regime-switching price path.
 
-    At each step the active regime switches (to a uniformly-drawn regime) with
-    probability ``p_switch``; log-returns are then drawn from the active
+    The initial regime is drawn uniformly (rather than always starting in
+    regime 0, which biased short paths toward the first regime). At each
+    subsequent step the active regime switches (to a uniformly-drawn regime)
+    with probability ``p_switch``; log-returns are then drawn from the active
     regime's ``(mu, sigma)``. The varying volatility makes it a natural input
     for :func:`fynance.detect_regimes`.
 
@@ -122,7 +124,9 @@ def regime_switching(
 
     steps = max(n - 1, 0)
     states: NDArray[np.int_] = np.empty(steps, dtype=np.int_)
-    state = 0
+    # Draw the initial regime uniformly so short paths are not biased toward
+    # regime 0; subsequent steps switch with probability ``p_switch``.
+    state = int(rng.integers(0, k))
     for t in range(steps):
         if rng.random() < p_switch:
             state = int(rng.integers(0, k))

--- a/fynance/tests/research/test_compare.py
+++ b/fynance/tests/research/test_compare.py
@@ -4,6 +4,7 @@
 """ Tests for :mod:`fynance.research.compare`. """
 
 # Built-in
+import math
 from pathlib import Path
 
 # Third-party
@@ -12,7 +13,13 @@ import pytest
 
 # Local
 import fynance
-from fynance.research import compare_report, gbm, leaderboard, run_experiment
+from fynance.research import (
+    Experiment,
+    compare_report,
+    gbm,
+    leaderboard,
+    run_experiment,
+)
 from fynance.strategy import Strategy
 
 
@@ -35,6 +42,35 @@ def test_leaderboard_ranked_by_sharpe(experiments):
     assert {r["name"] for r in rows} == {"a", "b", "c"}
     sharpes = [r["sharpe"] for r in rows]
     assert sharpes == sorted(sharpes, reverse=True)
+
+
+def test_leaderboard_nan_sinks_to_bottom():
+    # A present-but-NaN metric must sort as "worst", not float to the top.
+    exps = [
+        Experiment(name="good", metrics={"sharpe": 2.0}),
+        Experiment(name="bad", metrics={"sharpe": float("nan")}),
+        Experiment(name="mid", metrics={"sharpe": 1.0}),
+    ]
+
+    rows = leaderboard(exps, sort_by="sharpe", descending=True)
+
+    assert [r["name"] for r in rows[:2]] == ["good", "mid"]
+    assert rows[-1]["name"] == "bad"  # NaN sank to the bottom
+    assert math.isnan(rows[-1]["sharpe"])
+
+
+def test_leaderboard_nan_sinks_ascending():
+    # Ascending (lower is better): NaN must still sink to the bottom.
+    exps = [
+        Experiment(name="bad", metrics={"sharpe": float("nan")}),
+        Experiment(name="best", metrics={"sharpe": -1.0}),
+        Experiment(name="worst", metrics={"sharpe": 5.0}),
+    ]
+
+    rows = leaderboard(exps, sort_by="sharpe", descending=False)
+
+    assert rows[0]["name"] == "best"
+    assert rows[-1]["name"] == "bad"
 
 
 def test_compare_report_writes_md_and_png(tmp_path, experiments):

--- a/fynance/tests/research/test_experiment.py
+++ b/fynance/tests/research/test_experiment.py
@@ -74,3 +74,28 @@ def test_version_and_timestamp_autoset():
 
     assert e.fynance_version == fynance.__version__
     assert e.created_at  # non-empty ISO timestamp
+
+
+def test_from_dict_tolerates_unknown_keys(populated):
+    # Forward compatibility: an artifact from a newer fynance may carry extra
+    # fields. from_dict must ignore them rather than raise TypeError.
+    data = populated.to_dict()
+    data["a_future_field"] = {"not": "known here"}
+    data["another_extra"] = 42
+
+    restored = Experiment.from_dict(data)
+
+    assert restored.name == "demo"
+    assert restored.metrics["sharpe"] == 1.5
+    assert not hasattr(restored, "a_future_field")
+
+
+def test_load_raises_clear_error_on_corrupt_json(tmp_path):
+    # A truncated / corrupt artifact must raise a clear ValueError naming the
+    # path, not leak a bare JSONDecodeError.
+    path = tmp_path / "bad" / "experiment.json"
+    path.parent.mkdir(parents=True)
+    path.write_text('{"name": "demo", "metrics": {', encoding="utf-8")  # truncated
+
+    with pytest.raises(ValueError, match="corrupt or truncated"):
+        Experiment.load(path)

--- a/fynance/tests/research/test_guards.py
+++ b/fynance/tests/research/test_guards.py
@@ -53,6 +53,44 @@ def test_dsr_decreases_with_more_trials():
     assert 0.0 <= many <= 1.0
 
 
+def test_psr_matches_hand_computed_reference():
+    # Worked reference (Bailey & Lopez de Prado PSR), hand-computed:
+    #   sr = 0.10 (per-observation), n_obs = 100, benchmark = 0, normal returns
+    #   denom = sqrt(1 - 0*sr + (3-1)/4 * sr^2) = sqrt(1 + 0.5 * 0.01) = 1.0024969
+    #   z     = (0.10 - 0) * sqrt(100 - 1) / denom = 0.99250926
+    #   PSR   = Phi(z) = 0.83952542
+    assert probabilistic_sharpe_ratio(0.1, 100) == pytest.approx(
+        0.8395254171844497, abs=1e-12
+    )
+
+
+def test_dsr_matches_hand_computed_reference():
+    # Worked reference (Bailey & Lopez de Prado DSR), hand-computed:
+    #   n_trials = 10, sr_variance = 0.04 (std 0.2)
+    #   E[max] gauss factor = (1 - g) * Phi^-1(1 - 1/10)
+    #                         + g * Phi^-1(1 - 1/(10 e)) = 1.57459830
+    #     (g = Euler-Mascheroni = 0.5772156649)
+    #   sr_star = sqrt(0.04) * 1.57459830 = 0.31491966
+    #   then PSR(sr=0.30 per-obs, n_obs=500, benchmark=sr_star):
+    #     denom = sqrt(1 + 0.5 * 0.30^2) = 1.0220568
+    #     z     = (0.30 - 0.31491966) * sqrt(499) / denom = -0.32602512
+    #     DSR   = Phi(z) = 0.37220268
+    assert deflated_sharpe_ratio(0.3, 500, 10, sr_variance=0.04) == pytest.approx(
+        0.3722026752956389, abs=1e-12
+    )
+
+
+def test_psr_dsr_not_saturated_for_realistic_inputs():
+    # A realistic annualized Sharpe (~1.0 daily) de-annualized to per-obs
+    # (1 / sqrt(252) = 0.063) must yield a sensible, non-saturated PSR/DSR.
+    sr_obs = 1.0 / np.sqrt(252)
+    psr = probabilistic_sharpe_ratio(sr_obs, 500)
+    dsr = deflated_sharpe_ratio(sr_obs, 500, 10, sr_variance=0.04 / 252)
+
+    assert 0.6 < psr < 0.999  # informative, not pinned at 1.0
+    assert 0.3 < dsr < 0.95   # the multiple-testing correction still bites
+
+
 # -- permutation test ------------------------------------------------------
 
 def test_permutation_structure_and_determinism():
@@ -62,6 +100,49 @@ def test_permutation_structure_and_determinism():
     assert set(out1) == {"observed", "p_value", "null_mean", "null_std"}
     assert 0.0 < out1["p_value"] <= 1.0
     assert out1 == out2  # fully reproducible
+
+
+def stochastic_momentum() -> Strategy:
+    """ Momentum whose features carry noise drawn from the global numpy RNG. """
+    def features(p):
+        base = np.diff(p, prepend=p[0])
+        return base + 0.01 * np.std(base) * np.random.standard_normal(base.shape)
+
+    return Strategy(features=features)
+
+
+def test_permutation_threads_distinct_seeds_per_run():
+    # Regression: the master seed used to be reused verbatim for the observed
+    # run and every permutation, so a stochastic strategy replayed *identical*
+    # model RNG draws on every path. The fix derives a distinct seed per run.
+    # Reconstruct the old "reuse one seed" null and assert the real null is not
+    # the same sequence, while staying fully reproducible.
+    from fynance.research.runner import run_experiment
+
+    strat = stochastic_momentum()
+    prices = gbm(300, seed=1).to_numpy()
+    log_ret = np.diff(np.log(prices))
+    s0 = float(prices[0])
+    seed, n_perm = 7, 30
+
+    out = permutation_test(strat, prices, n_permutations=n_perm, seed=seed)
+
+    # Old behavior: every run seeded with the same master seed.
+    rng = np.random.default_rng(seed)
+    legacy = np.empty(n_perm)
+    for i in range(n_perm):
+        shuffled = rng.permutation(log_ret)
+        path = s0 * np.exp(np.concatenate([[0.0], np.cumsum(shuffled)]))
+        legacy[i] = run_experiment(strat, path, name="perm", seed=seed
+                                   ).metrics["sharpe"]
+
+    # The fixed null differs from the legacy (one-seed) null for a stochastic
+    # strategy: the model noise now varies across permutations too.
+    assert not np.allclose([out["null_mean"]], [legacy.mean()])
+    assert out["null_std"] > 0.0
+    # Still reproducible for a fixed seed.
+    out2 = permutation_test(strat, prices, n_permutations=n_perm, seed=seed)
+    assert out == out2
 
 
 def test_permutation_detects_autocorrelation_edge():

--- a/fynance/tests/research/test_ledger.py
+++ b/fynance/tests/research/test_ledger.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 # Third-party
 import numpy as np
+import pytest
 
 # Local
 import fynance
@@ -75,3 +76,62 @@ def test_n_trials_counts_only_experiments(tmp_path):
     (tmp_path / "stray" / "report.md").write_text("noise")
 
     assert led.n_trials == 1
+
+
+def test_append_rejects_duplicate_name(tmp_path):
+    # Append-only: a name collision must raise rather than silently overwrite
+    # (which would undercount n_trials and deflate the DSR correction).
+    led = Ledger(tmp_path)
+    led.append(Experiment(name="dup", metrics={"sharpe": 1.0}))
+
+    with pytest.raises(FileExistsError):
+        led.append(Experiment(name="dup", metrics={"sharpe": 9.0}))
+
+    # The original is untouched and the trial count stays correct.
+    assert led.n_trials == 1
+    assert led.load()[0].metrics["sharpe"] == 1.0
+
+
+def test_deflated_sharpe_deannualizes_not_saturated(tmp_path):
+    # Realistic annualized Sharpes (~1) over n_obs ~ 500 must NOT saturate the
+    # DSR to ~1 once de-annualized; before the fix the annualized Sharpe was
+    # fed straight in, pinning the DSR at ~1.
+    led = Ledger(tmp_path)
+    rng = np.random.default_rng(0)
+    for i in range(12):
+        n = 500
+        # Per-day Sharpe ~ 0.06 -> annualized ~ 1.0, with spread across trials.
+        per_day = 0.06 + 0.02 * rng.standard_normal()
+        sharpe_annual = per_day * np.sqrt(252)
+        returns = (per_day + rng.standard_normal(n)).tolist()
+        led.append(Experiment(
+            name=f"t{i}",
+            spec={"period": 252},
+            metrics={"sharpe": float(sharpe_annual)},
+            series={"returns": returns},
+        ))
+
+    best = max(led.load(), key=lambda e: e.metrics["sharpe"])
+    dsr = led.deflated_sharpe(best)
+
+    assert 0.0 <= dsr <= 1.0
+    assert dsr < 0.999  # NOT saturated — the multiple-testing correction bites
+
+
+def test_deflated_sharpe_uses_recorded_period(tmp_path):
+    # The de-annualization must use the period recorded in spec. A monthly run
+    # (period=12) and a daily run (period=252) carrying the SAME annualized
+    # Sharpe de-annualize to different per-obs Sharpes -> different DSR.
+    returns = np.random.default_rng(1).standard_normal(400).tolist()
+
+    def _led(period):
+        led = Ledger(tmp_path / f"p{period}")
+        e = Experiment(name="x", spec={"period": period},
+                       metrics={"sharpe": 1.5}, series={"returns": returns})
+        led.append(e)
+        return led, e
+
+    led_d, e_d = _led(252)
+    led_m, e_m = _led(12)
+
+    assert led_d.deflated_sharpe(e_d) != led_m.deflated_sharpe(e_m)

--- a/fynance/tests/research/test_run_experiment.py
+++ b/fynance/tests/research/test_run_experiment.py
@@ -71,6 +71,27 @@ def test_costs_override_changes_result():
     assert free.metrics != pricey.metrics
 
 
+def test_costs_override_does_not_mutate_strategy():
+    # The override must be confined to the single run: a later run on the same
+    # strategy must not inherit it (an aliasing hazard in permutation loops).
+    own = ProportionalCost(0.0005)
+    strat = Strategy(features=lambda p: np.diff(p, prepend=p[0]), cost=own)
+    data = gbm(400, seed=3)
+
+    overridden = run_experiment(strat, data, name="ovr", costs=ProportionalCost(0.02))
+
+    assert strat.cost is own  # restored, not left pointing at the override
+
+    # And a subsequent run with no override uses the strategy's own cost.
+    again = run_experiment(strat, data, name="again")
+    baseline = run_experiment(
+        Strategy(features=lambda p: np.diff(p, prepend=p[0]), cost=ProportionalCost(0.0005)),
+        data, name="base",
+    )
+    assert again.metrics == baseline.metrics
+    assert again.metrics != overridden.metrics
+
+
 def test_no_lookahead_walk_forward():
     # Perturbing the tail must not change the out-of-sample returns on the
     # earlier (unperturbed) prefix — a black-box causality probe.

--- a/fynance/tests/research/test_synthetic.py
+++ b/fynance/tests/research/test_synthetic.py
@@ -52,3 +52,26 @@ def test_zero_length_edge_cases():
     # n == 1 -> a single starting price, no returns.
     assert gbm(1, s0=100.0, seed=0).to_numpy().tolist() == [100.0]
     assert regime_switching(1, s0=100.0, seed=0).to_numpy().tolist() == [100.0]
+
+
+def test_regime_switching_initial_state_is_drawn():
+    # With p_switch=0 the only regime randomness is the *initial* state. It used
+    # to be hard-coded to regime 0 (biasing short paths); now it is drawn, so
+    # across seeds both regimes must appear. Distinct sigmas make the active
+    # regime visible in the first log-return's magnitude.
+    regimes = ((0.0, 0.001), (0.0, 0.5))
+    high_vol = []
+    for s in range(40):
+        p = regime_switching(2, regimes=regimes, p_switch=0.0, seed=s).to_numpy()
+        first_ret = np.diff(np.log(p))[0]
+        high_vol.append(abs(first_ret) > 0.05)  # True => started in regime 1
+
+    assert any(high_vol)          # regime 1 was sometimes the initial state
+    assert any(not h for h in high_vol)  # regime 0 too -> genuinely drawn
+
+
+def test_regime_switching_initial_state_reproducible():
+    a = regime_switching(50, p_switch=0.1, seed=9).to_numpy()
+    b = regime_switching(50, p_switch=0.1, seed=9).to_numpy()
+
+    assert np.allclose(a, b)


### PR DESCRIPTION
## Summary

Audited bug fixes in the **data-agnostic, results-free** `fynance.research` R&D harness (roadmap 1.H). Scope confined to `fynance/research/*.py` and the mirror tests in `fynance/tests/research/`. No real datasets or empirical results embedded.

## Findings fixed

| Sev | Location | Fix |
|-----|----------|-----|
| HIGH | `ledger.deflated_sharpe` | De-annualize the stored Sharpe and across-trial variance before calling `deflated_sharpe_ratio` (which expects a **per-observation** Sharpe): `sr/sqrt(period)`, `var/period`, using the `period` recorded in `spec`. Previously the annualized Sharpe was fed straight in, saturating PSR/DSR to ~1. |
| HIGH | `ledger.append` | Reject duplicate experiment `name` (`FileExistsError`) instead of silently overwriting — the overwrite undercounted `n_trials` and deflated the DSR multiple-testing correction. |
| HIGH | `runner.run_experiment` | Save/restore `strategy.cost` in a `finally` when `costs=` is given, so the override no longer leaks into later runs (aliasing hazard in permutation loops). |
| MED | `compare.leaderboard` / `ledger.leaderboard` | Treat a present-but-NaN sort metric as the worst sentinel (sinks to the bottom, per the docstring) instead of floating to the top. |
| MED | `experiment.from_dict` / `load` | `from_dict` filters to known dataclass fields (forward-compatible with newer artifacts); `load` re-raises corrupt/truncated JSON as a clear `ValueError` naming the path. |
| MED | `guards.permutation_test` | Thread a distinct per-run seed derived from the master seed so a stochastic strategy does not replay identical RNG draws on every permutation (biasing the null variance). Stays reproducible. Documents the `prices>0` precondition and the `sr_variance` placeholder. |
| MED (tests) | `test_guards.py` | Added PSR/DSR assertions against **hand-computed worked reference values** (Bailey & Lopez de Prado), plus corrupt-input / schema-evolution / duplicate-name tests. |
| LOW | `synthetic.regime_switching` | Draw the initial regime uniformly instead of always starting in regime 0 (biased short paths). Reproducibility preserved. |
| LOW | `guards.deflated_sharpe_ratio` docstring | Note `sr_variance=1.0` is a conservative placeholder; clarify `sr` must be per-observation. |

## Formula correctness

PSR/DSR formulas unchanged and verified against hand-computed values:
- `PSR(0.1, 100) = 0.83952542`
- `DSR(0.3, 500, n_trials=10, sr_variance=0.04) = 0.37220268`

The permutation p-value `(#{null >= obs} + 1) / (n + 1)` is untouched.

## Tests

Each fix has a seeded regression test that **fails before, passes after** — verified by stashing the source fixes and running the new tests against the buggy tree (10/13 failed as expected; the 3 that passed are direct PSR/DSR guard-formula assertions, correct on both sides).

## Gate

- `ruff check fynance/` — clean
- `mypy fynance/` — clean (168 files)
- `pytest fynance/research/ fynance/tests/research/ -o addopts='--doctest-modules'` — 73 passed, 1 skipped

`CHANGELOG.md`, `doc/dev/07-roadmap.md`, and `__init__.py` exports were **not** touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYiBP4z6rdZA1BHnEUqG4p