### PR TITLE
docs: fix doc drift (CONTRIBUTING/status/README/Sphinx) for v2.9.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,12 +8,13 @@ git clone https://github.com/ArthurBernard/Fynance.git
 cd Fynance
 pip install -e ".[dev]"
 
-# Compile Cython extensions
-python setup.py build_ext --inplace
-
 # Activate the project git hooks (run once per clone)
 git config core.hooksPath .githooks
 ```
+
+The build is **pure-Python** — there is no compile step and no `setup.py`.
+Numerical kernels are Numba `@njit` (JIT-compiled on first call), and
+`pyproject.toml` is the authoritative build config.
 
 ## Git Flow
 
@@ -34,12 +35,12 @@ master          ← stable releases only (tagged vX.Y.Z, published to PyPI)
 - `develop` → `master` happens only at release time (version bump + tag).
 
 **Branch naming:** `feat/`, `fix/`, `chore/`, `docs/` + short kebab-case description.
-Examples: `feat/transformer-model`, `fix/cython3-compat`, `chore/pyproject-migration`.
+Examples: `feat/transformer-model`, `fix/numpy2-compat`, `chore/pyproject-migration`.
 
 **Commit style:** [Conventional Commits](https://www.conventionalcommits.org/)
 ```
 feat: add TCN model to fynance/models/
-fix: replace ** operator in momentums_cy.pyx for Cython 3 compat
+fix: clamp adaptive window to avoid lookahead on short series
 chore: migrate setup.py metadata to pyproject.toml
 docs: add Git Flow section to CONTRIBUTING.md
 ```
@@ -48,15 +49,20 @@ docs: add Git Flow section to CONTRIBUTING.md
 
 | Subpackage | Description | Policy |
 |---|---|---|
-| `fynance.features` | Metrics, indicators, filters (Cython + Python) | Extend only — never rewrite Cython |
-| `fynance.algorithms` | Portfolio allocation (HRP, MVP, ERC, IVP, MDP) | Stable public API — deprecation path required |
-| `fynance.models` | PyTorch neural networks (MLP, GRU, LSTM, Transformer) | Modernize freely |
-| `fynance.backtest` | Performance evaluation, loss series | Improve freely |
-| `fynance.estimator` | Cython ARMA/GARCH parameter estimation | Do not duplicate in Python layer |
+| `fynance.features` | Indicators, momentums, filters, scaling, regime, money management (Numba kernels) | Extend freely — kernels are Numba `@njit` |
+| `fynance.metrics` | Risk-adjusted ratios, drawdown, returns, `summary` | Extend freely |
+| `fynance.portfolio` | Portfolio allocation (HRP, MVP, ERC, IVP, MDP) + sizing | Stable public API — deprecation path required |
+| `fynance.models` | PyTorch nets (MLP, RNN/GRU/LSTM, attention, TCN, Transformer) + econometric ARMA/GARCH + losses | Modernize freely |
+| `fynance.backtest` | Vectorized engine, cost models, `BacktestResult` | Improve freely |
+| `fynance.estimator` / `fynance.models.econometric_models` | Numba ARMA/GARCH parameter estimation | Single implementation — do not duplicate parameter logic |
+
+See [`doc/dev/04-subpackages.md`](doc/dev/04-subpackages.md) for the full
+policy matrix (including `core`, `data`, `signal`, `plot`, `strategy`,
+`research`).
 
 ## Code conventions
 
-**Numerical code:** new performance-critical functions go in the `.py` file using Numba `@njit`. Do not add new Cython files — Cython is only for wrapping C libraries.
+**Numerical code:** new performance-critical functions go in the `.py` file using Numba `@njit`. There is **no Cython** in the package (since 2.1 the former `*_cy.pyx` kernels were ported to Numba); only add Cython to wrap a C library.
 
 **ML:** PyTorch only. Do not extend the legacy Keras/TensorFlow code.
 
@@ -81,16 +87,6 @@ pytest --cov=fynance --cov-report=term-missing
 
 Tests must pass before opening a PR. No lookahead bias in time-series tests (no shuffling, no future data leaking into training windows).
 
-## Cython extensions
-
-When editing a `.pyx` file, recompile before running tests:
-
-```bash
-python setup.py build_ext --inplace
-```
-
-Do not add new Cython files. New numerical code goes in the `.py` counterpart using Numba `@njit`.
-
 ## Linting
 
 ```bash
