### PR TITLE
fix: align metric/econometric edge cases and docs (roadmap 1.D)

### DIFF
--- a/fynance/estimator/estimator.py
+++ b/fynance/estimator/estimator.py
@@ -50,7 +50,48 @@ def estimation(y, x0, p=0, q=0, Q=0, P=0, cons=True, model='arch'):
 
 
 def target_function(params, y, p=0, q=0, Q=0, P=0, cons=True, model='arch'):
-    """ Target function """
+    """ Objective (cost) to minimise when fitting an ARMA/GARCH model.
+
+    Splits the flat ``params`` vector with :func:`get_parameters`, runs the
+    selected model recursion over ``y`` to obtain the residuals ``u`` (and the
+    conditional volatility ``h`` for GARCH models), then returns the negative
+    Gaussian log-likelihood (see :func:`loglikelihood`). Smaller is better, so
+    the value can be handed straight to a minimiser.
+
+    Parameters
+    ----------
+    params : np.ndarray[np.float64, ndim=1]
+        Flat parameter vector laid out as expected by :func:`get_parameters`
+        for the given ``p, q, Q, P, cons`` configuration.
+    y : np.ndarray[np.float64, ndim=1]
+        Time series to fit.
+    p, q : int, optional
+        Orders of the AR and MA parts of the ARMA mean equation. Default is 0.
+    Q, P : int, optional
+        Orders of the ARCH and GARCH parts of the conditional variance.
+        Default is 0.
+    cons : bool, optional
+        Whether ``params`` includes a leading constant term. Default is True.
+    model : {'arch', 'garch', 'arma'}, optional
+        Model family driving the residual recursion. ``'arch'`` and
+        ``'garch'`` both use the ARMA-GARCH recursion; ``'arma'`` uses the ARMA
+        recursion with unit conditional volatility. Default is ``'arch'``.
+
+    Returns
+    -------
+    np.float64
+        Negative Gaussian log-likelihood of the residuals (cost to minimise).
+
+    Raises
+    ------
+    ValueError
+        If ``model`` is not one of ``'arch'``, ``'garch'`` or ``'arma'``.
+
+    See Also
+    --------
+    loglikelihood, get_parameters
+
+    """
     phi, theta, alpha, beta, c, omega = get_parameters(
         params, p, q, Q, P, cons
     )
@@ -86,23 +127,38 @@ def _loglikelihood(u, h):
 
 
 def loglikelihood(u, h):
-    """ Normal log-likelihood function.
+    r""" Negative Gaussian log-likelihood (a cost to minimise).
+
+    Despite its name, this function returns the *negative* of the Normal
+    log-likelihood of the residuals, i.e. a cost suitable for direct
+    minimisation by an optimiser (smaller is better). The likelihood itself is
+    the opposite of the returned value.
+
+    .. math::
+
+        -\ln \mathcal{L} = \frac{1}{2}\left(T \ln(2\pi)
+        + \sum_t \ln(h_t^2) + \sum_t \left(\frac{u_t}{h_t}\right)^2\right)
+
+    The input ``h`` is left unchanged: a working copy is used and its zero
+    entries are floored to ``1e-8`` to avoid division by zero.
 
     Parameters
     ----------
     u : np.ndarray[dtype=np.float64, ndim=1]
         Standardized residuals series.
     h : np.ndarray[dtype=np.float64, ndim=1]
-        Conditional standard deviation series of residuals.
+        Conditional standard deviation series of residuals. Not modified in
+        place.
 
     Returns
     -------
     np.float64
