### PR TITLE
fix: repair 2-D axis=1 path across features (roadmap 1.A)

### DIFF
--- a/fynance/_wrappers.py
+++ b/fynance/_wrappers.py
@@ -61,13 +61,13 @@ def wrap_axis(func):
                 stacklevel=2,
             )
 
-        if shape[axis] < min_size:
+        if X.ndim <= axis:
+
+            raise np.exceptions.AxisError(axis, X.ndim)
+
+        elif shape[axis] < min_size:
 
             raise ArraySizeError(shape[axis], axis=axis, min_size=min_size)
-
-        elif X.ndim <= axis:
-
-            raise np.AxisError(axis, len(X.shape))
 
         elif axis == 1 and X.ndim == 2:
 
@@ -105,8 +105,13 @@ def wrap_window(func):
     """ Check if the lagged window `w` is available for `X` array. """
     @wraps(func)
     def check_window(X, w=None, **kwargs):
+        # The window must be validated against the time axis. `wrap_window`
+        # runs before `wrap_axis` transposes the array, so the time axis is
+        # still `axis` (default 0) of the input array here.
+        axis = kwargs.get('axis', 0)
+        size = X.shape[axis] if axis < X.ndim else X.shape[0]
         if w == 0 or w is None:
-            w = X.shape[0]
+            w = size
 
         elif 'min_size' in kwargs.keys() and w < kwargs['min_size']:
 
@@ -118,14 +123,14 @@ def wrap_window(func):
             raise ValueError('lagged window of size {} is not available, \
                 must be positive.'.format(w))
 
-        elif w > X.shape[0]:
+        elif w > size:
             warn(
                 'lagged window of size {} is out of bounds with time axis '
-                'of size {}'.format(w, X.shape[0]),
+                'of size {}'.format(w, size),
                 category=UserWarning,
                 stacklevel=2,
             )
-            w = X.shape[0]
+            w = size
 
         return func(X, w=int(w), **kwargs)
 

--- a/fynance/features/momentums.py
+++ b/fynance/features/momentums.py
@@ -296,7 +296,10 @@ def wma(X: NDArray, w: int | None = None, axis: int = 0, dtype=None) -> NDArray:
 
     .. math::
 
-        wma^w_t(X) = \frac{2}{w (w-1)} \sum^{w-1}_{i=0} (w-i) \times X_{t-i}
+        wma^w_t(X) = \frac{2}{w (w+1)} \sum^{w-1}_{i=0} (w-i) \times X_{t-i}
+
+    The weights :math:`(w - i)` decrease linearly with the lag and sum to
+    :math:`w (w + 1) / 2`, which is the normalizer applied above.
 
     Parameters
     ----------
@@ -498,9 +501,12 @@ def wmstd(X: NDArray, w: int | None = None, axis: int = 0, dtype=None) -> NDArra
 
     .. math::
 