@@ -99,16 +95,24 @@ ruff check fynance/
 
 ## Stability and deprecations
 
-The symbols re-exported from `fynance.models`, `fynance.algorithms.allocation`,
-`fynance.features` and `fynance.estimator` form the **public API for the 1.x
-series**. Within 1.x:
+> **2.0 was a breaking release** (layered architecture, import-path map in
+> [`doc/MIGRATION-2.0.md`](doc/MIGRATION-2.0.md) — e.g. `fynance.algorithms` →
+> `fynance.portfolio`, performance metrics → `fynance.metrics`). The notes below
+> describe the stability contract **within the 2.x series**.
 
-- public function and class signatures are frozen — no removals, no
+Per-subpackage change budgets are governed by the policy matrix in
+[`doc/dev/04-subpackages.md`](doc/dev/04-subpackages.md). The headline rule:
+`fynance.portfolio.allocation` (ERC/HRP/IVP/MDP/MVP) and
+`fynance.estimator` / `fynance.models.econometric_models` are the **stable
+public surface** — within 2.x:
+
+- public function and class signatures there are frozen — no removals, no
   backward-incompatible signature changes;
 - behavioural changes that would break user code go through **one
   release** of `DeprecationWarning` before becoming the default;
-- internal helpers (names prefixed with `_`) and `fynance.backtest`
-  remain free to evolve without a deprecation cycle.
+- internal helpers (names prefixed with `_`) and the freely-evolving layers
+  (`features`/`metrics`/`models`/`backtest`/`plot`/`strategy`/`research`) may
+  change without a deprecation cycle, additively.
 
 Active deprecations are tracked in [CHANGELOG.md](CHANGELOG.md).
 
@@ -118,7 +122,7 @@ Active deprecations are tracked in [CHANGELOG.md](CHANGELOG.md).
 import warnings
 
 warnings.warn(
-    "old_function() is deprecated and will be removed in fynance 2.0; "
+    "old_function() is deprecated and will be removed in fynance 3.0; "
     "use new_function() instead.",
     category=DeprecationWarning,
     stacklevel=2,
@@ -142,7 +146,7 @@ def test_old_function_still_works():
 
 ### Silencing fynance deprecations (downstream users)
 
-If you depend on a deprecated path and need to stay on 1.x while you
+If you depend on a deprecated path and need to stay on 2.x while you
 migrate, opt out **explicitly**:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -60,9 +60,11 @@ alignment/resampling, and no-lookahead temporal splits (`train_test_split`,
 `walk_forward`).
 
 **Features** `fynance.features` — technical indicators (Bollinger, RSI, MACD, ROC,
-realized volatility, rolling skew/kurtosis/autocorr, …), momentums (SMA, EMA, WMA),
-scaling (incl. rolling rank), statistics, feature engineering (multi-resolution,
-Granger causality) and market-regime detection.
+realized volatility, rolling skew/kurtosis/autocorr, …), OHLCV indicators (ATR,
+ADX, Williams %R, OBV, VWAP), a causal GARCH(1,1) conditional-volatility feature,
+momentums (SMA, EMA, WMA) and adaptive windows, scaling (incl. rolling rank),
+statistics, feature engineering (multi-resolution, Granger causality) and
+market-regime detection.
 
 **Metrics** `fynance.metrics` — performance/evaluation metrics (Sharpe, Sortino,
 Calmar, drawdown, …) and a one-call `summary`.