-        Normal log likelihood of residuals.
+        Negative Gaussian log-likelihood of the residuals (cost to minimise).
 
     """
     l_sq_pi = np.log(2 * np.pi)
     T = h.size
+    h = np.array(h, dtype=np.float64, copy=True)
     h[h == 0] = 1e-8
     L = T * l_sq_pi + np.sum(np.log(np.square(h))) + np.sum(np.square(u / h))
 

--- a/fynance/metrics/ratios.py
+++ b/fynance/metrics/ratios.py
@@ -269,7 +269,7 @@ def calmar(X: NDArray, period: int = 252, axis: int = 0, dtype=None, ddof: int =
 
     Notes
     -----
-    Calmar ratio [3]_ is the compouned annual return
+    Calmar ratio [3]_ is the compounded annual return
     (:func:`~fynance.metrics.annual_return`) over the maximum drawdown
     (:func:`~fynance.metrics.mdd`). Let :math:`T` the number of time
     observations, DD the vector of drawdown:
@@ -278,11 +278,16 @@ def calmar(X: NDArray, period: int = 252, axis: int = 0, dtype=None, ddof: int =
 
         calmarRatio = \frac{annualReturn}{MDD}
 
-    With, :math:`annualReturn = \frac{X_T}{X_1}^{\frac{period}{T}} - 1` and
-    :math:`MDD = max(DD_{1:T})`.
+    With, :math:`annualReturn = \left(\frac{X_T}{X_1}\right)^{\frac{period}{T}}
+    - 1` and :math:`MDD = max(DD_{1:T})`.
 
     Where, :math:`DD_t = 1 - \frac{X_t}{max(X_{1:t})}`,
     :math:`\forall t \in [1:T]`.
+
+    A drawdown-free curve has a zero maximum drawdown, which leaves the ratio
+    undefined: it is ``+inf`` when the annual return is positive (a riskless
+    gain) and ``0`` when the annual return is also zero (a flat curve). This is
+    the same zero-denominator convention as :func:`sharpe` and :func:`sortino`.
 
     Parameters
     ----------
@@ -315,9 +320,14 @@ def calmar(X: NDArray, period: int = 252, axis: int = 0, dtype=None, ddof: int =
 
     >>> X = np.array([70, 100, 80, 120, 160, 105, 80]).astype(np.float64)
     >>> calmar(X, period=12, ddof=1)
-    array(0.6122449)
+    0.6122448979591835
     >>> calmar(X.reshape([7, 1]), period=12)
     array([0.51446018])
+
+    A drawdown-free (monotonically increasing) curve yields ``inf``:
+
+    >>> calmar(np.array([100., 101., 102., 103., 104.]), period=12)
+    inf
 
     See Also
     --------
@@ -327,11 +337,8 @@ def calmar(X: NDArray, period: int = 252, axis: int = 0, dtype=None, ddof: int =
     ret = _annual_return(X, period, ddof)
     dd = _drawdown(X, False)
     mdd = np.max(dd, axis=axis)
-    calmar = np.zeros(ret.shape)
-    slice_bool = (mdd != 0)
-    calmar[slice_bool] = ret[slice_bool] / mdd[slice_bool]
 
-    return calmar
+    return _safe_ratio(ret, mdd)
 
 
 @WrapperArray('axis')
@@ -341,7 +348,7 @@ def diversified_ratio(X: NDArray, W: NDArray | None = None, std_method: str = 's
     Notes
     -----
     Diversification ratio, denoted D, is defined as the ratio of the
-    portfolio's weighted average volatility to its overll volatility,
+    portfolio's weighted average volatility to its overall volatility,
     developed by Choueifaty and Coignard [4]_.
 
     .. math:: D(P) = \\frac{P' \\Sigma}{\\sqrt{P'VP}}
@@ -364,7 +371,7 @@ def diversified_ratio(X: NDArray, W: NDArray | None = None, std_method: str = 's
 
     Returns
     -------
-    np.float64
+    float
         Value of diversification ratio of the portfolio.
 
     References
@@ -386,7 +393,7 @@ def diversified_ratio(X: NDArray, W: NDArray | None = None, std_method: str = 's
     sigma = np.std(X, axis=0).reshape([N, 1])
     V = np.cov(X, rowvar=False, bias=True).reshape([N, N])
 
-    return (W.T @ sigma) / np.sqrt(W.T @ V @ W)
+    return ((W.T @ sigma) / np.sqrt(W.T @ V @ W)).item()
 
 
 @WrapperArray('dtype', 'axis', 'null', 'window', 'ddof', min_size=3)
@@ -566,7 +573,7 @@ def roll_calmar(X: NDArray, period: float = 252., w: int | None = None, axis: in
 
     Notes
     -----
-    Calmar ratio [3]_ is the rolling compouned annual return
+    Calmar ratio [3]_ is the rolling compounded annual return
     (:func:`~fynance.metrics.roll_annual_return`) over the rolling
     maximum drawdown (:func:`~fynance.metrics.roll_mdd`). Let
     :math:`T` the number of time observations, DD the vector of drawdown,
@@ -576,9 +583,13 @@ def roll_calmar(X: NDArray, period: float = 252., w: int | None = None, axis: in
 
         calmarRatio_t = \frac{annualReturn_t}{MDD_t} \\ \\
 
-    With, :math:`annualReturn_t = \frac{X_t}{X_1}^{\frac{period}{t}} - 1` and
-    :math:`MDD_t = max(DD_t)`, where
+    With, :math:`annualReturn_t = \left(\frac{X_t}{X_1}\right)^{\frac{period}{t}}
+    - 1` and :math:`MDD_t = max(DD_t)`, where
     :math:`DD_t = 1 - \frac{X_t}{max(X_{1:t})}`.
+
+    As for :func:`calmar`, a drawdown-free window has a zero maximum drawdown
+    and the ratio is ``+inf`` when its annual return is positive and ``0`` when
+    that return is also zero — the same convention as :func:`roll_sharpe`.
 
     Parameters
     ----------
@@ -614,7 +625,7 @@ def roll_calmar(X: NDArray, period: float = 252., w: int | None = None, axis: in
 
     >>> X = np.array([70, 100, 80, 120, 160, 80]).astype(np.float64)
     >>> roll_calmar(X, period=12)
-    array([ 0.        ,  0.        ,  3.52977926, 20.18950437, 31.35989887,
+    array([ 0.        ,         inf,  3.52977926, 20.18950437, 31.35989887,
             0.6122449 ])
 
     See Also
@@ -624,9 +635,6 @@ def roll_calmar(X: NDArray, period: float = 252., w: int | None = None, axis: in
     """
     ret = _roll_annual_return(X, period, w, ddof)
     mdd = _roll_mdd(X, w, False)
