### PR TITLE
fix: causality + numerical-stability bugs in training stack and losses

### DIFF
--- a/fynance/models/loss/__init__.py
+++ b/fynance/models/loss/__init__.py
@@ -16,6 +16,12 @@ Main entry points
   proxy; only penalizes negative excess returns).
 - :class:`DirectionalAccuracyLoss` — sigmoid surrogate for directional
   accuracy (differentiable approximation of sign-prediction rate).
+- :class:`CalmarLoss` — negative Calmar ratio (return per unit of
+  maximum drawdown).
+- :class:`OmegaLoss` — negative Omega ratio (expected gains over
+  expected losses relative to a threshold).
+- :class:`HybridLoss` — convex combination of two losses with a fixed or
+  learnable weight.
 
 Notes
 -----

--- a/fynance/models/loss/_base.py
+++ b/fynance/models/loss/_base.py
@@ -16,6 +16,13 @@ import torch.nn
 
 __all__ = ['BaseLoss']
 
+#: Hard magnitude bound for ratio-style losses (Sharpe / Sortino / Calmar /
+#: Omega). It is far above any plausible real ratio (which are O(1)-O(10)), so
+#: it never touches a normal-case value; it only caps the runaway that a
+#: collapsing risk denominator would otherwise produce, keeping the loss finite
+#: and its gradients well-scaled.
+MAX_RATIO: float = 1e3
+
 
 class BaseLoss(torch.nn.Module):
     """ Base class for differentiable financial loss functions.
@@ -41,7 +48,16 @@ class BaseLoss(torch.nn.Module):
         self.rf = rf
         self.period = period
         self.eps = eps
-        self._rf_per_period: float = rf / period
+
+    @property
+    def _rf_per_period(self) -> float:
+        """ Per-period risk-free rate, recomputed from the live ``rf``/``period``.
+
+        Computed as a property (not cached in ``__init__``) so that mutating
+        ``loss.rf`` or ``loss.period`` after construction takes effect on the
+        next :meth:`forward` instead of being a silent no-op.
+        """
+        return self.rf / self.period
 
     def _check_tensor(self, x: object) -> None:
         """ Raise TypeError if *x* is not a :class:`torch.Tensor`. """

--- a/fynance/models/loss/calmar.py
+++ b/fynance/models/loss/calmar.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import torch
 
 # Local packages
+from ._base import MAX_RATIO as _MAX_RATIO
 from ._base import BaseLoss
 
 __all__ = ['CalmarLoss']
@@ -24,6 +25,15 @@ class CalmarLoss(BaseLoss):
 
     Parameters are inherited from :class:`BaseLoss` (``period``, ``eps``).
 
+    Notes
+    -----
+    Drawdowns are :math:`O(\text{returns})`, so a fixed absolute ``eps``
+    (e.g. ``1e-8``) is dimensionally wrong: on a low- or zero-drawdown
+    batch the ratio would explode and dominate gradients. The drawdown is
+    therefore floored with a **returns-scaled** epsilon,
+    ``eps * |equity|.mean()``, keeping the loss finite and bounded while
+    preserving its sign convention (minimizing it maximizes the ratio).
+
     """
 
     def forward(
@@ -35,5 +45,13 @@ class CalmarLoss(BaseLoss):
         running_max, _ = torch.cummax(equity, dim=0)
         max_drawdown = (running_max - equity).max()
         annual_return = y_pred.mean() * self.period
+        # Returns-scaled floor: a fixed absolute eps is dimensionally wrong for
+        # an O(returns) drawdown and lets the ratio explode on a low-drawdown
+        # batch. Scaling by the equity magnitude keeps the floor on the right
+        # scale; the bare eps backstop guards the degenerate all-zero-return
+        # case and the final clamp bounds the magnitude when the drawdown is
+        # near zero (so the loss stays finite with well-scaled gradients).
+        floor = self.eps * equity.abs().mean() + self.eps
+        ratio = annual_return / torch.clamp(max_drawdown, min=floor)
 
-        return -(annual_return / (max_drawdown + self.eps))
+        return -torch.clamp(ratio, min=-_MAX_RATIO, max=_MAX_RATIO)

--- a/fynance/models/loss/omega.py
+++ b/fynance/models/loss/omega.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import torch
 
 # Local packages
+from ._base import MAX_RATIO as _MAX_RATIO
 from ._base import BaseLoss
 
 __all__ = ['OmegaLoss']
@@ -21,6 +22,15 @@ class OmegaLoss(BaseLoss):
     the ratio of expected gains to expected losses relative to a threshold
     ``L``. Fully differentiable through :func:`torch.relu`. Minimizing the
     loss maximizes the Omega ratio.
+
+    Notes
+    -----
+    Both gains and losses are :math:`O(|r - L|)`, so a fixed absolute
+    ``eps`` is dimensionally wrong: on an all-gains batch (zero losses) the
+    ratio would explode (e.g. ``-1e6``) and dominate gradients. The
+    denominator is therefore floored with a **returns-scaled** epsilon,
+    ``eps * |r - L|.mean()``, keeping the loss finite and bounded while
+    preserving the sign convention (minimizing it maximizes the ratio).
 
     Parameters
     ----------
@@ -43,5 +53,11 @@ class OmegaLoss(BaseLoss):
         diff = y_pred - self.threshold
         gains = torch.relu(diff).mean()
         losses = torch.relu(-diff).mean()
+        # Returns-scaled floor: a fixed absolute eps is dimensionally wrong for
+        # O(|r - L|) losses and lets the ratio explode on an all-gains batch.
+        # The bare eps backstop guards the degenerate all-zero-diff case and
+        # the final clamp bounds the magnitude when losses are near zero.
+        floor = self.eps * diff.abs().mean() + self.eps
+        ratio = gains / torch.clamp(losses, min=floor)
 
-        return -(gains / (losses + self.eps))
+        return -torch.clamp(ratio, min=-_MAX_RATIO, max=_MAX_RATIO)

--- a/fynance/models/loss/sortino.py
+++ b/fynance/models/loss/sortino.py
@@ -10,6 +10,7 @@ import torch
 import torch.nn.functional as F
 
 # Local packages
+from ._base import MAX_RATIO as _MAX_RATIO
 from ._base import BaseLoss
 
 __all__ = ['SortinoLoss']
@@ -38,6 +39,13 @@ class SortinoLoss(BaseLoss):
     **This is a training proxy** — the value is not comparable to the
     numpy :func:`~fynance.metrics.sortino` evaluation metric.
 
+    The downside deviation is :math:`O(\text{returns})`, so a fixed
+    absolute ``eps`` inside the square root is dimensionally wrong: on an
+    all-gains batch (zero downside) the loss would explode (e.g. ``-100``).
+    The downside is therefore floored with a **returns-scaled** epsilon
+    proportional to the excess-return magnitude, keeping the loss finite
+    and bounded while preserving the sign convention.
+
     Parameters
     ----------
     rf : float, optional
@@ -45,7 +53,8 @@ class SortinoLoss(BaseLoss):
     period : int, optional
         Number of periods per year. Default is 252.
     eps : float, optional
-        Numerical stabilizer added inside the square root. Default is 1e-8.
+        Relative numerical stabilizer scaling the downside-deviation floor
+        (see Notes). Default is 1e-8.
 
     Examples
     --------
@@ -88,5 +97,13 @@ class SortinoLoss(BaseLoss):
         """
         self._check_tensor(y_pred)
         excess = y_pred - self._rf_per_period
-        downside = torch.sqrt(torch.mean(F.relu(-excess) ** 2) + self.eps)
-        return -(excess.mean() / downside)
+        downside = torch.sqrt(torch.mean(F.relu(-excess) ** 2))
+        # Floor the downside relative to the return scale: a fixed absolute eps
+        # inside the sqrt is dimensionally wrong for an O(returns) downside and
+        # lets the ratio explode on an all-gains batch. ``eps`` backstops the
+        # degenerate all-zero case; the final clamp bounds the magnitude in the
+        # near-zero-downside regime (where pushing for more gains is fine, so
+        # saturating the gradient there is harmless for this training proxy).
+        floor = self.eps * excess.abs().mean() + self.eps
+        ratio = excess.mean() / torch.clamp(downside, min=floor)
+        return -torch.clamp(ratio, min=-_MAX_RATIO, max=_MAX_RATIO)

--- a/fynance/models/objective.py
+++ b/fynance/models/objective.py
@@ -18,7 +18,9 @@ protocol (``fit``/``predict``), so it drops into the harness via the precomputed
     run_experiment(strat, prices, X=features, y=returns, walk_forward=...)
 
 ``fit(X, y)`` interprets ``y`` as the **realized per-bar returns** aligned with
-``X``; ``predict(X)`` returns positions in ``[-1, 1]`` (via ``tanh``).
+``X``; ``predict(X)`` returns positions. With the default ``position_fn``
+(``tanh``) these are bounded in ``[-1, 1]``; a custom ``position_fn`` may be
+unbounded.
 
 """
 
@@ -209,7 +211,11 @@ class ObjectiveModel:
 
     @torch.no_grad()
     def predict(self, X: NDArray) -> NDArray:
-        """ Return positions in ``[-1, 1]`` for each row of ``X``. """
+        """ Return a position for each row of ``X``.
+
+        With the default ``position_fn`` (``tanh``) positions are bounded in
+        ``[-1, 1]``; a custom ``position_fn`` may produce unbounded values.
+        """
         self.net.eval()  # type: ignore[union-attr]
         Xt = torch.as_tensor(np.asarray(X, dtype=np.float32))
 

--- a/fynance/models/rolling.py
+++ b/fynance/models/rolling.py
@@ -9,6 +9,11 @@ window. The pattern enforces strict temporal ordering, eliminating
 lookahead bias and matching how a strategy would actually be retrained
 in production.
 
+Each step trains on ``X[t-n:t]`` and yields two slices: ``eval_set =
+slice(t-r, t)`` — the last ``r`` bars of the **training** window, used
+for an in-sample fit-quality check — and ``test_set = slice(t, t+s)`` —
+the next strictly out-of-sample window.
+
 A concrete :class:`RollMultiLayerPerceptron` combines this iterator
 with :class:`fynance.models.mlp.MultiLayerPerceptron`. The
 same pattern is applied to portfolio allocation in
@@ -17,7 +22,8 @@ same pattern is applied to portfolio allocation in
 Main entry points
 -----------------
 - :class:`_RollingBasis` — iterator that yields ``(eval_set,
-  test_set)`` slices and tracks training/evaluation/test losses.
+  test_set)`` slices (in-sample tail + out-of-sample window) and tracks
+  training/evaluation/test losses.
 - :class:`RollMultiLayerPerceptron` — walk-forward MLP, ready to use
   via :meth:`RollMultiLayerPerceptron.set_roll_period` and
   :meth:`RollMultiLayerPerceptron.run`.
