### PR TITLE
fix: honor dtype, deterministic predict, bias forwarding, honest cell contract

### DIFF
--- a/fynance/models/_base.py
+++ b/fynance/models/_base.py
@@ -63,21 +63,23 @@ class BaseNeuralNet(torch.nn.Module):
 
     **Public API contract (stable for the 1.x series)**
 
-    - **Shapes** — feed-forward subclasses (e.g.
-      :class:`~fynance.models.mlp.MultiLayerPerceptron`)
-      expect ``X`` of shape ``(T, N)`` and ``y`` of shape ``(T, M)``,
-      where ``T`` is the number of observations, ``N`` the number of
-      input features and ``M`` the number of targets. Recurrent
-      subclasses in :mod:`fynance.models.rnn`,
-      :mod:`fynance.models.gru`, :mod:`fynance.models.lstm`
-      consume ``X`` of shape ``(T, S, N)``, where ``S`` is the sequence
-      length.
+    - **Shapes** — all current subclasses (the feed-forward
+      :class:`~fynance.models.mlp.MultiLayerPerceptron`, the gated
+      cells in :mod:`fynance.models.rnn`, :mod:`fynance.models.gru`,
+      :mod:`fynance.models.lstm`, and the convolutional / attention
+      models) expect ``X`` of shape ``(T, N)`` and ``y`` of shape
+      ``(T, M)``, where ``T`` is the number of observations, ``N`` the
+      number of input features and ``M`` the number of targets. The
+      gated "recurrent" cells process each of the ``T`` rows
+      independently (they are stateless gated feed-forward cells — see
+      their own class docstrings); they do **not** thread a hidden state
+      across a time axis.
     - **Dtypes** — :meth:`set_data` coerces inputs through
-      :meth:`_set_data`. The expected default for both ``X`` and ``y``
-      is a floating tensor (``torch.float32`` is the de-facto convention
-      in the project doctests). Pass ``x_type`` / ``y_type`` explicitly
-      to override; mismatched dtypes between ``X``, ``y`` and the model
-      parameters will raise at the first ``forward`` pass.
+      :meth:`_set_data`, which casts floating-point inputs to
+      ``torch.get_default_dtype()`` (``float32`` by default) so plain
+      ``float64`` NumPy arrays train without manual ``.astype``. Integer
+      inputs keep their dtype. Pass ``x_type`` / ``y_type`` explicitly to
+      force a specific dtype.
     - **Device** — the wrapper does **not** move tensors automatically.
       Models live on CPU unless the caller explicitly calls ``.to(device)``
       on both the module and the data tensors before training.
@@ -134,7 +136,7 @@ class BaseNeuralNet(torch.nn.Module):
 
         Parameters
         ----------
-        criterion : Callabletorch.nn.modules.loss
+        criterion : Callable, torch.nn.modules.loss
             A loss function.
         optimizer : torch.optim.Optimizer
             An optimizer algorithm.
@@ -200,11 +202,12 @@ class BaseNeuralNet(torch.nn.Module):
         """ Trains the neural network model on a single batch.
 
         Runs one forward / backward / optimizer-step cycle on the batch
-        ``(X, y)``. As a side effect, gradients of all parameters are
-        zeroed before the forward pass and the optimizer state is
-        advanced afterwards. If a learning-rate scheduler has been
-        registered via :meth:`set_lr_scheduler`, its ``step`` is also
-        called.
+        ``(X, y)``. The module is switched to training mode (so dropout
+        and batch-norm behave as expected) before the forward pass. As a
+        side effect, gradients of all parameters are zeroed before the
+        forward pass and the optimizer state is advanced afterwards. If a
+        learning-rate scheduler has been registered via
+        :meth:`set_lr_scheduler`, its ``step`` is also called.
 
         Parameters
         ----------
@@ -225,6 +228,7 @@ class BaseNeuralNet(torch.nn.Module):
             If :meth:`set_optimizer` has not been called yet.
 
         """
+        self.train()
         self.optimizer.zero_grad()  # type: ignore[attr-defined]
         outputs = self(X)
         loss = self.criterion(outputs, y)
@@ -271,11 +275,15 @@ class BaseNeuralNet(torch.nn.Module):
     def predict(self, X) -> torch.Tensor:
         """ Predicts outputs of neural network model.
 
-        Runs ``self.forward(X)`` under :func:`torch.no_grad`, so no
-        autograd graph is built. The returned tensor is detached and
-        lives on the same device as the model parameters. Array-like inputs
-        (numpy / polars) are coerced to a tensor first, so the method also
-        satisfies the :class:`~fynance.core.protocols.SignalModel` contract.
+        Runs ``self.forward(X)`` under :func:`torch.no_grad` with the
+        module switched to evaluation mode, so no autograd graph is built
+        and stochastic layers (dropout, batch-norm) behave
+        deterministically. The previous training/eval mode is restored on
+        exit. The returned tensor is detached and lives on the same device
+        as the model parameters; the coerced input is moved to that device
+        too. Array-like inputs (numpy / polars) are coerced to a tensor
+        first, so the method also satisfies the
+        :class:`~fynance.core.protocols.SignalModel` contract.
 
         Parameters
         ----------
@@ -292,7 +300,22 @@ class BaseNeuralNet(torch.nn.Module):
         if not isinstance(X, torch.Tensor):
             X = self._set_data(X)
 
-        return self(X).detach()
+        try:
+            device = next(self.parameters()).device
+            X = X.to(device)
+
+        except StopIteration:
+            pass
+
+        was_training = self.training
+        self.eval()
+        try:
+            output = self(X).detach()
+
+        finally:
+            self.train(was_training)
+
+        return output
 
     def set_data(self, X: NDArray | torch.Tensor | pl.DataFrame, y: NDArray | torch.Tensor | pl.DataFrame, x_type=None, y_type=None):
         """ Set data inputs and outputs.