-    calmar = np.zeros(X.shape)
-    slice_bool = (mdd != 0)
-    calmar[slice_bool] = ret[slice_bool] / mdd[slice_bool]
 
-    return calmar
+    return _safe_ratio(ret, mdd)
 

--- a/fynance/metrics/returns.py
+++ b/fynance/metrics/returns.py
@@ -19,19 +19,19 @@ __all__ = ['annual_return', 'perf_index', 'perf_returns', 'roll_annual_return']
 
 @WrapperArray('dtype', 'axis', 'ddof', min_size=2)
 def annual_return(X: NDArray, period: int = 252, axis: int = 0, dtype=None, ddof: int = 0) -> NDArray:
-    r""" Compute compouned annual returns of each `X`' series.
+    r""" Compute compounded annual returns of each `X`' series.
 
     The annualised return [1]_ is the process of converting returns on a whole
     period to returns per year.
 
     Notes
     -----
-    Let T the number of timeframes in `X`' series, the annual compouned returns
+    Let T the number of timeframes in `X`' series, the annual compounded returns
     is computed such that:
 
     .. math::
 
-        annualReturn = \frac{X_T}{X_1}^{\frac{period}{T}} - 1
+        annualReturn = \left(\frac{X_T}{X_1}\right)^{\frac{period}{T}} - 1
 
     Parameters
     ----------
