### PR TITLE
chore: release v2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [2.10.0] - 2026-06-22
+
+### Breaking Changes
+
+### Added
+
+### Changed
+
 - **`RNN`/`GRU`/`LSTM` are documented as stateless gated feed-forward cells**,
   not temporal recurrent nets — they process each timestep independently and do
   not thread state across a time axis. The unsatisfiable `(T, S, N)` sequence

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fynance"
-version = "2.9.0"
+version = "2.10.0"
 description = "Pure-Python (Numba-accelerated) machine learning, econometrics and statistical tools for financial analysis and backtesting"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Release **v2.10.0** — full 2026-06 code-audit remediation (PRs #188–#196).

### Changed
- `RNN`/`GRU`/`LSTM` documented as stateless gated cells (false `(T,S,N)` contract removed); default activation `Identity` (was `Softmax`); `bias=False` honored.
- `predict()` runs in eval mode; `dtype` honored.
- `calmar`/`roll_calmar` → `+inf` on zero-MDD profitable curves.
- `iso_vol` standard return; `Ledger` append-only + DSR de-annualized.

### Fixed
- features `axis=1` path; `ERC`/`MVP_uc` 1/N convergence + N=1 guards; loss eps explosions; `_RollingBasis` future-leak guard; econometric list inputs; `loglikelihood` mutation; `resample`/`walk_forward`/`to_returns` guards; backtest cost timing; `run_experiment` cost mutation; doc drift (CONTRIBUTING/status/README/Sphinx).

## Test plan
All 5 gates green on develop: **819 passed, 1 skipped**; ruff; mypy (171 files); interrogate 94.7%; Sphinx -W.