@@ -311,7 +334,9 @@ class BaseNeuralNet(torch.nn.Module):
             ``(T, M)`` respectively.
         x_type, y_type : torch.dtype, optional
             Target dtypes for the resulting tensors. Default is `None`,
-            which preserves the input dtype.
+            which casts floating-point inputs to
+            ``torch.get_default_dtype()`` (``float32`` by default) and
+            leaves integer inputs unchanged. See :meth:`_set_data`.
 
         Returns
         -------
@@ -345,41 +370,96 @@ class BaseNeuralNet(torch.nn.Module):
     def set_seed(self, seed_torch=None, seed_numpy=None):
         r""" Set seed for PyTorch and NumPy random number generator.
 
+        Each generator is only (re)seeded when its argument is provided:
+        passing ``seed_torch`` alone leaves the global NumPy RNG
+        untouched, and vice versa.
+
         Parameters
         ----------
         seed_torch, seed_numpy : bool or int, optional
-            If `seed` is an int :math:`0 < seed < 2^32` set respectively
-            PyTorch and NumPy seed with the number. Otherwise if is True
-            then choose a random number, else doesn't set seed.
+            If an int :math:`0 \leq seed < 2^{32}`, seed respectively the
+            PyTorch and NumPy generator with that number. If ``True``,
+            draw a random seed. If ``None`` (default), leave that
+            generator untouched.
+
+        Examples
+        --------
+        >>> from fynance.models.mlp import MultiLayerPerceptron
+        >>> model = MultiLayerPerceptron(3, 1, layers=[4])
+        >>> model.set_seed(seed_torch=42)
+        >>> model.seed_torch
+        42
+        >>> model.seed_numpy is None
+        True
 
         """
-        self.seed_torch = self._set_seed(seed_torch)
-        self.seed_numpy = self._set_seed(seed_numpy)
-        torch.manual_seed(self.seed_torch)
-        np.random.seed(self.seed_numpy)
+        if seed_torch is not None:
+            self.seed_torch = self._set_seed(seed_torch)
+            torch.manual_seed(self.seed_torch)
+
+        if seed_numpy is not None:
+            self.seed_numpy = self._set_seed(seed_numpy)
+            np.random.seed(self.seed_numpy)
 
     def _set_seed(self, seed):
-        if isinstance(seed, int) and 0 <= seed < 2 ** 32:
+        if isinstance(seed, int) and not isinstance(seed, bool) and 0 <= seed < 2 ** 32:
 
             return seed
 
         return np.random.randint(0, 2 ** 32)
 
     def _set_data(self, X, dtype=None):
-        """ Convert array-like data to tensor. """
-        if isinstance(X, np.ndarray):
+        """ Convert array-like data to a tensor of a consistent dtype.
 
-            return torch.from_numpy(X)
+        Coerces ``X`` (NumPy array, polars ``DataFrame`` or tensor) to a
+        :class:`torch.Tensor`. When ``dtype`` is given the tensor is cast
+        to it. When ``dtype`` is ``None`` and the input is floating point,
+        the tensor is cast to ``torch.get_default_dtype()`` (``float32``
+        by default) so that plain ``float64`` NumPy input does not clash
+        with the model's ``float32`` parameters at the first ``forward``
+        pass. Integer inputs keep their dtype when ``dtype`` is ``None``.
+
+        Parameters
+        ----------
+        X : numpy.ndarray, polars.DataFrame or torch.Tensor
+            Array-like data to convert.
+        dtype : torch.dtype, optional
+            Target dtype. Default is ``None`` (see above).
+
+        Returns
+        -------
+        torch.Tensor
+            The converted tensor.
+
+        Raises
+        ------
+        ValueError
+            If ``X`` is not one of the accepted types.
+
+        """
+        if isinstance(X, np.ndarray):
+            # ``torch.from_numpy`` aliases the caller's memory; clone so a
+            # later in-place edit on the tensor cannot mutate the source.
+            tensor = torch.from_numpy(X).clone()
 
         elif isinstance(X, pl.DataFrame):
-            return torch.from_numpy(X.to_numpy())
+            tensor = torch.from_numpy(X.to_numpy()).clone()
 
         elif isinstance(X, torch.Tensor):
-
-            return X
+            tensor = X
 
         else:
             raise ValueError('Unkwnown data type: {}'.format(type(X)))