@@ -74,15 +76,17 @@ Calmar, drawdown, …) and a one-call `summary`.
 sizing (fractional Kelly, volatility targeting, transaction costs).
 
 **Backtest** `fynance.backtest` — vectorized engine (`backtest`: positions +
-returns/prices + cost → `BacktestResult`) and cost models.
+returns/prices + cost → `BacktestResult`) and cost models (`ProportionalCost`
+and the non-linear `MarketImpactCost`).
 
 **Plot** `fynance.plot` — composable matplotlib figures and a one-call
 `tearsheet` report.
 
 **Models** `fynance.models` — econometric models (MA, ARMA, ARMA-GARCH) and
 PyTorch nets (MLP, RNN, GRU, LSTM, MultiHeadAttention, TCN, Transformer), a
-direction+magnitude stacking ensemble, differentiable losses (Sharpe, Sortino,
-Calmar, Omega, directional, hybrid), and robust-training utilities.
+direction+magnitude stacking ensemble, `RegimeMoE` (regime-conditioned
+mixture-of-experts), differentiable losses (Sharpe, Sortino, Calmar, Omega,
+directional, hybrid), and robust-training utilities.
 
 **Strategy** `fynance.strategy` — optional orchestrator composing the maillons
 end-to-end, with single-run and walk-forward evaluation.

--- a/doc/dev/01-overview.md
+++ b/doc/dev/01-overview.md
@@ -33,13 +33,14 @@ library's core invariant, enforced in tests.
 
 ## Current state (snapshot)
 
-- **Version `2.8.0`** (in `pyproject.toml`, static), released on `master` and
+- **Version `2.9.0`** (in `pyproject.toml`, static), released on `master` and
   published to PyPI; `Development Status :: 5 - Production/Stable`.
 - **Python 3.10–3.13** (CI matrix). Build is **pure-Python** (setuptools, no
   compile step) — numerical kernels are Numba `@njit`. No Cython.
-- **518 tests** under `fynance/tests/` (mirrors the package), **plus doctests**
-  run on every module via `--doctest-modules` — docstring examples are part of
-  the suite and must stay runnable.
+- **~570 unit/benchmark tests** under `fynance/tests/` (mirrors the package),
+  **plus doctests** run on every module via `--doctest-modules` — docstring
+  examples are part of the suite and must stay runnable (~660 collected in
+  total).
 - **Four CI gates**: pytest (3.10–3.13), `ruff`, `interrogate` (docstring
   coverage ≥ 80%), Sphinx build `-W`, and `mypy` clean.
 - **Core stack**: NumPy, SciPy, Numba (`@njit`), **PyTorch** (the ML backend —

--- a/doc/dev/05-testing.md
+++ b/doc/dev/05-testing.md
@@ -4,7 +4,7 @@
 
 | Layer | Command | Catches |
 |-------|---------|---------|
-| **Unit** | `pytest` | logic, shapes, regressions (518 tests under `fynance/tests/`) |
+| **Unit** | `pytest` | logic, shapes, regressions (~570 unit/benchmark tests under `fynance/tests/`; ~660 collected with doctests) |
 | **Doctests** | `pytest --doctest-modules` (on by default in `pyproject.toml`) | every docstring `>>>` example — they are part of the suite |
 | **Benchmarks** | `pytest-benchmark` (e.g. `test_filters_benchmark.py`) | perf regressions on hot paths |
 | **Coverage** | `pytest --cov=fynance --cov-report=term-missing` | untested branches |

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -16,17 +16,21 @@ so an agent doesn't re-investigate settled ground or assume a known stub is a bu
 - **Data**: `load()` dispatcher + CSV/Parquet adapters, causal `align`/`resample`,
   and no-lookahead `train_test_split`/`walk_forward` (embargo/purge).
 - **Features**: technical indicators (RSI/MACD/Bollinger/CCI/HMA/ROC/realized-vol/
-  skew/kurt/autocorr), momentums (SMA/EMA/WMA + std variants), scaling (z-score,
-  rolling rank), statistics, feature engineering (multi-resolution, Granger,
+  skew/kurt/autocorr), **OHLCV indicators** (ATR/ADX/Williams %R/OBV/VWAP),
+  **causal GARCH(1,1) conditional volatility** as a feature (`garch_volatility`),
+  momentums (SMA/EMA/WMA + std variants), **adaptive windows** (`adaptive_roll`/
+  `adaptive_volatility`), scaling (z-score, rolling rank), statistics, money
+  management (`iso_vol`), feature engineering (multi-resolution, Granger,
   incremental moments) and k-means market-regime detection.
 - **Metrics**: `fynance.metrics` (Sharpe/Sortino/Calmar/diversified-ratio,
   annual return/vol, drawdown/mdd, perf_*, roll_*) + one-call `summary`.
 - **Models**: econometric (ARMA/GARCH) + neural (MLP, RNN/GRU/LSTM, attention,
   TCN, Transformer) on PyTorch; `StackingEnsemble` (direction+magnitude OOF
-  meta-model); differentiable losses (Sharpe/Sortino/Calmar/Omega/directional/
-  hybrid) in `models/loss/`; robust-training utils (purged CV, early stopping,
-  sample weighting) in `models/training.py`. All NN models conform to
-  `SignalModel` (`fit`/`predict`).
+  meta-model); **`RegimeMoE`** (regime-conditioned mixture-of-experts — an
+  objective-aligned net gated on a **causal** regime label); differentiable
+  losses (Sharpe/Sortino/Calmar/Omega/directional/hybrid) in `models/loss/`;
+  robust-training utils (purged CV, early stopping, sample weighting) in
+  `models/training.py`. All NN models conform to `SignalModel` (`fit`/`predict`).
 - **Objective-aligned training** (`models/objective.py`): `ObjectiveModel` trains
   any `nn.Module` (MLP by default) **directly on a differentiable financial
   objective** (`SharpeLoss`/`SortinoLoss`/…) — the net outputs positions, the loss