@@ -40,7 +40,7 @@ def annual_return(X: NDArray, period: int = 252, axis: int = 0, dtype=None, ddof
     period : int, optional
         Number of period per year, default is 252 (trading days per year).
     axis : {0, 1}, optional
-        Axis along wich the computation is done. Default is 0.
+        Axis along which the computation is done. Default is 0.
     dtype : np.dtype, optional
         The type of the output array.  If `dtype` is not given, infer the data
         type from `X` input.
@@ -52,7 +52,7 @@ def annual_return(X: NDArray, period: int = 252, axis: int = 0, dtype=None, ddof
     Returns
     -------
     dtype or np.ndarray[dtype, ndim=1]
-        Values of compouned annual returns of each series.
+        Values of compounded annual returns of each series.
 
     References
     ----------
@@ -322,19 +322,19 @@ def returns_strat(X: NDArray, S: NDArray | None = None, kind: str = 'pct', base:
 
 @WrapperArray('dtype', 'axis', 'window', 'ddof', min_size=2)
 def roll_annual_return(X: NDArray, period: int = 252, w: int | None = None, axis: int = 0, dtype=None, ddof: int = 0) -> NDArray:
-    r""" Compute rolling compouned annual returns of each `X`' series.
+    r""" Compute rolling compounded annual returns of each `X`' series.
 
     The annualised return [1]_ is the process of converting returns on a whole
     period to returns per year.
 
     Notes
     -----
-    The rolling annual compouned returns is computed such that :math:`\forall t
+    The rolling annual compounded returns is computed such that :math:`\forall t
     \in [1: T]`:
 
     .. math::
 
-        annualReturn_t = \frac{X_t}{X_1}^{\frac{period}{t}} - 1
+        annualReturn_t = \left(\frac{X_t}{X_1}\right)^{\frac{period}{t}} - 1
 
     Parameters
     ----------
@@ -346,7 +346,7 @@ def roll_annual_return(X: NDArray, period: int = 252, w: int | None = None, axis
         Size of the lagged window of the rolling function, must be positive. If
         ``w is None`` or ``w=0``, then ``w=X.shape[axis]``. Default is None.
     axis : {0, 1}, optional
-        Axis along wich the computation is done. Default is 0.
+        Axis along which the computation is done. Default is 0.
     dtype : np.dtype, optional
         The type of the output array.  If `dtype` is not given, infer the data
         type from `X` input.
@@ -358,7 +358,7 @@ def roll_annual_return(X: NDArray, period: int = 252, w: int | None = None, axis
     Returns
     -------
     np.ndarray[dtype, ndim=1 or 2]
-        Values of rolling compouned annual returns of each series.
+        Values of rolling compounded annual returns of each series.
 
     References
     ----------

--- a/fynance/metrics/summary.py
+++ b/fynance/metrics/summary.py
@@ -69,11 +69,16 @@ def summary(prices: NDArray, period: int = 252, rf: float = 0.0) -> dict[str, fl
     """
     p = np.asarray(prices, dtype=np.float64)
 
+    # ``sharpe`` and ``sortino`` default to ``log=False``; report the volatility
+    # under the same convention so the displayed vol is the one implied by the
+    # displayed Sharpe ratio.
+    log = False
+
     return {
         'annual_return': float(annual_return(p, period=period)),
-        'annual_volatility': float(annual_volatility(p, period=period)),
-        'sharpe': float(sharpe(p, period=period, rf=rf)),
-        'sortino': float(sortino(p, period=period)),
+        'annual_volatility': float(annual_volatility(p, period=period, log=log)),
+        'sharpe': float(sharpe(p, period=period, rf=rf, log=log)),
+        'sortino': float(sortino(p, period=period, log=log)),
         'calmar': float(calmar(p, period=period)),
         'max_drawdown': float(mdd(p)),
     }

--- a/fynance/models/econometric_models.py
+++ b/fynance/models/econometric_models.py
@@ -297,7 +297,8 @@ def ARMA(y, phi, theta, c, p, q):
 
     """
     # Set type variables and parameters
-    y = np.asarray(y, dtype=np.float64).reshape([y.size])
+    y = np.asarray(y, dtype=np.float64)
+    y = y.reshape([y.size])
     theta = np.asarray(theta, dtype=np.float64)
     phi = np.asarray(phi, dtype=np.float64)
 
@@ -361,7 +362,8 @@ def ARMA_GARCH(y, phi, theta, alpha, beta, c, omega, p, q, Q, P):
     ARMAX_GARCH, ARMA, MA.
 
     """
-    y = np.asarray(y, dtype=np.float64).reshape([y.size])
+    y = np.asarray(y, dtype=np.float64)
+    y = y.reshape([y.size])
     theta = np.asarray(theta, dtype=np.float64)
     phi = np.asarray(phi, dtype=np.float64)
     alpha = np.asarray(alpha, dtype=np.float64)
@@ -380,7 +382,8 @@ def ARMAX_GARCH(y, x, phi, psi, theta, alpha, beta, c, omega, p, q, Q, P):
 
     .. math::
 
-        y_t = c + \phi_1 * y_{t-1} + ... + \phi_p * y_{t-p} + \psi_t * x_t
+        y_t = c + \phi_1 * y_{t-1} + ... + \phi_p * y_{t-p}
+        + \sum_k \psi_k * x_{t,k}
         + \theta_1 * u_{t-1} + ... + \theta_q * u_{t-q} + u_t
 
     With Generalized AutoRegressive Conditional Heteroskedasticity volatility
@@ -409,7 +412,9 @@ def ARMAX_GARCH(y, x, phi, psi, theta, alpha, beta, c, omega, p, q, Q, P):
     beta : np.ndarray[np.float64, ndim=1]
         Coefficients of AR part of GARCH.
     c : np.float64
-        Constant of the model.
+        Constant of ARMA model.
+    omega : np.float64
+        Constant of GARCH model.
     p : int
         Order of AR(p) model.
     q : int
@@ -432,7 +437,8 @@ def ARMAX_GARCH(y, x, phi, psi, theta, alpha, beta, c, omega, p, q, Q, P):
 
     """
     # Set array variables
-    y = np.asarray(y, dtype=np.float64).reshape([y.size])
+    y = np.asarray(y, dtype=np.float64)
+    y = y.reshape([y.size])
     x = np.asarray(x, dtype=np.float64)
     theta = np.asarray(theta, dtype=np.float64)
     phi = np.asarray(phi, dtype=np.float64)

--- a/fynance/portfolio/allocation.py
+++ b/fynance/portfolio/allocation.py
@@ -590,7 +590,7 @@ def MDP(
 
     # Set function to minimze
     def f_max_divers_weights(w):
-        return - diversified_ratio(X, W=w).flatten()
+        return -diversified_ratio(X, W=w)
 
     # Set inital weights
     if w0 is None:

--- a/fynance/tests/estimator/test_estimator.py
+++ b/fynance/tests/estimator/test_estimator.py
@@ -41,6 +41,31 @@ def test_loglikelihood_handles_zero_h():
     assert np.isfinite(loglikelihood(u, h))
 
 
+def test_loglikelihood_does_not_mutate_input_h():
+    # The zero-flooring must happen on a copy: the caller's h is preserved
+    # (in particular its zero entries are not overwritten by 1e-8).
+    u = np.array([0.0, 1.0, -1.0])
+    h = np.array([0.0, 1.0, 2.0])
+    h_before = h.copy()
+    loglikelihood(u, h)
+    assert np.array_equal(h, h_before)
+    assert h[0] == 0.0
+
+
+def test_loglikelihood_returns_negative_log_likelihood():
+    # Documented as the negative LL (a cost): it equals -(true Gaussian LL),
+    # which for non-degenerate residuals is a positive number.
+    rng = np.random.RandomState(0)
+    u = rng.randn(50)
+    h = np.abs(rng.randn(50)) + 0.5
+    true_ll = -0.5 * (
+        u.size * np.log(2 * np.pi)
+        + np.sum(np.log(np.square(h)))
+        + np.sum(np.square(u / h))
+    )
+    assert np.isclose(loglikelihood(u, h), -true_ll)
+
+
 def test_target_function_arma_returns_finite():
     import numpy as np
 

--- a/fynance/tests/metrics/test_metrics.py
+++ b/fynance/tests/metrics/test_metrics.py
@@ -105,6 +105,14 @@ def test_diversified_ratio():
     w = np.array([0.4, 0.3, 0.3])
     result = fy.diversified_ratio(X, W=w)
     assert result > 0
+    # Must be a Python float scalar (not a (1, 1) ndarray), matching the
+    # documented ``-> float`` return type.
+    assert isinstance(result, float)
+    assert not isinstance(result, np.ndarray)
+
+    # Equal weights (default W) should also return a plain float scalar.
+    result_eq = fy.diversified_ratio(X)
+    assert isinstance(result_eq, float)
 
 
 def test_drawdown_zero_initial_warns():

--- a/fynance/tests/metrics/test_summary.py
+++ b/fynance/tests/metrics/test_summary.py
@@ -8,7 +8,12 @@ import numpy as np
 
 # Local packages
 from fynance.core import Metric
-from fynance.metrics import METRICS, sharpe, summary
+from fynance.metrics import (
+    METRICS,
+    annual_volatility,
+    sharpe,
+    summary,
+)
 
 
 def test_summary_keys():
@@ -35,3 +40,16 @@ def test_registry_contains_metrics():
 def test_metric_functions_conform_to_protocol():
     # plain callables structurally satisfy the Metric protocol
     assert isinstance(sharpe, Metric)
+
+
+def test_summary_volatility_consistent_with_sharpe():
+    # The reported annual_volatility must use the same log convention as the
+    # reported sharpe (log=False), so that sharpe == annual_return / vol holds
+    # on the displayed numbers (rf=0). Under the old default (log=True for vol,
+    # log=False for sharpe) the displayed vol did not imply the displayed Sharpe.
+    eq = np.array([100., 101.5, 99., 104., 108., 103., 110.])
+    s = summary(eq)
+    vol_log_false = float(annual_volatility(eq, period=252, log=False))
+    assert np.isclose(s["annual_volatility"], vol_log_false)
+    # sharpe (rf=0) implied by the displayed vol and return.
+    assert np.isclose(s["sharpe"], s["annual_return"] / s["annual_volatility"])

--- a/fynance/tests/metrics/test_zero_vol_ratios.py
+++ b/fynance/tests/metrics/test_zero_vol_ratios.py
@@ -7,7 +7,7 @@
 import numpy as np
 
 # Local
-from fynance.metrics import sharpe, sortino
+from fynance.metrics import calmar, roll_calmar, sharpe, sortino
 from fynance.metrics.ratios import _safe_ratio
 from fynance.metrics.summary import summary
 
@@ -43,3 +43,33 @@ def test_summary_on_flat_curve():
     out = summary(np.full(30, 100.0))
     assert out["sharpe"] == 0.0
     assert np.isfinite(out["max_drawdown"])
+
+
+def test_calmar_zero_mdd_is_inf_not_zero():
+    # A profitable, drawdown-free curve has zero maximum drawdown. Calmar must
+    # follow the same zero-denominator convention as sharpe/sortino (+inf for a
+    # riskless gain), not return 0.0 (the worst possible Calmar).
+    up = np.array([100., 101., 102., 103., 104., 105.])
+    assert np.isposinf(calmar(up, period=12))
+    # a flat curve (zero return over zero drawdown) stays 0.0
+    assert calmar(np.full(10, 100.0), period=12) == 0.0
+
+
+def test_calmar_zero_mdd_2d_columns():
+    up = np.array([100., 101., 102., 103., 104., 105.])
+    drawdown = np.array([100., 90., 95., 80., 85., 70.])
+    X = np.column_stack([up, drawdown])
+    res = calmar(X, period=12)
+    assert res.shape == (2,)
+    assert np.isposinf(res[0])      # drawdown-free profitable column
+    assert np.isfinite(res[1])      # column with a real drawdown
+
+
+def test_roll_calmar_zero_mdd_is_inf_not_zero():
+    # Same convention for the rolling variant: a window that has gained without
+    # any drawdown yet must score +inf, not 0.0.
+    X = np.array([70., 100., 80., 120., 160., 80.])
+    rc = roll_calmar(X, period=12)
+    # index 1 = strictly increasing so far (70 -> 100), zero MDD, positive ret.
+    assert np.isposinf(rc[1])
+    assert rc[0] == 0.0             # first point: zero return over zero MDD

--- a/fynance/tests/models/test_econometric_models.py
+++ b/fynance/tests/models/test_econometric_models.py
@@ -24,25 +24,37 @@ def set_variables():
     return y, params, p, q, P, Q
 
 
-def test_get_parameters(set_variables):
-    y, params, p, q, P, Q = set_variables
+def test_get_parameters():
+    # Use distinct orders (p=1, q=1, Q=2, P=1) and distinct parameter values so
+    # that a Q<->P packing swap, or an argument passed out of signature order,
+    # changes one of the asserted slices and fails. The signature is
+    # ``get_parameters(params, p, q, Q, P, cons)`` and, with a constant, the
+    # flat layout is [c, phi(p), theta(q), omega, alpha(Q), beta(P)].
+    p, q, Q, P = 1, 1, 2, 1
+    # c=0.5, phi=0.3, theta=-0.2, omega=0.1, alpha=[0.4, 0.05], beta=0.8
+    params = np.array([0.5, 0.3, -0.2, 0.1, 0.4, 0.05, 0.8])
+
     phi, theta, alpha, beta, c, omega = fy.get_parameters(
-        params, p, q, P, Q, cons=True
+        params, p, q, Q, P, cons=True
     )
     assert c == params[0]
-    assert phi == params[1]
-    assert theta == params[2]
+    assert np.array_equal(phi, params[1:2])
+    assert np.array_equal(theta, params[2:3])
     assert omega == params[3]
-    assert alpha == params[4]
-    assert beta == params[5]
+    assert np.array_equal(alpha, params[4:6])  # Q=2 -> two ARCH coefficients
+    assert np.array_equal(beta, params[6:7])   # P=1 -> one GARCH coefficient
+
+    # Without a constant the constant slot disappears and everything shifts left.
+    params_nc = np.array([0.3, -0.2, 0.1, 0.4, 0.05, 0.8])
     phi, theta, alpha, beta, c, omega = fy.get_parameters(
-        params, p, q, P, Q, cons=False
+        params_nc, p, q, Q, P, cons=False
     )
-    assert phi == params[0]
-    assert theta == params[1]
-    assert omega == params[2]
-    assert alpha == params[3]
-    assert beta == params[4]
+    assert c == 0.
+    assert np.array_equal(phi, params_nc[0:1])
+    assert np.array_equal(theta, params_nc[1:2])
+    assert omega == params_nc[2]
+    assert np.array_equal(alpha, params_nc[3:5])
+    assert np.array_equal(beta, params_nc[5:6])
 
 
 def test_ARMA_GARCH(set_variables):
@@ -105,3 +117,46 @@ def test_ARMAX_GARCH_shapes_and_positive_vol(set_variables):
     assert u.shape == (y.size,) and h.shape == (y.size,)
     assert np.all(np.isfinite(u)) and np.all(np.isfinite(h))
     assert np.all(h > 0)
+
+
+def test_ARMA_accepts_list_like_MA():
+    # ARMA must coerce a plain Python list for y like MA does, instead of
+    # crashing on ``'list' object has no attribute 'size'``.
+    y_list = [60., 100., 80., 120., 160., 80.]
+    u_list = np.asarray(fy.ARMA(y_list, phi=[0.5], theta=[-0.3], c=0.2, p=1, q=1))
+    u_arr = np.asarray(
+        fy.ARMA(np.array(y_list), phi=np.array([0.5]),
+                theta=np.array([-0.3]), c=0.2, p=1, q=1)
+    )
+    assert np.allclose(u_list, u_arr)
+
+
+def test_ARMA_GARCH_accepts_list():
+    y_list = [60., 100., 80., 120., 160., 80.]
+    u_l, h_l = fy.ARMA_GARCH(
+        y_list, phi=[0.5], theta=[-0.3], alpha=[0.1], beta=[0.1],
+        c=0.2, omega=0.6, p=1, q=1, Q=1, P=1,
+    )
+    u_a, h_a = fy.ARMA_GARCH(
+        np.array(y_list), phi=np.array([0.5]), theta=np.array([-0.3]),
+        alpha=np.array([0.1]), beta=np.array([0.1]),
+        c=0.2, omega=0.6, p=1, q=1, Q=1, P=1,
+    )
+    assert np.allclose(np.asarray(u_l), np.asarray(u_a))
+    assert np.allclose(np.asarray(h_l), np.asarray(h_a))
+
+
+def test_ARMAX_GARCH_accepts_list():
+    y_list = [60., 100., 80., 120., 160., 80.]
+    x = np.zeros((len(y_list), 1))
+    u_l, h_l = fy.ARMAX_GARCH(
+        y_list, x, phi=[0.5], psi=[0.1], theta=[-0.3], alpha=[0.1],
+        beta=[0.1], c=0.2, omega=0.6, p=1, q=1, Q=1, P=1,
+    )
+    u_a, h_a = fy.ARMAX_GARCH(
+        np.array(y_list), x, phi=np.array([0.5]), psi=np.array([0.1]),
+        theta=np.array([-0.3]), alpha=np.array([0.1]), beta=np.array([0.1]),
+        c=0.2, omega=0.6, p=1, q=1, Q=1, P=1,
+    )
+    assert np.allclose(np.asarray(u_l), np.asarray(u_a))
+    assert np.allclose(np.asarray(h_l), np.asarray(h_a))


### PR DESCRIPTION
Fixes the roadmap 1.D audited issues in the metrics and econometric layers. Each fix has a test that fails before and passes after.

## Findings fixed

| Severity | Area | Fix |
|---|---|---|
| HIGH | `metrics/ratios.py` `calmar`, `roll_calmar` | Zero max-drawdown now routes through `_safe_ratio`: a profitable drawdown-free curve scores `+inf` (consistent with `sharpe`/`sortino`) instead of `0.0`. |
| HIGH | `estimator/estimator.py` `loglikelihood` | No longer mutates the caller's `h` (operates on a copy); docstring clarified that it returns the **negative** Gaussian log-likelihood (a cost to minimise). |
| MEDIUM | `models/econometric_models.py` `ARMA`, `ARMA_GARCH`, `ARMAX_GARCH` | Coerce `y` with `np.asarray` before `.reshape`, so Python `list` input no longer crashes (parity with `MA`). |
| MEDIUM | `metrics/ratios.py` `diversified_ratio` | Returns a Python `float` (was a `(1, 1)` ndarray); the single `MDP()` call site that used `.flatten()` is updated. |
| MEDIUM (docs) | `models/econometric_models.py` `ARMAX_GARCH` | Docstring now documents `omega`; regressor math is a sum `Σ_k ψ_k x_{t,k}`. |
| MEDIUM (tests) | `tests/models/test_econometric_models.py` `test_get_parameters` | Rewritten with distinct orders (`Q=2, P=1`) and distinct values, in signature order, so a Q↔P packing swap fails. |
| LOW | `metrics/summary.py` | Reports `annual_volatility` with the same `log=False` convention as the reported `sharpe`/`sortino`, so the displayed vol implies the displayed Sharpe. |
| LOW | `estimator/estimator.py` `target_function` | Added a full numpydoc docstring (Parameters/Returns/Raises). |
| LOW (docs) | `metrics/returns.py` & `ratios.py` | Annualized-return TeX wrapped as `\left(\frac{X_T}{X_1}\right)^{...}`; typos fixed (`compouned`→`compounded`, `wich`→`which`, `overll`→`overall`). |

## Notes

- The single Numba ARMA/GARCH parameter implementation is untouched; no parameter logic duplicated between estimator and `econometric_models`.
- Re-blessed doctests: `calmar` (1-D scalar repr + new `inf` example) and `roll_calmar` (index 1 now `inf`). Financial formulas verified.
- No `__init__.py` exports were touched.

## Gates

- `ruff check fynance/` — passes
- `mypy fynance/` — passes (no issues, 168 files)
- Targeted suite with `--doctest-modules` — 90 passed
- Full suite — 667 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYiBP4z6rdZA1BHnEUqG4p