-        wma^w_t(X) = \frac{2}{w (w-1)} \sum^{w-1}_{i=0} (w-i) \times X_{t-i} \\
-        wmstd^w_t(X) = \sqrt{\frac{2}{w(w-1)} \sum^{w-1}_{i=0}
+        wma^w_t(X) = \frac{2}{w (w+1)} \sum^{w-1}_{i=0} (w-i) \times X_{t-i} \\
+        wmstd^w_t(X) = \sqrt{\frac{2}{w(w+1)} \sum^{w-1}_{i=0}
         (w-i) \times (X_{t-i} - wma^w_t(X))^2}
+
+    As for :func:`wma`, the linearly decreasing weights :math:`(w - i)` sum
+    to :math:`w (w + 1) / 2`.
 
     Parameters
     ----------
@@ -552,8 +558,12 @@ def emstd(X: NDArray, alpha: float = 0.94, w: int | None = None, axis: int = 0, 
 
     .. math::
 
-        emstd^{\alpha}_t(X) = \sqrt{\alpha\times emstd^{\alpha}_{t-1}^2 +
-        (1-\alpha) \times X_t^2}
+        emstd^{\alpha}_t(X) = \sqrt{\alpha \times {emstd^{\alpha}_{t-1}}^2 +
+        (1-\alpha) \times (X_t - ema^{\alpha}_t(X))^2}
+
+    Where :math:`ema^{\alpha}_t(X)` is the exponential moving average (see
+    :func:`ema`); the squared deviation is taken around it rather than around
+    zero.
 
     Parameters
     ----------

--- a/fynance/features/scale.py
+++ b/fynance/features/scale.py
@@ -280,7 +280,8 @@ class Scale:
             axis = self.axis
 
         if axis == 1:
-            self.func(X.T, **self.params).T
+
+            return self._apply(self.func, X)
 
         return self.func(X, **self.params)
 
@@ -302,9 +303,40 @@ class Scale:
             axis = self.axis
 
         if axis == 1:
-            self.revert_func(X.T, **self.params).T
+
+            return self._apply(self.revert_func, X)
 
         return self.revert_func(X, **self.params)
+
+    def _apply(self, func, X):
+        """ Apply `func` along axis 1 with fitted parameters.
+
+        The fitted parameters were computed along ``axis=1`` and therefore
+        share the orientation of ``X``. The data is transposed so that the
+        time axis lands on axis 0; any array-valued parameter that matches
+        the dimensionality of ``X`` is transposed as well to keep the
+        orientation consistent before broadcasting.
+
+        Parameters
+        ----------
+        func : callable
+            The scale (or revert) function to apply.
+        X : np.ndarray[dtype, ndim=1 or 2]
+            Data to transform along axis 1.
+
+        Returns
+        -------
+        np.ndarray[dtype, ndim=1 or 2]
+            The transformed data, with the original orientation restored.
+
+        """
+        params = dict(self.params)
+        for key in ("m", "s"):
+            value = params.get(key)
+            if isinstance(value, np.ndarray) and value.ndim == X.ndim:
+                params[key] = value.T
+
+        return func(X.T, **params).T
 
 
 def standardize(X, a=0, b=1, axis=0):

--- a/fynance/features/stats.py
+++ b/fynance/features/stats.py
@@ -340,7 +340,7 @@ def mad(X: NDArray, axis: int = 0, dtype=None) -> NDArray:
     roll_mad
 
     """
-    return np.mean(np.abs(X.T - np.mean(X, axis=axis)).T, axis=axis)
+    return np.mean(np.abs(X - np.mean(X, axis=axis, keepdims=True)), axis=axis)
 
 
 @WrapperArray('dtype', 'axis', 'window')

--- a/fynance/tests/features/test_momentums.py
+++ b/fynance/tests/features/test_momentums.py
@@ -136,3 +136,109 @@ def test_emstd(set_variables):
     assert (ma_2d == fy.emstd(x_2d, a, dtype=np.float32)).all()
     assert (fy.emstd(x_1d, 0.) == 0.).all()
     assert (fy.emstd(x_1d, 1.) == 0.).all()
+
+
+# --------------------------------------------------------------------------- #
+#   Genuine multi-column axis=1 parity (roadmap 1.A)                           #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture()
+def multi_col():
+    # Time on axis 1, three distinct rows, non-square (3, 6).
+    return np.array([
+        [70., 100., 80., 120., 160., 80.],
+        [60., 90., 110., 70., 130., 100.],
+        [50., 80., 60., 90., 120., 70.],
+    ])
+
+
+def _stack_rows(f, X, **kwargs):
+    return np.vstack([f(X[i], **kwargs) for i in range(X.shape[0])])
+
+
+@pytest.mark.parametrize("name", ["sma", "wma", "smstd", "wmstd"])
+def test_moving_axis1_matches_per_row(multi_col, name):
+    # axis=1 must equal stacking the 1-D result of each row.
+    f = getattr(fy, name)
+    out = f(multi_col, w=3, axis=1)
+    assert np.allclose(out, _stack_rows(f, multi_col, w=3))
+
+
+@pytest.mark.parametrize("name", ["sma", "wma", "smstd", "wmstd"])
+def test_moving_axis1_window_greater_than_n_columns(multi_col, name):
+    # The window must be validated against the time axis (axis=1, length 6),
+    # not the leading axis (length 3). A window of 4 > 3 used to be silently
+    # clamped to 3 before the axis transpose.
+    f = getattr(fy, name)
+    out = f(multi_col, w=4, axis=1)
+    assert np.allclose(out, _stack_rows(f, multi_col, w=4))
+    # axis=1 with w=4 differs from the (buggy) clamped w=3 result.
+    assert not np.allclose(out, _stack_rows(f, multi_col, w=3))
+
+
+def test_sma_axis1_differs_from_axis0():
+    # On a non-square multi-column array, axis=1 and axis=0 disagree.
+    X = np.array([
+        [1., 2., 3., 4.],
+        [5., 7., 9., 11.],
+        [2., 4., 8., 16.],
+    ])
+    assert not np.allclose(fy.sma(X, w=2, axis=1), fy.sma(X, w=2, axis=0))
+
+
+@pytest.mark.parametrize(
+    "name", ["sma", "wma", "smstd", "wmstd", "ema", "emstd"],
+)
+def test_axis_error_on_1d(name):
+    # axis=1 on a 1-D array must raise a clean AxisError (np.AxisError was
+    # removed in NumPy 2; the size check also used to raise IndexError first).
+    f = getattr(fy, name)
+    with pytest.raises(np.exceptions.AxisError):
+        f(np.arange(5.), axis=1)
+
+
+def test_z_score_axis1_matches_per_row(multi_col):
+    from fynance.features.stats import z_score
+    for kind in ("s", "w", "e"):
+        out = z_score(multi_col, w=3, kind=kind, axis=1)
+        expected = np.array([
+            z_score(multi_col[i], w=3, kind=kind)
+            for i in range(multi_col.shape[0])
+        ])
+        assert np.allclose(out, expected)
+
+
+def test_roll_z_score_axis1_matches_per_row(multi_col):
+    from fynance.features.stats import roll_z_score
+    for kind in ("s", "w", "e"):
+        out = roll_z_score(multi_col, w=3, kind=kind, axis=1)
+        expected = _stack_rows(roll_z_score, multi_col, w=3, kind=kind)
+        assert np.allclose(out, expected)
+
+
+def test_roll_z_score_e_kind_single_conversion(multi_col):
+    # The e->alpha conversion w = 1 - 2/(1+w) must be applied exactly once,
+    # regardless of axis: axis=1 must equal the per-row 1-D result.
+    from fynance.features.stats import roll_z_score
+    out = roll_z_score(multi_col, w=3, kind="e", axis=1)
+    expected = _stack_rows(roll_z_score, multi_col, w=3, kind="e")
+    assert np.allclose(out, expected)
+
+
+def test_mad_axis1_matches_per_row():
+    from fynance.features.stats import mad
+    # Non-square array whose leading axis differs from the trailing axis so a
+    # broadcast bug (X.T - mean) would raise instead of returning per-row mad.
+    X = np.array([
+        [1., 2.],
+        [3., 4.],
+        [5., 6.],
+    ])
+    out = mad(X, axis=1)
+    expected = np.array([mad(X[i]) for i in range(X.shape[0])])
+    assert np.allclose(out, expected)
+    # axis=0 stays correct (per-column).
+    assert np.allclose(
+        mad(X, axis=0), [mad(X[:, j]) for j in range(X.shape[1])]
+    )

--- a/fynance/tests/features/test_roll_functions_numba.py
+++ b/fynance/tests/features/test_roll_functions_numba.py
@@ -44,3 +44,37 @@ def test_roll_min_default_window_is_expanding():
     X = np.array([3.0, 1.0, 2.0, 0.5, 4.0])
     # w=None -> full length -> expanding min
     assert np.allclose(roll_min(X, dtype=np.float64), np.minimum.accumulate(X))
+
+
+def _multi_col():
+    # Time on axis 1, non-square (3, 6).
+    return np.array([
+        [70., 100., 80., 120., 160., 80.],
+        [60., 90., 110., 70., 130., 100.],
+        [50., 80., 60., 90., 120., 70.],
+    ])
+
+
+def test_roll_min_axis1_matches_per_row():
+    X = _multi_col()
+    out = roll_min(X, w=3, axis=1, dtype=np.float64)
+    expected = np.vstack([_ref(X[i], 3, np.min) for i in range(X.shape[0])])
+    assert np.allclose(out, expected)
+
+
+def test_roll_max_axis1_matches_per_row():
+    X = _multi_col()
+    out = roll_max(X, w=3, axis=1, dtype=np.float64)
+    expected = np.vstack([_ref(X[i], 3, np.max) for i in range(X.shape[0])])
+    assert np.allclose(out, expected)
+
+
+def test_roll_min_axis1_window_greater_than_n_columns():
+    # Window 4 > leading axis length 3 must validate against the time axis.
+    X = _multi_col()
+    out = roll_min(X, w=4, axis=1, dtype=np.float64)
+    expected = np.vstack([_ref(X[i], 4, np.min) for i in range(X.shape[0])])
+    assert np.allclose(out, expected)
+    assert not np.allclose(
+        out, np.vstack([_ref(X[i], 3, np.min) for i in range(X.shape[0])])
+    )

--- a/fynance/tests/features/test_scale.py
+++ b/fynance/tests/features/test_scale.py
@@ -157,3 +157,41 @@ def test_roll_rank_2d_columnwise():
     out = np.asarray(roll_rank(X2, w=3))
     assert out.shape == (5, 2)
     assert np.allclose(out[:, 0], roll_rank(X, w=3))
+
+
+# --------------------------------------------------------------------------- #
+#   Genuine multi-column axis=1 parity (roadmap 1.A)                           #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture()
+def multi_col():
+    # Time on axis 1, distinct rows, non-square (3, 4).
+    return np.array([
+        [1., 2., 3., 4.],
+        [6., 5., 7., 8.],
+        [2., 9., 1., 3.],
+    ])
+
+
+@pytest.mark.parametrize(
+    "kind, base_func",
+    [("std", "standardize"), ("norm", "normalize")],
+)
+def test_scale_axis1_matches_per_row(multi_col, kind, base_func):
+    # Scale(axis=1) must equal stacking the 1-D transform of each row, and
+    # must round-trip through revert. Previously the axis=1 branch discarded
+    # its result (missing return) and silently fell back to axis=0 behaviour.
+    f = getattr(fy, base_func)
+    s = fy.Scale(multi_col, kind=kind, axis=1, a=0, b=1)
+    out = s.scale(multi_col)
+    expected = np.vstack([f(multi_col[i]) for i in range(multi_col.shape[0])])
+    assert np.allclose(out, expected)
+    assert np.allclose(s.revert(out), multi_col)
+
+
+@pytest.mark.parametrize("kind", ["std", "norm"])
+def test_scale_axis1_differs_from_axis0(multi_col, kind):
+    s1 = fy.Scale(multi_col, kind=kind, axis=1, a=0, b=1)
+    s0 = fy.Scale(multi_col, kind=kind, axis=0, a=0, b=1)
+    assert not np.allclose(s1.scale(multi_col), s0.scale(multi_col))


### PR DESCRIPTION
## Summary

The 2-D `axis=1` code path was broken across several `fynance.features` functions. The existing `axis=1` assertions used a degenerate `(6, 1)` single-column array (time-axis length 1) that masked every bug. This PR fixes the path and adds genuine multi-column (non-square) parity tests.

## Findings fixed

| # | Severity | Location | Fix |
|---|----------|----------|-----|
| 1 | CRITICAL | `features/scale.py` `Scale.scale` / `Scale.revert` | The `axis == 1` branch computed but **discarded** its result (missing `return`), silently falling back to axis=0. Restore the `return` via a `_apply` helper that also transposes array-valued params so orientation stays consistent for both std/norm and rolling kinds. |
| 2 | CRITICAL | `_wrappers.py` `wrap_window` | Window `w` was validated against `X.shape[0]` *before* `wrap_axis` transposes time onto axis 0, so `w > n_columns` was silently clamped for `axis=1`. Now validated against `X.shape[axis]`. |
| 3 | CRITICAL | `features/momentums.py` / `features/stats.py` `z_score`/`roll_z_score` | The `e`→alpha conversion now happens exactly once for any axis (the double-application reported was a side effect of the window-clamp bug; root-caused and locked in with parity tests). |
| 4 | HIGH | `_wrappers.py` `wrap_axis` | `np.AxisError` was removed in NumPy 2 (raised `AttributeError`); `shape[axis]` was also read before the ndim guard (`IndexError` on `sma(1d, axis=1)`). Check `axis < X.ndim` first and raise `np.exceptions.AxisError`. |
| 5 | HIGH | `features/stats.py` `mad` | `mad(X2d, axis=1)` raised a broadcast `ValueError` on non-square arrays. Compute the mean with `keepdims=True` so it broadcasts on either axis. |
| 6 | HIGH (tests) | `tests/features/` | Added genuine multi-column non-square `axis=1` parity tests (vs. stacked per-row 1-D results) for sma/wma/smstd/wmstd/roll_min/roll_max/z_score/roll_z_score/mad and `Scale` std/norm, including windows larger than the column count and an `AxisError` test on 1-D input. |
| 7 | MEDIUM (docs) | `features/momentums.py` | Corrected the `wma`/`wmstd` normalizer to `2/(w(w+1))` (weights sum to `w(w+1)/2`) and the `emstd` formula to use the mean-deviation term `(1-α)(X_t - m_t)²`, matching the implementation. Docstrings only — no behaviour change. |

`wrap_lags` was checked (also flagged in the audit): it is already axis-aware (`X.shape[axis]`) and is not composed by any function, so no change was needed.

## Gates

- `ruff check fynance/` — passed
- `mypy fynance/` — passed (no issues, 168 files)
- `pytest fynance/features/ fynance/tests/features/ --doctest-modules` — 220 passed
- full suite — 595 passed, 1 skipped

No changes to `fynance/features/__init__.py`, `CHANGELOG.md`, or the roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYiBP4z6rdZA1BHnEUqG4p