@@ -38,9 +42,11 @@ so an agent doesn't re-investigate settled ground or assume a known stub is a bu
   vol-targeting + **anti-churn** `ema_smooth`/`deadband`/`min_hold` +
   `SignalPipeline`); `portfolio/` allocation (ERC/HRP/IVP/MDP/MVP) + sizing
   (fractional Kelly, vol-targeting, transaction costs).
-- **Backtest / Plot**: vectorized `backtest()` engine → `BacktestResult`,
-  `ProportionalCost`; reporting via `fynance.plot` (`tearsheet`, composable
-  figures, lazy matplotlib so `import fynance` stays matplotlib-free).
+- **Backtest / Plot**: vectorized `backtest()` engine → `BacktestResult`, cost
+  models (`ProportionalCost` + **`MarketImpactCost`** — a convex, super-linear
+  market-impact term on top of the linear fee); reporting via `fynance.plot`
+  (`tearsheet`, composable figures, lazy matplotlib so `import fynance` stays
+  matplotlib-free).
 - **Research harness** (`fynance.research`, S1–S3 complete): `Experiment`
   (serializable spec + code + seed + metrics + curves), `run_experiment` (seeded,
   cost-aware, walk-forward; no-lookahead probe; records a **provenance** block —
@@ -60,21 +66,22 @@ so an agent doesn't re-investigate settled ground or assume a known stub is a bu
 - **Numerical kernels on Numba `@njit`** — no Cython anywhere; the build is
   pure-Python (no `setup.py`, no compile step). Every kernel has a golden-value
   parity test (1e-9/1e-10) captured from the former Cython.
-- **Quality gates (all 4 enforced in CI)**: 593 tests collected (unit + doctests
-  on every module via `--doctest-modules`), incl. property tests (kernel parity + no-lookahead);
-  `ruff`; `interrogate` (docstring coverage ≥ 80%, currently ~93.6%); Sphinx
-  build `-W`; **`mypy` clean (0 errors)**.
-- **Released**: `v2.8.0` on `master` + PyPI; `Production/Stable`. CI matrix
+- **Quality gates (all 4 enforced in CI)**: ~660 tests collected (~570 unit/
+  benchmark + doctests on every module via `--doctest-modules`), incl. property
+  tests (kernel parity + no-lookahead); `ruff`; `interrogate` (docstring coverage
+  ≥ 80%, currently ~93.6%); Sphinx build `-W`; **`mypy` clean (0 errors)**.
+- **Released**: `v2.9.0` on `master` + PyPI; `Production/Stable`. CI matrix
   3.10–3.13; release builds a pure-Python universal wheel + sdist and creates the
   GitHub Release from the CHANGELOG on tag.
 
 ## In progress / active surface
 
-Nothing is currently in flight (`develop` is clean). The 2.x library is
-feature-complete for its current scope; remaining open work is **library bricks**
-only — multi-series OHLCV indicators, regime-conditioned architecture, adaptive
-windows, a richer backtest, and an optional Streamlit ledger explorer. See the
-roadmap (§1–§2) and the **Deferred** section below.
+Nothing is currently in flight (`develop` is clean). The v2.9.0 **library
+bricks** all shipped (OHLCV indicators, causal GARCH-volatility feature,
+adaptive windows, `RegimeMoE`, `MarketImpactCost`). Remaining open work is the
+**2026-06 audit remediation** (correctness/tests/docs the CI gates don't catch —
+roadmap §1), an optional **Streamlit ledger explorer** (roadmap §2), and minor
+**CI/badge hygiene** (roadmap §3). See `07-roadmap.md`.
 
 **Out of scope here**: strategy research on **real data** (empirical loss /
 architecture / normalization benchmarks, out-of-sample Sharpe, online regimes,
@@ -110,10 +117,24 @@ which depends on fynance. This public repo stays data-agnostic and result-free.
 
 ## Deferred
 
-Larger axes parked for later: realistic backtesting beyond proportional cost
-(non-linear slippage / market impact), market-regime conditioning of the
-architecture, adaptive windows, and multi-series OHLCV indicators (ATR/ADX/OBV/
-VWAP) requiring a multi-series input API. Tracked in the roadmap; not bugs.
+The library bricks that were parked here — realistic backtesting beyond
+proportional cost (non-linear market impact), market-regime conditioning of the
+architecture, adaptive windows, and multi-series OHLCV indicators
+(ATR/ADX/OBV/VWAP) — **all shipped in v2.9.0**. The only library axis still
+deferred is the optional **Streamlit ledger explorer** (roadmap §2). Tracked in
+the roadmap; not bugs.
+
+## 2026-06-22 — library bricks shipped (v2.9.0); audit remediation opened
+
+The data-agnostic **library bricks** that the re-scoped roadmap kept all landed
+in **v2.9.0**: an `OHLCV` container + multi-series indicators
+(ATR/ADX/Williams %R/OBV/VWAP), the **causal GARCH(1,1) conditional-volatility
+feature** (`garch_volatility`), **adaptive windows** (`adaptive_roll`/
+`adaptive_volatility`), regime-conditioned architecture (`RegimeMoE`), and a
+non-linear **`MarketImpactCost`**. A full audit (2026-06-22) — all five gates
+(pytest/ruff/mypy/interrogate/sphinx) already green — surfaced correctness bugs,
+test gaps and doc drift the gates don't catch; tracked as the parallelizable
+remediation backlog in roadmap §1.
 
 ## 2026-06-21 — research line shipped (v2.2 → v2.8); roadmap re-scoped
 

--- a/doc/dev/README.md
+++ b/doc/dev/README.md
@@ -20,8 +20,8 @@ live in the repo-root `CLAUDE.md`.
    Numba kernels (golden-value parity), the rolling/walk-forward pattern, the
    estimator→models pipeline.
 3. [`03-decisions.md`](03-decisions.md) — the design choices and *why* (Numba over
-   new Cython, PyTorch over Keras, the loss-function split, NumPy over polars),
-   plus the running ADR journal.
+   new Cython, PyTorch over Keras, the loss-function split, polars at the edges
+   with NumPy at the core), plus the running ADR journal.
 4. [`04-subpackages.md`](04-subpackages.md) — the per-subpackage map, public API
    surface, and the stability/modernisation policy that governs each.
 5. [`05-testing.md`](05-testing.md) — the testing layers (pytest + doctests +

--- a/doc/source/data.rst
+++ b/doc/source/data.rst
@@ -17,3 +17,16 @@ alignment/resampling, and no-lookahead temporal splits.
    resample
    train_test_split
    walk_forward
+
+Custom sources
+==============
+
+The registry extension API: subclass :class:`BaseDataSource`, `register` it under
+a file extension, and :func:`load` (or :func:`get_source`) will dispatch to it.
+
+.. autosummary::
+   :toctree: generated/
+
+   BaseDataSource
+   register
+   get_source

--- a/doc/source/features.stats.rst
+++ b/doc/source/features.stats.rst
@@ -19,3 +19,17 @@ z-score, and mean absolute deviation.
    roll_z_score
    mad
    roll_mad
+
+Money management
+================
+
+Volatility-targeted position sizing as a **causal** feature: the
+:func:`~fynance.features.money_management.iso_vol` leverage scales an exposure so
+its realized volatility tracks a target, using only the past.
+
+.. currentmodule:: fynance.features.money_management
+
+.. autosummary::
+   :toctree: generated/
+
+   iso_vol

--- a/doc/source/metrics.rst
+++ b/doc/source/metrics.rst
@@ -54,3 +54,10 @@ Aggregated report
    :toctree: generated/
 
    summary
+
+:func:`summary` is driven by the ``METRICS`` registry — a name → callable
+mapping (``annual_return``, ``annual_volatility``, ``sharpe``, ``sortino``,
+``calmar``, ``max_drawdown``) you can read or extend.
+
+.. autodata:: METRICS
+   :no-value:


### PR DESCRIPTION
Roadmap §1.I — docs-only audit remediation. Fixes documentation drift after v2.9.0; no code in `fynance/*.py` changed (only `doc/source/*.rst` and markdown docs).

## Findings fixed
- **CRITICAL** `CONTRIBUTING.md`: removed the stale `python setup.py build_ext --inplace` / "recompile .pyx" / "Compile Cython extensions" steps (pure-Python/Numba since 2.1, no `setup.py`); setup is now `pip install -e ".[dev]"` + `git config core.hooksPath .githooks`; fixed `fynance.algorithms` → `fynance.portfolio` and the architecture table; re-framed the stability/deprecation contract for the **2.x** series (was "1.x → fynance 2.0") and linked `doc/dev/04-subpackages.md`.
- **HIGH** `doc/dev/06-status.md`: bumped to **v2.9.0**; moved OHLCV indicators (ATR/ADX/Williams %R/OBV/VWAP), the causal GARCH-volatility feature, adaptive windows, `RegimeMoE` and `MarketImpactCost` from Deferred/in-progress to **Done**; reconciled the test count; added a dated 2026-06-22 entry.
- **HIGH** `doc/dev/01-overview.md` + `05-testing.md`: `2.8.0` → `2.9.0`; replaced the stale "518 tests" with accurate counts (~570 unit/benchmark, ~660 collected with doctests).
- **MEDIUM** `README.md`: surfaced the v2.9 headline additions (OHLCV indicators, causal GARCH-volatility feature, adaptive windows, `RegimeMoE`, `MarketImpactCost`).
- **MEDIUM** Sphinx: documented `iso_vol` (new Money-management block in `features.stats.rst`) and the data registry extension API (`BaseDataSource`/`register`/`get_source` — new "Custom sources" block in `data.rst`).
- **LOW** `doc/dev/README.md`: "NumPy over polars" → "polars at the edges, NumPy at the core". Added the `METRICS` registry to `metrics.rst`.

`README.md` Notebooks/apps references were verified to still exist — left unchanged.

## Gates
- `sphinx-build -W` (warnings-as-errors): **build succeeded, 0 warnings**; all new autosummary/autodata entries resolve.
- README quickstart + every doc-referenced import (`iso_vol`, OHLCV indicators, `garch_volatility`, adaptive windows, `BaseDataSource`/`register`/`get_source`, `RegimeMoE`, `MarketImpactCost`, `METRICS`) run clean.
- Only `doc/source/*.rst` source + markdown docs staged; no generated artifacts committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYiBP4z6rdZA1BHnEUqG4p