@@ -27,7 +33,6 @@ Main entry points
 from __future__ import annotations
 
 # Built-in packages
-from multiprocessing import Process
 from typing import Callable
 
 # External packages
@@ -126,7 +131,9 @@ class _RollingBasis:
         end : int, optional
             Ending observation, default is last observation.
         roll_period : int, optional
-            Size of the rolling period, default equals ``test_period``.
+            Size of the rolling period, default equals ``test_period``. Must
+            not exceed ``train_period`` — the in-sample ``eval_set`` is the
+            last ``roll_period`` bars of the training window.
         eval_period : int, optional
             Size of the evaluating period (unused, kept for API compat).
         batch_size : int, optional
@@ -138,6 +145,12 @@ class _RollingBasis:
         -------
         _RollingBasis
 
+        Raises
+        ------
+        ValueError
+            If ``roll_period`` exceeds ``train_period`` (would push the
+            in-sample evaluation window outside the training window).
+
         """
         self.n = train_period
         self.s = test_period
@@ -145,8 +158,23 @@ class _RollingBasis:
         self.b = batch_size
         self.e = epochs
 
+        # Causality guards. The eval window is the last ``r`` bars of the
+        # training window (``slice(t - r, t)``), so a roll larger than the
+        # train length (``r > n``) would make the eval window reach outside
+        # the in-sample window. Combined with a negative ``t0`` it also turns
+        # the eval / train slices into negative indices that wrap to the tail
+        # of the array — i.e. silently leak FUTURE bars into training and
+        # evaluation. Reject ``r > n`` and clamp the window start to ``>= 0``.
+        if self.r > self.n:
+            raise ValueError(
+                f"roll_period ({self.r}) must not exceed train_period "
+                f"({self.n}): the evaluation window is the last roll_period "
+                "bars of the training window, so r > n would reach outside "
+                "the in-sample window (lookahead leak)."
+            )
+
         self.T = self.T if end is None else min(self.T, end)
-        self.t0 = max(self.n - self.r, min(start, self.T - self.n - self.s))
+        self.t0 = max(0, self.n - self.r, min(start, self.T - self.n - self.s))
         self.n_iter = (self.T - self.t0 - self.s) // self.r * self.e
         self.log = []
 
@@ -174,6 +202,9 @@ class _RollingBasis:
             self.t += self.r
             self.t_idx = np.arange(self.t - self.n, self.t)
 
+        # ``eval_set`` is the last ``r`` bars of the *training* window
+        # (in-sample): an enforced ``r <= n`` keeps it inside ``[t - n, t)``.
+        # ``test_set`` is the next, strictly out-of-sample window.
         eval_set = slice(self.t - self.r, self.t)
         test_set = slice(self.t, self.t + self.s)
 
@@ -334,6 +365,7 @@ class _RollingBasis:
 
     def _training(self):
         loss_epoch = 0.
+        n_batches = 0
         np.random.shuffle(self.t_idx)
         for t in range(0, self.n, self.b):
             s = min(t + self.b, self.n)
@@ -343,8 +375,14 @@ class _RollingBasis:
                 y=self.f(self.y[train_slice]),
             )
             loss_epoch += lo.item()
+            n_batches += 1
 
-        self.loss_train[self.i] = loss_epoch / s
+        # ``lo`` is already a per-batch *mean* loss, so the epoch loss is the
+        # mean over batches — divide by the batch count, not by the train
+        # length ``n`` (the stale ``s`` from the last batch) which made the
+        # reported loss depend on the batch size and span a different scale
+        # than a single-batch loss.
+        self.loss_train[self.i] = loss_epoch / n_batches
 
     def run(self, backtest_plot=True, backtest_kpi=True, figsize=(9, 6),
             func=np.sign):
@@ -371,7 +409,6 @@ class _RollingBasis:
 
         self.bnn = BacktestNeuralNet(figsize)
         self.log = []
-        p_print = None
 
         for eval_set, test_set in self:
             self._training()
@@ -398,14 +435,13 @@ class _RollingBasis:
                     r[test_set], func(self.y_test[test_set]), v0=v0
                 )
 
+            # Render in-process. A forked multiprocessing.Process is not
+            # fork-safe here: it would share live torch tensors and the
+            # matplotlib figure across the fork. Display is cheap and purely
+            # a side effect, so do it inline.
             if self.t > self.t0 + self.r:
-                if p_print is None or not p_print.is_alive():
-                    p_print = Process(
-                        target=self._print,
-                        args=(self.t, self.i, r, y_perf, func,
-                              backtest_plot, backtest_kpi)
-                    )
-                    p_print.start()
+                self._print(self.t, self.i, r, y_perf, func,
+                            backtest_plot, backtest_kpi)
 
         self._print(self.t, self.i, r, y_perf, func, backtest_plot,
                     backtest_kpi)
@@ -434,8 +470,10 @@ class _RollingBasis:
         pct = t - self.n - self.s
         pct = pct / (self.T - self.n - self.T % self.s)
         txt = '{:5.2%} is done | '.format(pct)
-        txt += 'Eval loss is {:5.2} | '.format(self.loss_eval[-1])
-        txt += 'Test loss is {:5.2} | '.format(self.loss_test[-1])
+        # Use the current iteration index ``self.i`` — ``[-1]`` is the last
+        # array slot, which stays 0 until the final iteration.
+        txt += 'Eval loss is {:5.2} | '.format(self.loss_eval[self.i])
+        txt += 'Test loss is {:5.2} | '.format(self.loss_test[self.i])
         print(txt, end='\r')
 
     def _display_plot_loss(self, bnn, i):
@@ -459,10 +497,12 @@ class RollMultiLayerPerceptron(MultiLayerPerceptron, _RollingBasis):
 
     End-to-end walk-forward training pipeline for an MLP: at each step
     the model is fitted on a sliding window of length ``n``, evaluated
-    on the previous out-of-sample slice, then used to predict the next
-    slice. Losses (train, eval, test) and out-of-sample predictions are
-    accumulated step by step in ``self.log``, ``self.y_eval`` and
-    ``self.y_test`` for downstream analysis.
+    on the last ``r`` bars of that **training** window (the in-sample
+    ``eval_set = slice(t-r, t)``, a fit-quality check — *not* out-of-sample
+    data), then used to predict the next, strictly out-of-sample slice
+    ``test_set = slice(t, t+s)``. Losses (train, eval, test) and
+    out-of-sample predictions are accumulated step by step in ``self.log``,
+    ``self.y_eval`` and ``self.y_test`` for downstream analysis.
 
     Use :meth:`set_roll_period` to configure window sizes and batch
     options, then :meth:`run` to execute the loop. ``run`` can also

--- a/fynance/tests/models/test_loss.py
+++ b/fynance/tests/models/test_loss.py
@@ -63,6 +63,17 @@ class TestSharpeLoss:
         assert not torch.isnan(loss)
         assert not torch.isinf(loss)
 
+    def test_rf_change_takes_effect(self):
+        # _rf_per_period is recomputed in forward (a property), so mutating rf
+        # after construction must change the loss instead of being a no-op.
+        loss_fn = SharpeLoss()
+        before = loss_fn(RETURNS).item()
+        loss_fn.rf = 0.10
+        after = loss_fn(RETURNS).item()
+        assert after != before
+        # Matches building a fresh loss with the same rf.
+        assert after == pytest.approx(SharpeLoss(rf=0.10)(RETURNS).item())
+
 
 class TestSortinoLoss:
     def test_forward_scalar(self):
@@ -86,16 +97,45 @@ class TestSortinoLoss:
         assert not torch.isnan(loss)
         assert not torch.isinf(loss)
 
+    def test_all_positive_finite_bounded_and_scale_invariant(self):
+        # On an all-gains batch the downside is ~0. A *fixed absolute* eps inside
+        # the sqrt is dimensionally wrong: the loss then scales with the return
+        # magnitude (10x returns -> 10x loss) instead of being scale-invariant
+        # like a true Sortino ratio, and explodes. A returns-scaled floor keeps
+        # the loss finite, bounded, and scale-invariant.
+        r = torch.abs(RETURNS) + 0.001   # strictly positive → downside = 0
+        loss = SortinoLoss(eps=1e-8)(r)
+        loss_10x = SortinoLoss(eps=1e-8)(10.0 * r)
+        assert torch.isfinite(loss)
+        assert abs(loss.item()) <= 1e3 + 1.0          # bounded
+        # scale invariance (old absolute-eps code is off by ~10x here)
+        assert loss_10x.item() == pytest.approx(loss.item(), rel=1e-2)
+
+    def test_positive_when_negative_mean(self):
+        # Sign convention (like SharpeLoss): a negative-mean return series has a
+        # negative Sortino ratio, so the negated loss must be positive.
+        loss = SortinoLoss()(RETURNS_NEG)
+        assert loss.item() > 0
+
+    def test_rf_change_takes_effect(self):
+        # _rf_per_period is a property (not cached in __init__), so mutating rf
+        # after construction must change the computed loss.
+        loss_fn = SortinoLoss()
+        before = loss_fn(RETURNS).item()
+        loss_fn.rf = 5.0   # huge rf -> excess turns negative -> loss flips sign
+        after = loss_fn(RETURNS).item()
+        assert before != after
+
     def test_downside_only_penalized(self):
         # Two series identical except one has large upside: Sortino should
-        # be lower (better) for the one with large upside because upside
-        # doesn't count against the denominator.
+        # be strictly lower (better) for the one with large upside because
+        # upside doesn't count against the denominator.
         r_base = torch.tensor([-0.01, 0.005, -0.008, 0.003, -0.006])
         r_upside = torch.tensor([-0.01, 0.500, -0.008, 0.003, -0.006])
         loss_base = SortinoLoss()(r_base)
         loss_upside = SortinoLoss()(r_upside)
         # Large upside improves mean without worsening downside → lower loss
-        assert loss_upside.item() <= loss_base.item()
+        assert loss_upside.item() < loss_base.item()
 
 
 class TestDirectionalAccuracyLoss:
@@ -151,6 +191,23 @@ class TestCalmarLoss:
         with pytest.raises(TypeError):
             CalmarLoss()(np.zeros(10))
 
+    def test_no_drawdown_loss_is_bounded(self):
+        from fynance.models.loss import CalmarLoss
+        # Monotonically increasing equity -> zero drawdown. A fixed absolute
+        # eps (1e-8) on an O(returns) drawdown made the ratio explode (e.g.
+        # -3.78e7). A returns-scaled floor keeps it finite and bounded.
+        r = torch.full((100,), 0.01)   # constant gains -> no drawdown
+        loss = CalmarLoss(eps=1e-8)(r)
+        assert torch.isfinite(loss)
+        assert abs(loss.item()) < 1e4
+
+    def test_all_zero_returns_is_finite(self):
+        from fynance.models.loss import CalmarLoss
+        # Degenerate all-zero series: numerator and drawdown are both 0; the
+        # bare-eps backstop in the floor must keep the loss finite (not NaN).
+        loss = CalmarLoss(eps=1e-8)(torch.zeros(50))
+        assert torch.isfinite(loss)
+
 
 class TestOmegaLoss:
     def test_known_value(self):
@@ -168,6 +225,22 @@ class TestOmegaLoss:
         loss = OmegaLoss(threshold=0.01)(r)
         loss.backward()
         assert r.grad is not None
+
+    def test_all_gains_loss_is_bounded(self):
+        from fynance.models.loss import OmegaLoss
+        # All returns above the threshold -> zero losses. A fixed absolute eps
+        # made the ratio explode (e.g. -1e6); a returns-scaled floor bounds it.
+        r = torch.full((100,), 0.01)   # all gains, no losses below threshold
+        loss = OmegaLoss(eps=1e-8)(r)
+        assert torch.isfinite(loss)
+        assert abs(loss.item()) < 1e4
+
+    def test_all_zero_diff_is_finite(self):
+        from fynance.models.loss import OmegaLoss
+        # Returns exactly at threshold: gains == losses == 0; the bare-eps
+        # backstop must keep the loss finite (not NaN).
+        loss = OmegaLoss(threshold=0.0, eps=1e-8)(torch.zeros(50))
+        assert torch.isfinite(loss)
 
 
 class TestHybridLoss:

--- a/fynance/tests/models/test_objective.py
+++ b/fynance/tests/models/test_objective.py
@@ -53,6 +53,24 @@ def test_reproducible_with_seed():
     assert np.allclose(a, b)
 
 
+def test_warm_started_refit_is_reproducible():
+    # The net warm-starts across successive fit() calls (walk-forward refit).
+    # Two equal-seed refit sequences over the same data must yield identical
+    # predictions -- no hidden non-determinism in the online adaptation.
+    X1, r1 = _edge_data(n=300, seed=1)
+    X2, r2 = _edge_data(n=300, seed=2)
+
+    def refit_sequence():
+        m = ObjectiveModel(layers=(8,), epochs=15, lr=5e-3, seed=11)
+        m.fit(X1, r1)        # first walk-forward window
+        m.fit(X2, r2)        # warm-started refit on the next window
+        return np.asarray(m.predict(X2))
+
+    a = refit_sequence()
+    b = refit_sequence()
+    assert np.allclose(a, b)
+
+
 def test_accepts_custom_net_and_loss():
     X, returns = _edge_data(n=300)
     net = torch.nn.Sequential(torch.nn.Linear(2, 4), torch.nn.ReLU(),

--- a/fynance/tests/models/test_rolling.py
+++ b/fynance/tests/models/test_rolling.py
@@ -6,7 +6,11 @@ import torch
 import torch.nn as nn
 
 from fynance.models.mlp import MultiLayerPerceptron
-from fynance.models.rolling import CVResult, _RollingBasis
+from fynance.models.rolling import (
+    CVResult,
+    RollMultiLayerPerceptron,
+    _RollingBasis,
+)
 
 # ---------------------------------------------------------------------------
 # Shared fixtures
@@ -127,3 +131,159 @@ class TestPurge:
         rb = make_rb()
         result = rb.cross_validate(model_factory, X_t, y_t, purge=3)
         assert result.oof_predictions.shape == (T, N_OUT)
+
+
+# ---------------------------------------------------------------------------
+# Causality: window-start guards (no negative-index / future-wrapping windows)
+# ---------------------------------------------------------------------------
+
+class TestWindowGuards:
+
+    def test_roll_period_exceeding_train_period_raises(self):
+        # r > n would push the in-sample eval window (last r bars of the
+        # training window) outside the training window and, with a negative
+        # t0, turn slices into negative indices wrapping to future bars.
+        rb = _RollingBasis(X_t, y_t)
+        with pytest.raises(ValueError, match="roll_period"):
+            rb(train_period=10, test_period=5, roll_period=20)
+
+    def test_negative_start_does_not_produce_negative_windows(self):
+        # A negative start used to let t0 go negative -> slice(t-r, t) and
+        # arange(t-n, t) became negative indices wrapping to the tail (future
+        # leak). t0 must be clamped to >= 0.
+        rb = _RollingBasis(X_t, y_t)
+        rb(train_period=20, test_period=5, start=-8, roll_period=10)
+        assert rb.t0 >= 0
+        it = iter(rb)
+        for eval_set, test_set in it:
+            assert eval_set.start >= 0
+            assert test_set.start >= 0
+            # the rebuilt training index must never be negative
+            assert rb.t_idx.min() >= 0
+
+    def test_all_windows_non_negative_and_train_before_test(self):
+        # Sweep the iterator: every train/eval/test window starts at a
+        # non-negative index and the training window precedes the test window.
+        rb = _RollingBasis(X_t, y_t)
+        rb(train_period=TRAIN, test_period=TEST, roll_period=ROLL)
+        it = iter(rb)
+        for eval_set, test_set in it:
+            train_start = rb.t - rb.n
+            assert train_start >= 0
+            assert eval_set.start >= 0
+            assert test_set.start >= 0
+            # training window [t-n, t) is entirely before the test window.
+            assert rb.t <= test_set.start
+            # eval window is the in-sample tail: inside the training window.
+            assert eval_set.start >= train_start
+            assert eval_set.stop <= rb.t
+
+
+# ---------------------------------------------------------------------------
+# Reported training loss scale (must not depend on batch size)
+# ---------------------------------------------------------------------------
+
+class TestTrainLossScale:
+
+    def _make(self, batch_size):
+        # Seed both RNGs (weight init + the t_idx shuffle in _training) so the
+        # reported loss is deterministic.
+        torch.manual_seed(0)
+        np.random.seed(0)
+        model = RollMultiLayerPerceptron(X_t, y_t, layers=[8])
+        model.set_optimizer(nn.MSELoss, torch.optim.Adam, lr=1e-3)
+        model.set_roll_period(
+            train_period=TRAIN, test_period=TEST, roll_period=ROLL,
+            batch_size=batch_size, epochs=1,
+        )
+        return model
+
+    def _one_train_step(self, model):
+        np.random.seed(0)
+        it = iter(model)
+        next(it)
+        model._training()
+        return model.loss_train[model.i]
+
+    def test_train_loss_on_single_batch_scale(self):
+        # _training reports the mean over batches of per-batch mean losses.
+        # That must be on the same (MSE) scale as a single full-batch loss,
+        # not divided by the train length n (the old `/ n` bug, which made the
+        # reported loss ~ n_batches times too small).
+        model = self._make(batch_size=8)   # 5 batches over n=40
+        reported = self._one_train_step(model)
+        # Reference MSE on the same training window: O(1) for unit-variance
+        # data. The old `/ n` scaling would push it to ~ O(1/40) instead.
+        ref = float(((model.predict(model.X[model.t_idx]).numpy()
+                      - model.y[model.t_idx].numpy()) ** 2).mean())
+        assert reported == pytest.approx(ref, rel=0.6, abs=0.6)
+        assert reported > ref / 3   # not collapsed by the 1/n factor
+
+    def test_train_loss_scale_independent_of_batch_size(self):
+        # Reported train loss for batch_size=8 (5 batches) and batch_size=40
+        # (1 batch) must be on the same scale. The old `/ n` bug divided the
+        # 5-batch sum by n=40 (not by 5), so the small-batch loss came out
+        # several times smaller -- a batch-size-dependent, meaningless scale.
+        ls = self._one_train_step(self._make(batch_size=8))
+        lf = self._one_train_step(self._make(batch_size=TRAIN))
+        assert 0.4 < ls / lf < 2.5
+
+
+# ---------------------------------------------------------------------------
+# _display_kpi reads the current iteration, not the last array slot
+# ---------------------------------------------------------------------------
+
+class TestDisplayKpi:
+
+    def test_kpi_reports_current_iteration_loss(self, capsys):
+        # _display_kpi must read loss_eval[self.i] / loss_test[self.i] -- the
+        # current step -- not [-1] (the last array slot, which stays 0 until the
+        # final iteration and would print the wrong, stale value mid-run).
+        rb = make_rb()
+        rb.loss_eval = np.zeros(5)
+        rb.loss_test = np.zeros(5)
+        rb.i = 1
+        rb.loss_eval[rb.i] = 0.42   # current step value
+        rb.loss_test[rb.i] = 0.73
+        # last slot stays 0 -> if the code used [-1] the printout would show 0.0
+        rb._display_kpi(t=rb.n + rb.s)
+        out = capsys.readouterr().out
+        assert '0.42' in out
+        assert '0.73' in out
+
+
+# ---------------------------------------------------------------------------
+# run(): minimal walk-forward sanity (display off)
+# ---------------------------------------------------------------------------
+
+class TestRunWalkForward:
+
+    def test_run_no_display_train_precedes_test(self):
+        # A tiny seeded walk-forward run with both display paths off must
+        # complete and log per-step losses; and every training window must
+        # precede its test window (causality).
+        torch.manual_seed(0)
+        model = RollMultiLayerPerceptron(X_t, y_t, layers=[8])
+        model.set_optimizer(nn.MSELoss, torch.optim.Adam, lr=1e-3)
+        model.set_roll_period(
+            train_period=TRAIN, test_period=TEST, roll_period=ROLL, epochs=1,
+        )
+        # Record the (train_start, test_start) pairs as the loop advances.
+        bounds = []
+        model.set_roll_period(
+            train_period=TRAIN, test_period=TEST, roll_period=ROLL, epochs=1,
+        )
+        for eval_set, test_set in iter(model):
+            bounds.append((model.t - model.n, test_set.start))
+        for train_start, test_start in bounds:
+            assert train_start >= 0
+            assert train_start + TRAIN <= test_start
+
+        model.set_roll_period(
+            train_period=TRAIN, test_period=TEST, roll_period=ROLL, epochs=1,
+        )
+        out = model.run(backtest_plot=False, backtest_kpi=False)
+        assert out is model
+        stats = model.get_stats()
+        assert stats.size > 0
+        assert np.all(np.isfinite(stats["train_loss"]))


### PR DESCRIPTION
Fixes the audited bugs in the training stack + custom losses (roadmap 1.E). Scope limited to `rolling.py`, `objective.py`, `loss/*`; the recurrent/attention model files are untouched (owned by a parallel PR).

## Findings fixed

### rolling.py (walk-forward)
- **HIGH — negative-index / future-wrapping windows.** When `roll_period > train_period`, the eval window (the last `r` bars of the training window) reached outside the in-sample window, and with a negative `t0` the eval/train slices became negative indices that wrapped to the tail of the array (future-bar leak). Now: reject `r > n` with a clear `ValueError` and clamp the window start to `>= 0`.
- **HIGH (docs) — eval_set mislabeled.** `run()` / `RollMultiLayerPerceptron` docstrings called `eval_set = slice(t-r, t)` the "previous out-of-sample slice"; it is the **in-sample** tail of the training window. Corrected.
- **MEDIUM — train-loss scale.** `loss_train` divided the sum of per-batch mean losses by the train length `n` (stale last-batch `s`) instead of the batch count → meaningless across batch sizes. Now divides by the number of batches.
- **MEDIUM — `_display_kpi` read `[-1]`** (last slot, 0 until the final iter) instead of `[self.i]`. Fixed.
- **MEDIUM — fork-unsafe display.** `run()` spawned a `multiprocessing.Process` sharing torch tensors / a live matplotlib figure across the fork. Now renders in-process; `backtest_plot` / `backtest_kpi=False` paths preserved.

### loss/*
- **HIGH (calmar) / MEDIUM (omega, sortino) — eps-scale explosion.** The fixed absolute `eps=1e-8` is dimensionally wrong for an `O(returns)` risk denominator; on low/zero-drawdown / all-gains batches the ratio exploded (Calmar ~-3.78e7, Omega -1e6, Sortino ~-100) and dominated gradients. Now: a **returns-scaled floor** on the denominator + a hard magnitude clamp (`MAX_RATIO`, far above any real ratio). Sign conventions preserved (minimizing the loss maximizes the metric).
- **LOW (_base) — `_rf_per_period` cached in `__init__`.** Mutating `loss.rf` afterward was a silent no-op. Now a property recomputed in `forward`.
- **LOW (__init__ docstring)** — added `CalmarLoss`, `OmegaLoss`, `HybridLoss` to "Main entry points".

### objective.py
- **MEDIUM (docs)** — qualified the `[-1, 1]` position guarantee to the default `tanh` `position_fn` (a custom one may be unbounded).

## Tests
All seeded/deterministic, fail-before / pass-after where a behavioral fix exists:
window guards (`r>n` raises, no negative-index windows), train-loss scale (single-batch + batch-size-independence), KPI current-iteration read, `run()` walk-forward causality; loss finiteness/boundedness/scale-invariance on degenerate batches, rf-change-takes-effect (Sharpe & Sortino), Sortino sign convention, tightened downside-penalty to strict `<`, ObjectiveModel warm-started-refit reproducibility.

## Gates
- `ruff check fynance/` — pass
- `mypy fynance/` — pass (168 files)
- target pytest (with `--doctest-modules`) — 82 passed; full `fynance/tests/models/` — 187 passed

`__init__.py` touched: only `fynance/models/loss/__init__.py` **docstring** (explicitly allowed); no exports changed. `CHANGELOG.md` / roadmap not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYiBP4z6rdZA1BHnEUqG4p