+
+        if dtype is not None:
+
+            return tensor.to(dtype)
+
+        if tensor.is_floating_point() and tensor.dtype != torch.get_default_dtype():
+
+            return tensor.to(torch.get_default_dtype())
+
+        return tensor
 
     def save_model(self, path, save_optimizer=False):
         """ Save the model with this weights and parameters.
@@ -399,7 +479,7 @@ class BaseNeuralNet(torch.nn.Module):
         torch.save(state_dict, path)
 
     def load_model(self, path, load_optimizer=False):
-        """ Save the model with this weights and parameters.
+        """ Load the model weights and parameters from a file.
 
         Parameters
         ----------

--- a/fynance/models/_recurrent_base.py
+++ b/fynance/models/_recurrent_base.py
@@ -1,15 +1,19 @@
 #!/usr/bin/env python3
 # coding: utf-8
 
-""" Internal building blocks for recurrent neural network models.
+""" Internal building blocks for the gated cell models.
 
-Defines two private classes used by all RNN variants:
+Defines two private classes shared by the gated-cell variants
+(:mod:`fynance.models.rnn`, :mod:`fynance.models.gru`,
+:mod:`fynance.models.lstm`):
 
-- :class:`_RecurrentBase` — shared backbone that sets up the recurrent
-  weight matrix ``W_h``, the hidden activation ``f_h``, and dropout.
-  Its ``forward(X, H)`` implements the vanilla Elman RNN step
-  (concatenate input with hidden state, apply linear + activation).
-  :class:`~fynance.models.gru._GRUCell` and
+- :class:`_RecurrentBase` — shared backbone that sets up the weight
+  matrix ``W_h``, the hidden activation ``f_h``, and dropout. Its
+  ``forward(X, H)`` implements one Elman-style step (concatenate input
+  with the supplied hidden state, apply linear + activation). **Each row
+  of the input is processed independently**: the backbone does not loop
+  over a time axis or thread state across rows — it is a *stateless*
+  gated feed-forward cell. :class:`~fynance.models.gru._GRUCell` and
   :class:`~fynance.models.lstm._LSTMCell` override ``forward`` to add
   their gating logic on top of this backbone.
 
@@ -37,12 +41,15 @@ from fynance.models._base import BaseNeuralNet
 
 
 class _RecurrentBase(BaseNeuralNet):
-    """ Shared recurrent backbone for all RNN-flavored models.
+    """ Shared backbone for the gated cell models.
 
-    Sets up the recurrent weight matrix ``W_h``, the hidden-state
-    activation ``f_h``, and the dropout layer. Its ``forward(X, H)``
-    implements the vanilla Elman RNN step: concatenate input with hidden
-    state, apply ``W_h`` + ``f_h``.
+    Sets up the weight matrix ``W_h``, the hidden-state activation
+    ``f_h``, and the dropout layer. Its ``forward(X, H)`` implements one
+    Elman-style step: concatenate input with the supplied hidden state,
+    apply ``W_h`` + ``f_h``. Each row of ``X`` is processed
+    independently against the matching row of ``H``; no state is threaded
+    across rows, so this is a *stateless* gated feed-forward cell rather
+    than a sequence model.
 
     :class:`~fynance.models.gru._GRUCell` and
     :class:`~fynance.models.lstm._LSTMCell` subclass this and override
@@ -61,6 +68,8 @@ class _RecurrentBase(BaseNeuralNet):
         projection (e.g. :class:`~fynance.models.gru.GRUCell`).
     drop : float, optional
         Probability of an element to be zeroed.
+    bias : bool, optional
+        If ``True`` (default), the linear layers learn an additive bias.
     hidden_activation : torch.nn.Module, optional
         Activation functions, default is Tanh function.
     hidden_state_size : int, optional
@@ -107,9 +116,10 @@ class _RecurrentBase(BaseNeuralNet):
         else:
             self.set_data(X=X, y=y, x_type=x_type, y_type=y_type)  # type: ignore[arg-type]
 
+        self.bias = bias
         self.H = self.N if hidden_state_size is None else hidden_state_size
 
-        self.W_h = nn.Linear(self.N + self.H, self.H)
+        self.W_h = nn.Linear(self.N + self.H, self.H, bias=bias)
 
         self.f_h = hidden_activation()
 
@@ -161,8 +171,8 @@ class _OutputLayerMixin:
 
     """
 
-    def __init__(self, forward_activation=nn.Softmax):
-        self.W_y = nn.Linear(self.H, self.M)
+    def __init__(self, forward_activation=nn.Identity):
+        self.W_y = nn.Linear(self.H, self.M, bias=getattr(self, 'bias', True))
         self.f_y = nn.Softmax(dim=-1) if forward_activation is nn.Softmax else forward_activation()
 
     @torch.enable_grad()
@@ -182,6 +192,7 @@ class _OutputLayerMixin:
             Updated states of the model.
 
         """
+        self.train()  # type: ignore[attr-defined]
         self.optimizer.zero_grad()  # type: ignore[attr-defined]
         outputs, H = self(X, H)  # type: ignore[operator]
         loss = self.criterion(outputs, y)  # type: ignore[attr-defined]
@@ -212,6 +223,12 @@ class _OutputLayerMixin:
            Updated states of the model.
 
         """
-        Y, H = self(X, H)  # type: ignore[operator]
+        was_training = self.training  # type: ignore[attr-defined]
+        self.eval()  # type: ignore[attr-defined]
+        try:
+            Y, H = self(X, H)  # type: ignore[operator]
+
+        finally:
+            self.train(was_training)  # type: ignore[attr-defined]
 
         return Y.detach(), H.detach()

--- a/fynance/models/gru.py
+++ b/fynance/models/gru.py
@@ -94,8 +94,8 @@ class _GRUCell(_RecurrentBase):
             hidden_state_size=hidden_state_size,
         )
 
-        self.W_u = nn.Linear(self.N + self.H, self.H)
-        self.W_r = nn.Linear(self.N + self.H, self.H)
+        self.W_u = nn.Linear(self.N + self.H, self.H, bias=bias)
+        self.W_r = nn.Linear(self.N + self.H, self.H, bias=bias)
 
         self.f_u = update_activation()
         self.f_r = reset_activation()
@@ -173,13 +173,18 @@ class GRUCell(_GRUCell):
 
 
 class GatedRecurrentUnit(_OutputLayerMixin, GRUCell):  # type: ignore[misc]
-    """ Gated Recurrent Unit neural network.
+    """ Gated Recurrent Unit cell with output projection.
 
-    Full GRU model: :class:`_GRUCell` gating logic followed by a
-    forward output projection. Mitigates vanishing gradients compared to
-    :class:`~fynance.models.rnn.RecurrentNeuralNetwork` via reset and
-    update gates. Use :class:`~fynance.models.lstm.LongShortTermMemory`
-    when you need an explicit memory cell state (longer dependencies).
+    GRU gating logic (:class:`_GRUCell`) followed by a forward output
+    projection. Like :class:`~fynance.models.rnn.RecurrentNeuralNetwork`,
+    this is a *stateless* gated feed-forward cell: each of the ``T`` rows
+    of ``X`` is processed independently against the supplied hidden state
+    ``H``, and no state is threaded across rows. The gating mitigates the
+    vanishing-gradient pathology *within* a step but does not, on its
+    own, model temporal dependencies — the caller must thread ``H``
+    explicitly. For built-in sequence modeling use
+    :class:`~fynance.models.tcn.TemporalConvNet` or
+    :class:`~fynance.models.transformer.Transformer`.
 
     Parameters
     ----------
@@ -188,9 +193,13 @@ class GatedRecurrentUnit(_OutputLayerMixin, GRUCell):  # type: ignore[misc]
         - If it's an integer, respectively dimension of inputs and outputs.
     drop : float, optional
         Probability of an element to be zeroed.
+    bias : bool, optional
+        If ``True`` (default), the linear layers learn an additive bias.
     forward_activation, hidden_activation : torch.nn.Module, optional
-        Activation functions, default is respectively Softmax and Tanh
-        function.
+        Activation functions, default is respectively Identity and Tanh
+        function. The output activation defaults to Identity so the cell
+        produces unconstrained regression outputs (pass ``nn.Softmax`` for
+        a probability-simplex output).
     hidden_state_size : int, optional
         Size of hidden states, default is the same size than input.
     reset_activation, update_activation : torch.nn.Module, optional
@@ -217,7 +226,7 @@ class GatedRecurrentUnit(_OutputLayerMixin, GRUCell):  # type: ignore[misc]
 
     def __init__(
         self, X, y, drop=None, x_type=None, y_type=None, bias=True,
-        forward_activation=nn.Softmax, hidden_activation=nn.Tanh,
+        forward_activation=nn.Identity, hidden_activation=nn.Tanh,
         hidden_state_size=None, reset_activation=nn.Sigmoid,
         update_activation=nn.Sigmoid,
     ):

--- a/fynance/models/lstm.py
+++ b/fynance/models/lstm.py
@@ -108,19 +108,19 @@ class _LSTMCell(_RecurrentBase):
         self.C = self.H if memory_state_size is None else memory_state_size
 
         # Forget gate
-        self.W_f = nn.Linear(self.N + self.H, self.C)
+        self.W_f = nn.Linear(self.N + self.H, self.C, bias=bias)
         self.f_f = forget_activation()
 
         # Update gate
-        self.W_i = nn.Linear(self.N + self.H, self.C)
+        self.W_i = nn.Linear(self.N + self.H, self.C, bias=bias)
         self.f_i = update_activation()
 
         # Candidate value
-        self.W_c = nn.Linear(self.N + self.H, self.C)
+        self.W_c = nn.Linear(self.N + self.H, self.C, bias=bias)
         self.f_c = memory_activation()
 
         # Output gate
-        self.W_o = nn.Linear(self.N + self.H, self.C)
+        self.W_o = nn.Linear(self.N + self.H, self.C, bias=bias)
         self.f_o = output_activation()
 
         # Hidden activation (applied to cell state before output gate)
@@ -210,17 +210,19 @@ class LSTMCell(_LSTMCell):
 
 
 class LongShortTermMemory(_OutputLayerMixin, LSTMCell):
-    """ Long Short-Term Memory neural network.
+    """ Long Short-Term Memory cell with output projection.
 
-    Full LSTM model: :class:`_LSTMCell` four-gate architecture followed
-    by a forward output projection. The cell state ``C`` and hidden
-    state ``H`` are threaded through the sequence, allowing the model to
-    carry information across many time steps without the
-    vanishing-gradient pathology that limits
-    :class:`~fynance.models.rnn.RecurrentNeuralNetwork`. Use it for
-    sequence modeling tasks where dependencies span dozens of steps
-    (intraday return series, multi-day momentum signals, regime
-    detection).
+    LSTM four-gate architecture (:class:`_LSTMCell`) followed by a
+    forward output projection. The caller supplies the hidden state ``H``
+    and cell state ``C``; :meth:`forward` returns updated ``(Y, H, C)``.
+    Like the other gated cells in this package, **each of the ``T`` rows
+    of ``X`` is processed independently** — the cell does *not* loop over
+    a time axis or thread ``H`` / ``C`` across rows on its own, so it is a
+    *stateless* gated feed-forward cell. To model temporal dependencies
+    the caller must thread ``H`` and ``C`` across successive steps
+    explicitly. For built-in, causal sequence modeling prefer
+    :class:`~fynance.models.tcn.TemporalConvNet` or
+    :class:`~fynance.models.transformer.Transformer`.
 
     Parameters
     ----------
@@ -229,8 +231,11 @@ class LongShortTermMemory(_OutputLayerMixin, LSTMCell):
         - If it's an integer, respectively dimension of inputs and outputs.
     drop : float, optional
         Probability of an element to be zeroed.
+    bias : bool, optional
+        If ``True`` (default), the linear layers learn an additive bias.
     forward_activation : torch.nn.Module, optional
-        Activation functions, default is Softmax.
+        Output activation, default is Identity (unconstrained regression
+        output; pass ``nn.Softmax`` for a probability-simplex output).
     hidden_activation, memory_activation : torch.nn.Module, optional
         Activation functions for respectively hidden and memory state,
         default both are Tanh function.
@@ -266,7 +271,7 @@ class LongShortTermMemory(_OutputLayerMixin, LSTMCell):
 
     def __init__(
         self, X, y, drop=None, x_type=None, y_type=None, bias=True,
-        forward_activation=nn.Softmax, hidden_activation=nn.Tanh,
+        forward_activation=nn.Identity, hidden_activation=nn.Tanh,
         hidden_state_size=None, memory_activation=nn.Tanh,
         memory_state_size=None, forget_activation=nn.Sigmoid,
         update_activation=nn.Sigmoid, output_activation=nn.Sigmoid,
@@ -334,6 +339,7 @@ class LongShortTermMemory(_OutputLayerMixin, LSTMCell):
             Cell memory of the model.
 
         """
+        self.train()
         self.optimizer.zero_grad()  # type: ignore[attr-defined]
         outputs, H, C = self(X, H, C)
         loss = self.criterion(outputs, y)
@@ -368,6 +374,12 @@ class LongShortTermMemory(_OutputLayerMixin, LSTMCell):
             Cell memory of the model.
 
         """
-        Y, H, C = self(X, H, C)
+        was_training = self.training
+        self.eval()
+        try:
+            Y, H, C = self(X, H, C)
+
+        finally:
+            self.train(was_training)
 
         return Y.detach(), H.detach(), C.detach()

--- a/fynance/models/mlp.py
+++ b/fynance/models/mlp.py
@@ -153,7 +153,9 @@ class MultiLayerPerceptron(BaseNeuralNet):
             return lambda x: x
 
     def _set_dropout(self, drop):
-        # Set dropout parameters
+        # Set dropout parameters. Use a ModuleList (with nn.Identity for
+        # the no-dropout slots) so the dropout layers are registered as
+        # submodules and respond to ``model.eval()`` / ``model.train()``.
         if isinstance(drop, list):
 
             if len(drop) != self.n_layers:
@@ -161,15 +163,17 @@ class MultiLayerPerceptron(BaseNeuralNet):
                 raise ValueError('if you pass a list of drop parameters '
                                  'this one must be of size of layers list + 1')
 
-            return [torch.nn.Dropout(p=p) for p in drop]
+            modules = [torch.nn.Dropout(p=p) for p in drop]
 
         elif drop is not None:
 
-            return [torch.nn.Dropout(p=drop) for _ in range(self.n_layers)]
+            modules = [torch.nn.Dropout(p=drop) for _ in range(self.n_layers)]
 
         else:
 
-            return [lambda x: x for _ in range(self.n_layers)]
+            modules = [torch.nn.Identity() for _ in range(self.n_layers)]
+
+        return torch.nn.ModuleList(modules)
 
     def forward(self, x):
         """ Forward computation. """

--- a/fynance/models/rnn.py
+++ b/fynance/models/rnn.py
@@ -1,19 +1,26 @@
 #!/usr/bin/env python3
 # coding: utf-8
 
-""" Vanilla Elman recurrent neural network model.
+""" Single-step Elman-style recurrent cell.
 
-Defines :class:`RecurrentNeuralNetwork`, the simplest recurrent model:
-a single recurrent layer (Elman RNN) followed by a forward output
-projection. For longer temporal dependencies, prefer
-:class:`~fynance.models.gru.GatedRecurrentUnit` (GRU) or
-:class:`~fynance.models.lstm.LongShortTermMemory` (LSTM), which
-mitigate the vanishing-gradient problem via explicit gating.
+Defines :class:`RecurrentNeuralNetwork`, an Elman-style cell: it
+concatenates an input row with a supplied hidden-state row, applies one
+linear layer plus activation, and projects to the output. Each of the
+``T`` rows of the input is processed **independently** — the class does
+**not** thread a hidden state across a time axis, so it is a *stateless*
+gated feed-forward cell rather than a sequence model. The caller is
+responsible for any state threading (e.g. by looping over time steps and
+feeding the returned ``H`` back in).
+
+For genuine sequence modeling with temporal state, use a dedicated
+sequence architecture such as :class:`~fynance.models.tcn.TemporalConvNet`
+or :class:`~fynance.models.transformer.Transformer`, which enforce
+causality over an explicit time axis.
 
 Main entry points
 -----------------
-- :class:`RecurrentNeuralNetwork` — vanilla Elman RNN ready for
-  walk-forward training via :meth:`~fynance.models._base.BaseNeuralNet.set_optimizer`.
+- :class:`RecurrentNeuralNetwork` — single-step Elman cell ready for
+  training via :meth:`~fynance.models._base.BaseNeuralNet.set_optimizer`.
 
 References
 ----------
@@ -33,15 +40,20 @@ __all__ = ['RecurrentNeuralNetwork']
 
 
 class RecurrentNeuralNetwork(_OutputLayerMixin, _RecurrentBase):  # type: ignore[misc]
-    """ Neural network with vanilla Elman recurrent architecture.
+    """ Single-step Elman-style gated cell.
 
-    A single recurrent linear layer followed by a forward output layer.
-    Each call to :meth:`forward` updates the hidden state ``H`` and
-    emits a prediction ``Y``. Suitable as a baseline for short-horizon
-    sequence prediction; for longer dependencies, use
-    :class:`~fynance.models.gru.GatedRecurrentUnit` or
-    :class:`~fynance.models.lstm.LongShortTermMemory` to mitigate
-    vanishing gradients.
+    A single linear layer (over the input concatenated with a supplied
+    hidden state) followed by an output projection. Each call to
+    :meth:`forward` consumes ``X`` of shape ``(T, N)`` and ``H`` of shape
+    ``(T, H)`` and returns ``(Y, H_new)`` with the same leading dimension
+    ``T``; **every row is processed independently** and no state is
+    threaded across rows. This is therefore a *stateless* gated
+    feed-forward cell, not a sequence model — the caller must perform any
+    temporal state threading explicitly.
+
+    For sequence modeling with built-in temporal state and causality,
+    prefer :class:`~fynance.models.tcn.TemporalConvNet` or
+    :class:`~fynance.models.transformer.Transformer`.
 
     Parameters
     ----------
@@ -50,9 +62,13 @@ class RecurrentNeuralNetwork(_OutputLayerMixin, _RecurrentBase):  # type: ignore
         - If it's an integer, respectively dimension of inputs and outputs.
     drop : float, optional
         Probability of an element to be zeroed.
+    bias : bool, optional
+        If ``True`` (default), the linear layers learn an additive bias.
     forward_activation, hidden_activation : torch.nn.Module, optional
-        Activation functions, default is respectively Softmax and Tanh
-        function.
+        Activation functions, default is respectively Identity and Tanh
+        function. The output activation defaults to Identity so the cell
+        produces unconstrained regression outputs (pass ``nn.Softmax`` for
+        a probability-simplex output).
     hidden_state_size : int, optional
         Size of hidden states, default is the same size than input.
 
@@ -67,6 +83,18 @@ class RecurrentNeuralNetwork(_OutputLayerMixin, _RecurrentBase):  # type: ignore
     f_y, f_h : torch.nn.Module
         Respectively forward and hidden activation functions.
 
+    Examples
+    --------
+    >>> import torch
+    >>> from fynance.models.rnn import RecurrentNeuralNetwork
+    >>> _ = torch.manual_seed(0)
+    >>> model = RecurrentNeuralNetwork(4, 1, hidden_state_size=3)
+    >>> X = torch.zeros(5, 4)
+    >>> H = torch.zeros(5, 3)
+    >>> Y, H_new = model(X, H)
+    >>> Y.shape, H_new.shape
+    (torch.Size([5, 1]), torch.Size([5, 3]))
+
     See Also
     --------
     fynance.models.gru.GatedRecurrentUnit,
@@ -76,7 +104,7 @@ class RecurrentNeuralNetwork(_OutputLayerMixin, _RecurrentBase):  # type: ignore
 
     def __init__(
         self, X, y, drop=None, x_type=None, y_type=None, bias=True,
-        forward_activation=nn.Softmax, hidden_activation=nn.Tanh,
+        forward_activation=nn.Identity, hidden_activation=nn.Tanh,
         hidden_state_size=None,
     ):
         _RecurrentBase.__init__(

--- a/fynance/tests/models/test_neural_network.py
+++ b/fynance/tests/models/test_neural_network.py
@@ -208,6 +208,71 @@ class TestMLP:
         model.set_optimizer(nn.MSELoss, torch.optim.Adam, params=[model], lr=1e-3)
         assert model.optimizer is not None
 
+    def test_dtype_request_is_applied(self):
+        """ A float32 request on float64 data yields float32 tensors. """
+        X64 = np.zeros((10, N_IN), dtype=np.float64)
+        y64 = np.zeros((10, N_OUT), dtype=np.float64)
+        model = MultiLayerPerceptron(N_IN, N_OUT, layers=[8])
+        model.set_data(X64, y64, x_type=torch.float32, y_type=torch.float32)
+        assert model.X.dtype == torch.float32
+        assert model.y.dtype == torch.float32
+
+    def test_float64_numpy_trains_without_astype(self):
+        """ Plain float64 numpy input must fit/predict without manual cast. """
+        rng = np.random.default_rng(0)
+        X64 = rng.standard_normal((20, N_IN))  # float64 by default
+        y64 = rng.standard_normal((20, N_OUT))
+        assert X64.dtype == np.float64
+        model = MultiLayerPerceptron(X64, y64, layers=[8])
+        model.set_optimizer(nn.MSELoss, torch.optim.SGD, lr=1e-3)
+        # Coerced to the default (float32) so it matches the float32 params.
+        assert model.X.dtype == torch.get_default_dtype()
+        loss = model.train_on(model.X, model.y)  # must not raise on dtype
+        assert torch.isfinite(loss)
+        pred = model.predict(model.X)
+        assert pred.shape == (20, N_OUT)
+
+    def test_set_data_does_not_alias_numpy(self):
+        """ set_data must not let later edits to the tensor mutate the source. """
+        X = np.zeros((10, N_IN), dtype=np.float32)
+        model = MultiLayerPerceptron(N_IN, N_OUT, layers=[8])
+        t = model._set_data(X)
+        t[0, 0] = 123.0
+        assert X[0, 0] == 0.0
+
+    def test_predict_deterministic_with_dropout(self):
+        """ With dropout>0, predict is deterministic and restores train mode. """
+        torch.manual_seed(0)
+        model = MultiLayerPerceptron(X_t, y_t, layers=[16], drop=0.5)
+        model.set_optimizer(nn.MSELoss, torch.optim.Adam, lr=1e-3)
+        assert model.training  # starts in train mode
+        p1 = model.predict(X_t)
+        p2 = model.predict(X_t)
+        assert torch.allclose(p1, p2)
+        # eval mode must be restored to training after predict
+        assert model.training
+
+    def test_train_on_sets_train_mode(self):
+        """ train_on must put the model back into training mode. """
+        model = MultiLayerPerceptron(X_t, y_t, layers=[16], drop=0.5)
+        model.set_optimizer(nn.MSELoss, torch.optim.Adam, lr=1e-3)
+        model.eval()
+        model.train_on(X_t, y_t)
+        assert model.training
+
+    def test_overfit_tiny_batch_loss_decreases(self):
+        """ Sanity: MLP can overfit a tiny batch (loss decreases). """
+        torch.manual_seed(0)
+        rng = np.random.default_rng(0)
+        X = torch.from_numpy(rng.standard_normal((8, N_IN)).astype(np.float32))
+        y = torch.from_numpy(rng.standard_normal((8, N_OUT)).astype(np.float32))
+        model = MultiLayerPerceptron(X, y, layers=[32, 32], activation=nn.ReLU)
+        model.set_optimizer(nn.MSELoss, torch.optim.Adam, lr=1e-2)
+        first = model.train_on(X, y).item()
+        for _ in range(200):
+            last = model.train_on(X, y).item()
+        assert last < first
+
 
 # ---------------------------------------------------------------------------
 # GatedRecurrentUnit
@@ -255,6 +320,28 @@ class TestGRU:
     def test_hidden_state_size_default(self):
         model = GatedRecurrentUnit(X_t, y_t)
         assert model.H == N_IN
+
+    def test_bias_false_removes_biases(self):
+        """ bias=False must drop the bias on every linear layer. """
+        model = GatedRecurrentUnit(N_IN, N_OUT, hidden_state_size=8, bias=False)
+        assert model.W_h.bias is None
+        assert model.W_u.bias is None
+        assert model.W_r.bias is None
+        assert model.W_y.bias is None
+        # default keeps biases
+        model_b = GatedRecurrentUnit(N_IN, N_OUT, hidden_state_size=8)
+        assert model_b.W_h.bias is not None
+        assert model_b.W_y.bias is not None
+
+    def test_default_activation_is_not_simplex(self):
+        """ Default output must not be a probability simplex (no Softmax). """
+        torch.manual_seed(0)
+        model = GatedRecurrentUnit(N_IN, N_OUT, hidden_state_size=8)
+        H = torch.zeros(T, model.H)
+        Y, _ = model(X_t, H)
+        row_sums = Y.sum(dim=-1)
+        # a Softmax default would force every row sum to exactly 1
+        assert not torch.allclose(row_sums, torch.ones(T))
 
 
 # ---------------------------------------------------------------------------
@@ -313,6 +400,36 @@ class TestLSTM:
     def test_hidden_state_size_default(self):
         model = LongShortTermMemory(X_t, y_t)
         assert model.H == N_IN
+
+    def test_bias_false_removes_biases(self):
+        """ bias=False must drop the bias on every linear layer. """
+        model = LongShortTermMemory(
+            N_IN, N_OUT, hidden_state_size=8, bias=False
+        )
+        for w in (model.W_f, model.W_i, model.W_c, model.W_o,
+                  model.W_h, model.W_y):
+            assert w.bias is None
+
+    def test_default_activation_is_not_simplex(self):
+        """ Default output must not be a probability simplex (no Softmax). """
+        torch.manual_seed(0)
+        model = LongShortTermMemory(N_IN, N_OUT, hidden_state_size=8)
+        H = torch.zeros(T, model.H)
+        C = torch.zeros(T, model.H)
+        Y, _, _ = model(X_t, H, C)
+        assert not torch.allclose(Y.sum(dim=-1), torch.ones(T))
+
+    def test_predict_deterministic_with_dropout(self):
+        """ predict with dropout>0 is deterministic and restores train mode. """
+        torch.manual_seed(0)
+        model = LongShortTermMemory(X_t, y_t, hidden_state_size=8, drop=0.5)
+        model.set_optimizer(nn.MSELoss, torch.optim.Adam, lr=1e-3)
+        H = torch.zeros(T, model.H)
+        C = torch.zeros(T, model.H)
+        Y1, _, _ = model.predict(X_t, H, C)
+        Y2, _, _ = model.predict(X_t, H, C)
+        assert torch.allclose(Y1, Y2)
+        assert model.training
 
 
 # ---------------------------------------------------------------------------
@@ -419,6 +536,36 @@ class TestAttention:
     def test_mha_invalid_heads(self):
         with pytest.raises(ValueError):
             MultiHeadAttention(d_model=33, num_heads=4)
+
+    def test_sdpa_mask_zeros_weight(self):
+        """ Masked positions (mask == 0) get ~0 attention weight. """
+        torch.manual_seed(0)
+        attn = ScaledDotProductAttention()
+        B, T_seq, d = 2, 4, 8
+        Q = torch.randn(B, T_seq, d)
+        K = torch.randn(B, T_seq, d)
+        V = torch.randn(B, T_seq, d)
+        mask = torch.ones(B, T_seq, T_seq)
+        mask[:, :, -1] = 0  # forbid attending to the last key position
+        _, weights = attn(Q, K, V, mask=mask)
+        # weight on masked positions must be (near) zero
+        assert torch.allclose(weights[:, :, -1], torch.zeros(B, T_seq), atol=1e-6)
+        # unmasked rows still sum to one
+        np.testing.assert_allclose(
+            weights.sum(dim=-1).numpy(), np.ones((B, T_seq)), atol=1e-5
+        )
+
+    def test_mha_mask_zeros_weight(self):
+        """ MultiHeadAttention honours the mask: masked keys get ~0 weight. """
+        torch.manual_seed(0)
+        mha = MultiHeadAttention(d_model=16, num_heads=2)
+        x = torch.randn(2, 5, 16)
+        mask = torch.ones(2, 1, 5, 5)
+        mask[:, :, :, -1] = 0  # forbid attending to the last position
+        _, attn = mha(x, mask=mask)
+        assert torch.allclose(
+            attn[:, :, :, -1], torch.zeros(2, mha.num_heads, 5), atol=1e-6
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/fynance/tests/models/test_rnn.py
+++ b/fynance/tests/models/test_rnn.py
@@ -61,3 +61,44 @@ class TestRecurrentNeuralNetwork:
         H = torch.zeros(T, 32)
         Y, H_out = model(X_t, H)
         assert H_out.shape == (T, 32)
+
+    def test_bias_false_removes_biases(self):
+        """ bias=False must drop the bias on the recurrent and output layers. """
+        model = RecurrentNeuralNetwork(N_IN, N_OUT, hidden_state_size=8, bias=False)
+        assert model.W_h.bias is None
+        assert model.W_y.bias is None
+        model_b = RecurrentNeuralNetwork(N_IN, N_OUT, hidden_state_size=8)
+        assert model_b.W_h.bias is not None
+        assert model_b.W_y.bias is not None
+
+    def test_default_output_is_not_simplex(self):
+        """ Default forward_activation is Identity, not Softmax. """
+        torch.manual_seed(0)
+        model = RecurrentNeuralNetwork(N_IN, N_OUT, hidden_state_size=8)
+        H = torch.zeros(T, model.H)
+        Y, _ = model(X_t, H)
+        # a Softmax default would force every row to sum to exactly 1
+        assert not torch.allclose(Y.sum(dim=-1), torch.ones(T))
+
+    def test_rows_processed_independently(self):
+        """ Honest stateless contract: each row depends only on its own row.
+
+        These cells do NOT thread state across the leading dimension, so
+        perturbing one row of (X, H) must leave the other rows' outputs
+        unchanged. This pins the documented stateless behaviour.
+        """
+        torch.manual_seed(0)
+        model = RecurrentNeuralNetwork(N_IN, N_OUT, hidden_state_size=5)
+        model.eval()
+        X = torch.randn(7, N_IN)
+        H = torch.randn(7, model.H)
+        with torch.no_grad():
+            Y_base, H_base = model(X, H)
+            X_pert = X.clone()
+            X_pert[3] += 100.0  # perturb a single row only
+            Y_pert, H_pert = model(X_pert, H)
+        idx = [i for i in range(7) if i != 3]
+        assert torch.allclose(Y_base[idx], Y_pert[idx], atol=1e-5)
+        assert torch.allclose(H_base[idx], H_pert[idx], atol=1e-5)
+        # the perturbed row itself does change
+        assert not torch.allclose(Y_base[3], Y_pert[3])

--- a/fynance/tests/models/test_signalmodel.py
+++ b/fynance/tests/models/test_signalmodel.py
@@ -45,3 +45,24 @@ def test_fit_returns_self():
     model = MultiLayerPerceptron(X, y, layers=[4])
     model.set_optimizer(nn.MSELoss, torch.optim.SGD, lr=1e-3)
     assert model.fit(X, y) is model
+
+
+def test_fit_predict_on_float64_numpy():
+    """ Plain float64 numpy (no .astype) must fit/predict without crashing. """
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(40, 3))  # float64 by default
+    y = X.sum(axis=1, keepdims=True)  # float64
+    assert X.dtype == np.float64 and y.dtype == np.float64
+    model = MultiLayerPerceptron(X, y, layers=[8])
+    model.set_optimizer(nn.MSELoss, torch.optim.SGD, lr=1e-3)
+    out = model.fit(X, y, epochs=2).predict(X)
+    assert np.asarray(out).shape[0] == X.shape[0]
+
+
+def test_set_seed_only_seeds_requested_generator():
+    """ Passing only seed_torch must leave the numpy seed untouched. """
+    X, y = _xy()
+    model = MultiLayerPerceptron(X, y, layers=[4])
+    model.set_seed(seed_torch=123)
+    assert model.seed_torch == 123
+    assert model.seed_numpy is None  # numpy generator not (re)seeded


### PR DESCRIPTION
## Summary

Fixes the audited correctness bugs in the PyTorch model layer (roadmap **1.F**). Scope limited to `_base.py`, `_recurrent_base.py`, `rnn.py`, `gru.py`, `lstm.py`, `mlp.py` (+ tests). No source change was needed in `attention.py` / `cv_result.py`.

## Findings fixed

| Sev | Finding | Fix |
|-----|---------|-----|
| HIGH | `_set_data`/`set_data`/`fit` accepted `dtype`/`x_type`/`y_type` but never applied it | `_set_data` now applies `dtype` via `.to()` |
| HIGH | float64 numpy + float32 params crashed at first forward | `_set_data` casts floating input to `torch.get_default_dtype()` (float32) by default; ints preserved |
| HIGH | `predict` never called `eval()`, `train_on` never called `train()` → dropout leaked into inference / non-deterministic | `predict` wraps forward in `eval()`/`no_grad` and restores prior mode (base + recurrent + LSTM); `train_on` calls `train()`. MLP dropout moved into `nn.ModuleList` so `eval()` actually reaches it |
| MEDIUM | `bias` ctor arg was a silent no-op | forwarded to every `nn.Linear` in RNN/GRU/LSTM cells and the output projection |
| MEDIUM | default `forward_activation=Softmax` forced a probability simplex | defaulted to `nn.Identity` for the gated cells; doctests/tests updated |
| CRITICAL/DESIGN | RNN/GRU/LSTM do not recur over time; base docstring claimed a false `(T, S, N)` sequence contract | **redocumented honestly** as stateless gated feed-forward cells; false contract removed (see below) |
| MEDIUM (tests) | attention masking only tested indirectly | direct tests that masked positions get ~0 weight (SDPA + MHA) |
| LOW | `set_seed` bounds/behavior, numpy reseed, `from_numpy` aliasing, device move, docstring typos | bounds aligned to `0 <= seed < 2**32`, bool rejected, numpy only seeded when requested, input cloned, predict moves to device, typos fixed, seeded doctests added |
| LOW (tests) | loss-shape tests tautological | added an overfit-tiny-batch sanity test for MLP |

## Recurrence finding: path taken

**Path (b) — honest redocumentation, not real recurrence.** The cells feed the `T` axis to `nn.Linear` as the batch dim and process every row independently; there is no state threaded across a time axis, and the whole stack (tests, rolling, objective) relies on the `(T, N)` 2-D batch semantics. Implementing genuine temporal recurrence (path a) would change the `forward` signature, the batch semantics, and `set_data` (3-D input), risking regressions in out-of-scope `rolling.py`/`objective.py` (owned by a parallel PR). Per the brief (correctness over ambition, do not ship half-working recurrence), the cells are now documented honestly as stateless gated feed-forward cells, the false `(T, S, N)` contract is removed, and all the concrete bugs are fixed. A new `test_rows_processed_independently` pins the honest stateless behaviour.

## Tests

18 new tests across `test_neural_network.py`, `test_rnn.py`, `test_signalmodel.py`. The 14 that target behavioural fixes fail before and pass after; the 4 coverage/contract tests (attention mask x2, MLP overfit, rows-independent) were requested as additive coverage.

## Gates

- `ruff check fynance/` — clean
- `mypy fynance/` — clean (168 files)
- gate pytest set with `--doctest-modules` — 115 passed
- full `fynance/tests/models/` — 189 passed; TCN/Transformer causality tests still green

`fynance/models/__init__.py` not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYiBP4z6rdZA1BHnEUqG4p