### PR TITLE
Release v2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [2.10.0] - 2026-06-22
+
+### Breaking Changes
+
+### Added
+
+### Changed
+
 - **`RNN`/`GRU`/`LSTM` are documented as stateless gated feed-forward cells**,
   not temporal recurrent nets — they process each timestep independently and do
   not thread state across a time axis. The unsatisfiable `(T, S, N)` sequence

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`RNN`/`GRU`/`LSTM` are documented as stateless gated feed-forward cells**,
+  not temporal recurrent nets — they process each timestep independently and do
+  not thread state across a time axis. The unsatisfiable `(T, S, N)` sequence
+  contract was removed from the docstrings, and the default `forward_activation`
+  is now `Identity` (was `Softmax`, which forced regression outputs onto a
+  probability simplex). `bias=False` is now honored.
+- **`model.predict()` runs in eval mode** (dropout disabled, deterministic) and
+  `set_data`/`fit` honor the requested `dtype`; float64 numpy input no longer
+  crashes against float32 parameters.
+- **`calmar`/`roll_calmar` return `+inf`** (not `0.0`) for a profitable
+  drawdown-free curve, consistent with `sharpe`/`sortino`.
+- **`features.money_management.iso_vol`** now uses the standard return
+  `s_t / s_{t-1} - 1` (was the reciprocal `s_{t-1} / s_t - 1`).
+- **`research.Ledger`** is strictly append-only (`append` raises on a duplicate
+  name) and `Ledger.deflated_sharpe` de-annualizes the Sharpe before the DSR so
+  the guard is no longer saturated.
+
 ### Fixed
+
+- **2-D `axis=1` path across `fynance.features`.** `Scale.scale`/`Scale.revert`
+  silently ignored `axis=1` (missing `return`); the rolling-window size was
+  clamped against the series axis instead of the time axis; `mad(axis=1)` raised
+  a broadcast error; `np.AxisError` no longer exists under NumPy 2. All fixed,
+  with genuine multi-column parity tests (the old tests used degenerate
+  single-column arrays).
+- **`portfolio.ERC` / `MVP_uc` returned the equal-weight starting guess.** The
+  SLSQP objective fell below the default `ftol` on return-scale inputs; the
+  covariance is now rescaled to unit trace so they converge. Single-asset inputs
+  no longer crash the covariance-based optimizers; `IVP(normalize=True)` no
+  longer distorts the inverse-variance weights.
+- **Custom losses** (`CalmarLoss`/`OmegaLoss`/`SortinoLoss`) no longer explode
+  to huge magnitudes on low-denominator (e.g. drawdown-free) batches.
+- **`_RollingBasis` walk-forward** now rejects `roll_period > train_period`
+  (which previously wrapped negative indices into future data — a lookahead
+  leak); train-loss normalization, per-step KPI indexing, and fork-unsafe
+  plotting in `run()` are fixed.
+- **`signal.rank`** raises `ValueError` on overlapping or negative legs
+  (previously produced silently non-dollar-neutral weights).
+- **`econometric_models.ARMA`/`ARMA_GARCH`/`ARMAX_GARCH`** accept list inputs;
+  `estimator.loglikelihood` no longer mutates its input array;
+  `diversified_ratio` returns a scalar.
+- **`data.align.resample`** validates the index dtype with a clear error;
+  `data.split.walk_forward` rejects empty-train configs;
+  `core.PriceSeries.to_returns` rejects non-positive prices for log/pct returns.
+- **`backtest` transaction-cost timing** on prices input;
+  `research.run_experiment` no longer mutates the caller's `strategy.cost`;
+  `leaderboard` sorts a NaN metric to the bottom.
+- Removed a dead `bollinger_band` deprecation warning; corrected numerous
+  docstring formulas/typos and `Raises` sections.
 
 ### Deprecated
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,12 +8,13 @@ git clone https://github.com/ArthurBernard/Fynance.git
 cd Fynance
 pip install -e ".[dev]"
 
-# Compile Cython extensions
-python setup.py build_ext --inplace
-
 # Activate the project git hooks (run once per clone)
 git config core.hooksPath .githooks
 ```
+
+The build is **pure-Python** — there is no compile step and no `setup.py`.
+Numerical kernels are Numba `@njit` (JIT-compiled on first call), and
+`pyproject.toml` is the authoritative build config.
 
 ## Git Flow
 
@@ -34,12 +35,12 @@ master          ← stable releases only (tagged vX.Y.Z, published to PyPI)
 - `develop` → `master` happens only at release time (version bump + tag).
 
 **Branch naming:** `feat/`, `fix/`, `chore/`, `docs/` + short kebab-case description.
-Examples: `feat/transformer-model`, `fix/cython3-compat`, `chore/pyproject-migration`.
+Examples: `feat/transformer-model`, `fix/numpy2-compat`, `chore/pyproject-migration`.
 
 **Commit style:** [Conventional Commits](https://www.conventionalcommits.org/)
 ```
 feat: add TCN model to fynance/models/
-fix: replace ** operator in momentums_cy.pyx for Cython 3 compat
+fix: clamp adaptive window to avoid lookahead on short series
 chore: migrate setup.py metadata to pyproject.toml
 docs: add Git Flow section to CONTRIBUTING.md
 ```
@@ -48,15 +49,20 @@ docs: add Git Flow section to CONTRIBUTING.md
 
 | Subpackage | Description | Policy |
 |---|---|---|
-| `fynance.features` | Metrics, indicators, filters (Cython + Python) | Extend only — never rewrite Cython |
-| `fynance.algorithms` | Portfolio allocation (HRP, MVP, ERC, IVP, MDP) | Stable public API — deprecation path required |
-| `fynance.models` | PyTorch neural networks (MLP, GRU, LSTM, Transformer) | Modernize freely |
-| `fynance.backtest` | Performance evaluation, loss series | Improve freely |
-| `fynance.estimator` | Cython ARMA/GARCH parameter estimation | Do not duplicate in Python layer |
+| `fynance.features` | Indicators, momentums, filters, scaling, regime, money management (Numba kernels) | Extend freely — kernels are Numba `@njit` |
+| `fynance.metrics` | Risk-adjusted ratios, drawdown, returns, `summary` | Extend freely |
+| `fynance.portfolio` | Portfolio allocation (HRP, MVP, ERC, IVP, MDP) + sizing | Stable public API — deprecation path required |
+| `fynance.models` | PyTorch nets (MLP, RNN/GRU/LSTM, attention, TCN, Transformer) + econometric ARMA/GARCH + losses | Modernize freely |
+| `fynance.backtest` | Vectorized engine, cost models, `BacktestResult` | Improve freely |
+| `fynance.estimator` / `fynance.models.econometric_models` | Numba ARMA/GARCH parameter estimation | Single implementation — do not duplicate parameter logic |
+
+See [`doc/dev/04-subpackages.md`](doc/dev/04-subpackages.md) for the full
+policy matrix (including `core`, `data`, `signal`, `plot`, `strategy`,
+`research`).
 
 ## Code conventions
 
-**Numerical code:** new performance-critical functions go in the `.py` file using Numba `@njit`. Do not add new Cython files — Cython is only for wrapping C libraries.
+**Numerical code:** new performance-critical functions go in the `.py` file using Numba `@njit`. There is **no Cython** in the package (since 2.1 the former `*_cy.pyx` kernels were ported to Numba); only add Cython to wrap a C library.
 
 **ML:** PyTorch only. Do not extend the legacy Keras/TensorFlow code.
 
@@ -81,16 +87,6 @@ pytest --cov=fynance --cov-report=term-missing
 
 Tests must pass before opening a PR. No lookahead bias in time-series tests (no shuffling, no future data leaking into training windows).
 
-## Cython extensions
-
-When editing a `.pyx` file, recompile before running tests:
-
-```bash
-python setup.py build_ext --inplace
-```
-
-Do not add new Cython files. New numerical code goes in the `.py` counterpart using Numba `@njit`.
-
 ## Linting
 
 ```bash
@@ -99,16 +95,24 @@ ruff check fynance/
 
 ## Stability and deprecations
 
-The symbols re-exported from `fynance.models`, `fynance.algorithms.allocation`,
-`fynance.features` and `fynance.estimator` form the **public API for the 1.x
-series**. Within 1.x:
+> **2.0 was a breaking release** (layered architecture, import-path map in
+> [`doc/MIGRATION-2.0.md`](doc/MIGRATION-2.0.md) — e.g. `fynance.algorithms` →
+> `fynance.portfolio`, performance metrics → `fynance.metrics`). The notes below
+> describe the stability contract **within the 2.x series**.
 
-- public function and class signatures are frozen — no removals, no
+Per-subpackage change budgets are governed by the policy matrix in
+[`doc/dev/04-subpackages.md`](doc/dev/04-subpackages.md). The headline rule:
+`fynance.portfolio.allocation` (ERC/HRP/IVP/MDP/MVP) and
+`fynance.estimator` / `fynance.models.econometric_models` are the **stable
+public surface** — within 2.x:
+
+- public function and class signatures there are frozen — no removals, no
   backward-incompatible signature changes;
 - behavioural changes that would break user code go through **one
   release** of `DeprecationWarning` before becoming the default;
-- internal helpers (names prefixed with `_`) and `fynance.backtest`
-  remain free to evolve without a deprecation cycle.
+- internal helpers (names prefixed with `_`) and the freely-evolving layers
+  (`features`/`metrics`/`models`/`backtest`/`plot`/`strategy`/`research`) may
+  change without a deprecation cycle, additively.
 
 Active deprecations are tracked in [CHANGELOG.md](CHANGELOG.md).
 
@@ -118,7 +122,7 @@ Active deprecations are tracked in [CHANGELOG.md](CHANGELOG.md).
 import warnings
 
 warnings.warn(
-    "old_function() is deprecated and will be removed in fynance 2.0; "
+    "old_function() is deprecated and will be removed in fynance 3.0; "
     "use new_function() instead.",
     category=DeprecationWarning,
     stacklevel=2,
@@ -142,7 +146,7 @@ def test_old_function_still_works():
 
 ### Silencing fynance deprecations (downstream users)
 
-If you depend on a deprecated path and need to stay on 1.x while you
+If you depend on a deprecated path and need to stay on 2.x while you
 migrate, opt out **explicitly**:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -60,9 +60,11 @@ alignment/resampling, and no-lookahead temporal splits (`train_test_split`,
 `walk_forward`).
 
 **Features** `fynance.features` — technical indicators (Bollinger, RSI, MACD, ROC,
-realized volatility, rolling skew/kurtosis/autocorr, …), momentums (SMA, EMA, WMA),
-scaling (incl. rolling rank), statistics, feature engineering (multi-resolution,
-Granger causality) and market-regime detection.
+realized volatility, rolling skew/kurtosis/autocorr, …), OHLCV indicators (ATR,
+ADX, Williams %R, OBV, VWAP), a causal GARCH(1,1) conditional-volatility feature,
+momentums (SMA, EMA, WMA) and adaptive windows, scaling (incl. rolling rank),
+statistics, feature engineering (multi-resolution, Granger causality) and
+market-regime detection.
 
 **Metrics** `fynance.metrics` — performance/evaluation metrics (Sharpe, Sortino,
 Calmar, drawdown, …) and a one-call `summary`.
@@ -74,15 +76,17 @@ Calmar, drawdown, …) and a one-call `summary`.
 sizing (fractional Kelly, volatility targeting, transaction costs).
 
 **Backtest** `fynance.backtest` — vectorized engine (`backtest`: positions +
-returns/prices + cost → `BacktestResult`) and cost models.
+returns/prices + cost → `BacktestResult`) and cost models (`ProportionalCost`
+and the non-linear `MarketImpactCost`).
 
 **Plot** `fynance.plot` — composable matplotlib figures and a one-call
 `tearsheet` report.
 
 **Models** `fynance.models` — econometric models (MA, ARMA, ARMA-GARCH) and
 PyTorch nets (MLP, RNN, GRU, LSTM, MultiHeadAttention, TCN, Transformer), a
-direction+magnitude stacking ensemble, differentiable losses (Sharpe, Sortino,
-Calmar, Omega, directional, hybrid), and robust-training utilities.
+direction+magnitude stacking ensemble, `RegimeMoE` (regime-conditioned
+mixture-of-experts), differentiable losses (Sharpe, Sortino, Calmar, Omega,
+directional, hybrid), and robust-training utilities.
 
 **Strategy** `fynance.strategy` — optional orchestrator composing the maillons
 end-to-end, with single-run and walk-forward evaluation.

--- a/doc/dev/01-overview.md
+++ b/doc/dev/01-overview.md
@@ -33,13 +33,14 @@ library's core invariant, enforced in tests.
 
 ## Current state (snapshot)
 
-- **Version `2.8.0`** (in `pyproject.toml`, static), released on `master` and
+- **Version `2.9.0`** (in `pyproject.toml`, static), released on `master` and
   published to PyPI; `Development Status :: 5 - Production/Stable`.
 - **Python 3.10–3.13** (CI matrix). Build is **pure-Python** (setuptools, no
   compile step) — numerical kernels are Numba `@njit`. No Cython.
-- **518 tests** under `fynance/tests/` (mirrors the package), **plus doctests**
-  run on every module via `--doctest-modules` — docstring examples are part of
-  the suite and must stay runnable.
+- **~570 unit/benchmark tests** under `fynance/tests/` (mirrors the package),
+  **plus doctests** run on every module via `--doctest-modules` — docstring
+  examples are part of the suite and must stay runnable (~660 collected in
+  total).
 - **Four CI gates**: pytest (3.10–3.13), `ruff`, `interrogate` (docstring
   coverage ≥ 80%), Sphinx build `-W`, and `mypy` clean.
 - **Core stack**: NumPy, SciPy, Numba (`@njit`), **PyTorch** (the ML backend —

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -72,6 +72,33 @@ Template:
 
 <!-- new entries below, newest first -->
 
+### 2026-06-22 — Full code audit + remediation (PRs #188–#196)  [accepted]
+
+A deep correctness/tests/docs audit (the 5 gates were already green) found logic
+bugs, weak/missing tests and doc drift the gates miss. Remediated in 9 atomic
+PRs (one concern each, parallel worktrees): features `axis=1` path, portfolio
+optimizers, metrics/econometrics, models training+losses, NN base/recurrent
+contract, data/core/signal/backtest, research guards, and doc drift. Roadmap §1
+held the backlog; closed here. Test count 658 → 819.
+
+Two choices worth recording as standing knowledge:
+
+- **`RNN`/`GRU`/`LSTM` are *not* temporal recurrent nets — kept as stateless
+  gated feed-forward cells and documented as such.** They feed the time axis to
+  `nn.Linear` as the batch dim; no state crosses time. Implementing genuine
+  recurrence (a `(T, S, N)` loop carrying hidden state) would change `forward`,
+  batch semantics and `set_data`, rippling into `rolling`/`objective`. We chose
+  the low-risk correct path: remove the false `(T, S, N)` contract, fix the
+  concrete bugs, and pin the stateless behavior with a test. **Negative
+  knowledge: do not "fix" these into recurrence casually — it is a deliberate,
+  separable enhancement, not a bug.**
+- **Optimizer-scale invariants made explicit.** ERC/MVP_uc rescale the
+  covariance to unit trace before SLSQP (the objective otherwise sinks below
+  `ftol` on return-scale data and the solver returns the 1/N start); the result
+  is argmin-invariant. Zero-denominator ratio conventions were unified
+  (`calmar` → `+inf` like `sharpe`).
+
+
 ### 2026-06-21 — Library-bricks epic: roadmap §1 shipped (PRs #177–#182)  [accepted]
 - **Choice**: ship the data-agnostic "library bricks" (roadmap §1) as six atomic
   PRs and **re-scope** the roadmap — real-data strategy research moves to the

--- a/doc/dev/05-testing.md
+++ b/doc/dev/05-testing.md
@@ -4,7 +4,7 @@
 
 | Layer | Command | Catches |
 |-------|---------|---------|
-| **Unit** | `pytest` | logic, shapes, regressions (518 tests under `fynance/tests/`) |
+| **Unit** | `pytest` | logic, shapes, regressions (~570 unit/benchmark tests under `fynance/tests/`; ~660 collected with doctests) |
 | **Doctests** | `pytest --doctest-modules` (on by default in `pyproject.toml`) | every docstring `>>>` example — they are part of the suite |
 | **Benchmarks** | `pytest-benchmark` (e.g. `test_filters_benchmark.py`) | perf regressions on hot paths |
 | **Coverage** | `pytest --cov=fynance --cov-report=term-missing` | untested branches |

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -16,17 +16,21 @@ so an agent doesn't re-investigate settled ground or assume a known stub is a bu
 - **Data**: `load()` dispatcher + CSV/Parquet adapters, causal `align`/`resample`,
   and no-lookahead `train_test_split`/`walk_forward` (embargo/purge).
 - **Features**: technical indicators (RSI/MACD/Bollinger/CCI/HMA/ROC/realized-vol/
-  skew/kurt/autocorr), momentums (SMA/EMA/WMA + std variants), scaling (z-score,
-  rolling rank), statistics, feature engineering (multi-resolution, Granger,
+  skew/kurt/autocorr), **OHLCV indicators** (ATR/ADX/Williams %R/OBV/VWAP),
+  **causal GARCH(1,1) conditional volatility** as a feature (`garch_volatility`),
+  momentums (SMA/EMA/WMA + std variants), **adaptive windows** (`adaptive_roll`/
+  `adaptive_volatility`), scaling (z-score, rolling rank), statistics, money
+  management (`iso_vol`), feature engineering (multi-resolution, Granger,
   incremental moments) and k-means market-regime detection.
 - **Metrics**: `fynance.metrics` (Sharpe/Sortino/Calmar/diversified-ratio,
   annual return/vol, drawdown/mdd, perf_*, roll_*) + one-call `summary`.
 - **Models**: econometric (ARMA/GARCH) + neural (MLP, RNN/GRU/LSTM, attention,
   TCN, Transformer) on PyTorch; `StackingEnsemble` (direction+magnitude OOF
-  meta-model); differentiable losses (Sharpe/Sortino/Calmar/Omega/directional/
-  hybrid) in `models/loss/`; robust-training utils (purged CV, early stopping,
-  sample weighting) in `models/training.py`. All NN models conform to
-  `SignalModel` (`fit`/`predict`).
+  meta-model); **`RegimeMoE`** (regime-conditioned mixture-of-experts — an
+  objective-aligned net gated on a **causal** regime label); differentiable
+  losses (Sharpe/Sortino/Calmar/Omega/directional/hybrid) in `models/loss/`;
+  robust-training utils (purged CV, early stopping, sample weighting) in
+  `models/training.py`. All NN models conform to `SignalModel` (`fit`/`predict`).
 - **Objective-aligned training** (`models/objective.py`): `ObjectiveModel` trains
   any `nn.Module` (MLP by default) **directly on a differentiable financial
   objective** (`SharpeLoss`/`SortinoLoss`/…) — the net outputs positions, the loss
@@ -38,9 +42,11 @@ so an agent doesn't re-investigate settled ground or assume a known stub is a bu
   vol-targeting + **anti-churn** `ema_smooth`/`deadband`/`min_hold` +
   `SignalPipeline`); `portfolio/` allocation (ERC/HRP/IVP/MDP/MVP) + sizing
   (fractional Kelly, vol-targeting, transaction costs).
-- **Backtest / Plot**: vectorized `backtest()` engine → `BacktestResult`,
-  `ProportionalCost`; reporting via `fynance.plot` (`tearsheet`, composable
-  figures, lazy matplotlib so `import fynance` stays matplotlib-free).
+- **Backtest / Plot**: vectorized `backtest()` engine → `BacktestResult`, cost
+  models (`ProportionalCost` + **`MarketImpactCost`** — a convex, super-linear
+  market-impact term on top of the linear fee); reporting via `fynance.plot`
+  (`tearsheet`, composable figures, lazy matplotlib so `import fynance` stays
+  matplotlib-free).
 - **Research harness** (`fynance.research`, S1–S3 complete): `Experiment`
   (serializable spec + code + seed + metrics + curves), `run_experiment` (seeded,
   cost-aware, walk-forward; no-lookahead probe; records a **provenance** block —
@@ -60,21 +66,22 @@ so an agent doesn't re-investigate settled ground or assume a known stub is a bu
 - **Numerical kernels on Numba `@njit`** — no Cython anywhere; the build is
   pure-Python (no `setup.py`, no compile step). Every kernel has a golden-value
   parity test (1e-9/1e-10) captured from the former Cython.
-- **Quality gates (all 4 enforced in CI)**: 593 tests collected (unit + doctests
-  on every module via `--doctest-modules`), incl. property tests (kernel parity + no-lookahead);
-  `ruff`; `interrogate` (docstring coverage ≥ 80%, currently ~93.6%); Sphinx
-  build `-W`; **`mypy` clean (0 errors)**.
-- **Released**: `v2.8.0` on `master` + PyPI; `Production/Stable`. CI matrix
+- **Quality gates (all 4 enforced in CI)**: ~660 tests collected (~570 unit/
+  benchmark + doctests on every module via `--doctest-modules`), incl. property
+  tests (kernel parity + no-lookahead); `ruff`; `interrogate` (docstring coverage
+  ≥ 80%, currently ~93.6%); Sphinx build `-W`; **`mypy` clean (0 errors)**.
+- **Released**: `v2.9.0` on `master` + PyPI; `Production/Stable`. CI matrix
   3.10–3.13; release builds a pure-Python universal wheel + sdist and creates the
   GitHub Release from the CHANGELOG on tag.
 
 ## In progress / active surface
 
-Nothing is currently in flight (`develop` is clean). The 2.x library is
-feature-complete for its current scope; remaining open work is **library bricks**
-only — multi-series OHLCV indicators, regime-conditioned architecture, adaptive
-windows, a richer backtest, and an optional Streamlit ledger explorer. See the
-roadmap (§1–§2) and the **Deferred** section below.
+Nothing is currently in flight (`develop` is clean). The v2.9.0 **library
+bricks** all shipped (OHLCV indicators, causal GARCH-volatility feature,
+adaptive windows, `RegimeMoE`, `MarketImpactCost`). Remaining open work is the
+**2026-06 audit remediation** (correctness/tests/docs the CI gates don't catch —
+roadmap §1), an optional **Streamlit ledger explorer** (roadmap §2), and minor
+**CI/badge hygiene** (roadmap §3). See `07-roadmap.md`.
 
 **Out of scope here**: strategy research on **real data** (empirical loss /
 architecture / normalization benchmarks, out-of-sample Sharpe, online regimes,
@@ -110,10 +117,24 @@ which depends on fynance. This public repo stays data-agnostic and result-free.
 
 ## Deferred
 
-Larger axes parked for later: realistic backtesting beyond proportional cost
-(non-linear slippage / market impact), market-regime conditioning of the
-architecture, adaptive windows, and multi-series OHLCV indicators (ATR/ADX/OBV/
-VWAP) requiring a multi-series input API. Tracked in the roadmap; not bugs.
+The library bricks that were parked here — realistic backtesting beyond
+proportional cost (non-linear market impact), market-regime conditioning of the
+architecture, adaptive windows, and multi-series OHLCV indicators
+(ATR/ADX/OBV/VWAP) — **all shipped in v2.9.0**. The only library axis still
+deferred is the optional **Streamlit ledger explorer** (roadmap §2). Tracked in
+the roadmap; not bugs.
+
+## 2026-06-22 — library bricks shipped (v2.9.0); audit remediation opened
+
+The data-agnostic **library bricks** that the re-scoped roadmap kept all landed
+in **v2.9.0**: an `OHLCV` container + multi-series indicators
+(ATR/ADX/Williams %R/OBV/VWAP), the **causal GARCH(1,1) conditional-volatility
+feature** (`garch_volatility`), **adaptive windows** (`adaptive_roll`/
+`adaptive_volatility`), regime-conditioned architecture (`RegimeMoE`), and a
+non-linear **`MarketImpactCost`**. A full audit (2026-06-22) — all five gates
+(pytest/ruff/mypy/interrogate/sphinx) already green — surfaced correctness bugs,
+test gaps and doc drift the gates don't catch; tracked as the parallelizable
+remediation backlog in roadmap §1.
 
 ## 2026-06-21 — research line shipped (v2.2 → v2.8); roadmap re-scoped
 

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -17,9 +17,9 @@ shipped, `03-decisions.md` for *why*. Keep it short and true.
 > brique d'entraînement aligné-objectif (`ObjectiveModel`) et les **bricks de
 > librairie** (conteneur `OHLCV` + indicateurs ATR/ADX/Williams %R/OBV/VWAP, feature
 > GARCH causale, `RegimeMoE`, fenêtres adaptatives, coût market-impact non-linéaire)
-> sont **terminés** — voir `CHANGELOG.md` / `03-decisions.md`. Un **audit complet** (2026-06-22) a relevé des bugs de
-> correctness, des trous de tests et des dérives de doc non couverts par les
-> gates — backlog détaillé en **section 1** ci-dessous.
+> sont **terminés** — voir `CHANGELOG.md` / `03-decisions.md`. Un **audit complet** (2026-06-22) a été
+> **entièrement remédié** en 9 PR atomiques (#188–#196) — voir `CHANGELOG.md`
+> / `03-decisions.md`. Il ne reste que les items optionnels ci-dessous.
 
 > ⚠️ **Hors scope ici** : la recherche de stratégie sur **vraie data** (benchmarks
 > empiriques loss / architecture / normalisation, évaluation Sharpe out-of-sample,
@@ -28,93 +28,6 @@ shipped, `03-decisions.md` for *why*. Keep it short and true.
 > code de librairie réutilisable, data-agnostique.
 
 ---
-
-## 1. Remédiation audit — correctness / tests / docs (2026-06)
-
-Audit complet du 2026-06-22 : les 5 gates (pytest/ruff/mypy/interrogate/sphinx)
-passaient déjà ; les points ci-dessous sont des **bugs de logique**, des **trous
-de tests** et des **dérives de doc** que les gates ne voient pas. Regroupés en PR
-atomiques **parallélisables** (fichiers disjoints). Sévérité notée par point.
-
-### 1.A — features : chemin 2-D `axis=1` cassé · `[fix/features-axis1]`
-- [ ] **CRITICAL** `Scale.scale`/`Scale.revert` : la branche `axis==1` est calculée puis jetée (pas de `return`) → axis=1 silencieusement ignoré.
-- [ ] **CRITICAL** `_wrappers.wrap_window` : fenêtre clampée sur `X.shape[0]` (axe séries) **avant** la transposition → `w > n_colonnes` rétréci en silence sur axis=1 (sma/wma/smstd/roll_*/z_score/cci/hma/rsi/roc/realized_volatility…).
-- [ ] **CRITICAL** `momentums.z_score`/`roll_z_score` (kind='e') : conversion `α=1-2/(1+w)` appliquée **deux fois** sur axis=1.
-- [ ] **HIGH** `_wrappers` : `np.AxisError` supprimé en NumPy 2 → utiliser `np.exceptions.AxisError` ; valider `axis < ndim` avant `shape[axis]`.
-- [ ] **HIGH** `stats.mad(axis=1)` lève (broadcast) — câbler le wrapper `axis`.
-- [ ] **HIGH (tests)** tous les asserts axis=1 utilisent un tableau `(6,1)` dégénéré → ajouter de vrais tests multi-colonnes (parité `f(X,axis=1)` vs per-row 1-D).
-- [ ] **MEDIUM (docs)** formules `wma`/`wmstd`/`emstd` ne correspondent pas au code (normalisateur, terme de déviation).
-
-### 1.B — features : guards & docs indicateurs · `[fix/features-guards]`
-- [ ] **MEDIUM** `ohlcv.atr`/`adx` : pas de garde `w>=1` (ZeroDivisionError pour `w=0`).
-- [ ] **MEDIUM** `ohlcv.williams_r` : doc annonce `[-100,0]` mais pas de clamp (borne conditionnelle à OHLC valide) — documenter ou clamper.
-- [ ] **MEDIUM** `indicators.bollinger_band` : `DeprecationWarning` morte ("removed in fynance 2.0") émise à chaque appel — supprimer.
-- [ ] **MEDIUM (docs)** `roll_functions.roll_min`/`roll_max` : math off-by-one (`w+1` vs fenêtre `w`) ; `roll_max` "See Also" se référence lui-même.
-- [ ] **MEDIUM** `money_management.iso_vol` : rendement réciproque `s_{t-1}/s_t-1` au lieu de `s_t/s_{t-1}-1` ; + tests (causalité, cap, plancher).
-- [ ] **LOW** `regime.regime_features` : ligne 0 `(0,0)` parasite injectée dans le clustering ; garde cluster vide.
-- [ ] **LOW (tests)** `garch` : balayage causalité par-index + corriger commentaire trompeur ; borne `min_train`. `engineering` : granger lag>1, `IncrementalMoments` n=1. `filters` : fit multivarié n>1. Sections `Raises:` manquantes (ohlcv, garch, filters).
-
-### 1.C — portfolio : optimiseurs · `[fix/portfolio-optimizers]`
-- [ ] **CRITICAL** `ERC` reste bloqué sur 1/N : objectif quartique (~1e-8) < `ftol=1e-6` SLSQP → renvoie le guess initial (contributions au risque non égalisées). API publique stable.
-- [ ] **HIGH** `MVP_uc` : même fragilité d'échelle (échoue sur variances faibles) — rescaler l'objectif / `ftol`.
-- [ ] **HIGH** entrée mono-actif (N=1) : `np.cov` scalaire → crash IVP/MVP/ERC/HRP. Garder N==1.
-- [ ] **HIGH (tests)** tests ERC/MVP_uc tautologiques (variances égales = 1/N) → cas variances inégales + assert contributions au risque / forme fermée MVP.
-- [ ] **MEDIUM** `IVP(normalize=True)` double-traite et distord la pondération `1/σ²` ; `_normalize` mute son entrée (copier).
-- [ ] **MEDIUM (docs)** `sizing.vol_target` : double-backslash dans la r-string (math non rendue) ; docstrings "Initial weights to maximize" (copier-coller).
-- [ ] **MEDIUM (tests)** HRP/MDP : seulement shape/sum → assert comportemental.
-
-### 1.D — metrics / econométrie · `[fix/metrics-econometrics]`
-- [ ] **HIGH** `calmar`/`roll_calmar` renvoient `0.0` sur MDD nulle (courbe profitable sans drawdown) alors que `sharpe`/`sortino` renvoient `inf` — convention dénominateur-nul incohérente.
-- [ ] **HIGH** `estimator.loglikelihood` mute `h` en place (`h[h==0]=1e-8`) + nom/doc trompeurs (c'est la LL **négative**).
-- [ ] **MEDIUM** `econometric_models.ARMA`/`ARMA_GARCH`/`ARMAX_GARCH` crashent sur entrée `list` (MA l'accepte) — `np.asarray`.
-- [ ] **MEDIUM** `diversified_ratio` renvoie un array `(1,1)` mais typé `float`.
-- [ ] **MEDIUM (docs)** `ARMAX_GARCH` : param `omega` manquant + somme sur régresseurs `Σ_k ψ_k x_{t,k}`.
-- [ ] **MEDIUM (tests)** `test_get_parameters` ordres tautologiques (p=q=P=Q=1) ; chemin calmar MDD-nulle non testé.
-- [ ] **LOW** `summary` mélange vol `log=True` et sharpe `log=False` ; `target_function` sans docstring ; TeX rendement annualisé + typos.
-
-### 1.E — models : training & losses · `[fix/models-training-loss]`
-- [ ] **HIGH** `rolling` (`roll_period > train_period`) : slices à index négatif → wrap sur la queue du tableau = **fuite de futur** dans train/eval. Clamp/garde.
-- [ ] **HIGH (docs)** `rolling.run` : `eval_set = slice(t-r,t)` = queue **in-sample** du train, pas OOS — relibeller / corriger.
-- [ ] **HIGH** `loss/calmar` : `eps=1e-8` mal dimensionné vs dénominateur (drawdowns O(rendements)) → ratio explose (-3.78e7) et domine le gradient.
-- [ ] **MEDIUM** `loss/omega` (et `sortino` plus doux) : même explosion d'échelle eps.
-- [ ] **MEDIUM** `rolling._training` : perte train normalisée par `n` et non par nb de batches (insensée selon batch) ; `_display_kpi` lit `loss_eval[-1]` au lieu de `[self.i]`.
-- [ ] **MEDIUM** `rolling.run` : fork d'un `multiprocessing.Process` partageant une figure matplotlib (non fork-safe) — rendre en process.
-- [ ] **MEDIUM (docs)** `objective.predict` : borne `[-1,1]` vraie seulement pour `position_fn=tanh` par défaut.
-- [ ] **LOW** `loss/_base._rf_per_period` mis en cache (muter `rf` = no-op) ; `loss/__init__` omet Calmar/Omega/Hybrid.
-- [ ] **LOW (tests)** convention de signe Sortino ; finitude edge calmar/omega/sortino ; reproductibilité refit `ObjectiveModel` ; aucun test du chemin `run()`/`__next__`/`_training` walk-forward.
-
-### 1.F — models : contrat NN · `[fix/models-nn-contract]`
-- [ ] **CRITICAL / design** `RNN`/`GRU`/`LSTM` ne récurrent **pas** dans le temps (axe T = batch de `nn.Linear`, aucun état threadé) → implémenter une vraie récurrence séquentielle **ou** redocumenter honnêtement comme couches gated stateless + retirer le contrat `(T,S,N)` impossible.
-- [ ] **HIGH** `_base.set_data` ignore `dtype`/`x_type`/`y_type` (float32 demandé → float64) ; float64-input + params float32 crashe.
-- [ ] **HIGH** `_base.predict` n'appelle pas `eval()` / `train_on` pas `train()` → dropout fuit en inférence.
-- [ ] **MEDIUM** arg `bias` no-op sur RNN/GRU/LSTM ; `predict` récurrent ne respecte pas `predict(X)` du protocole ; `forward_activation=Softmax` par défaut sur cibles de régression.
-- [ ] **MEDIUM (tests)** aucun test de causalité RNN/GRU/LSTM ; masquage attention non testé directement.
-- [ ] **LOW** `set_seed` bornes + reseed numpy global ; aliasing `from_numpy` ; device `predict` ; typos (`load_model` "Save", type `criterion`) ; pas de doctest mlp/_base/rnn ; asserts loss `>=0` tautologiques + pas de sanity overfit-tiny-batch.
-
-### 1.G — data / core / signal / backtest · `[fix/data-core-signal-backtest]`
-- [ ] **HIGH** `signal.rank` : `top+bottom>n_assets` écrase les jambes → non dollar-neutral ; pas de garde négatifs.
-- [ ] **HIGH** `data.align.resample` ne marche que sur index `datetime64` (object/int lèvent) + **zéro test**.
-- [ ] **MEDIUM** `data.split.walk_forward` : train vide silencieux si `purge>=train` (garde) ; `train_test_split` borne exclusive surprenante (1.0 → 1).
-- [ ] **MEDIUM** `core.price_series.to_returns("log"/"pct")` : inf/nan sur prix ≤0 (garde).
-- [ ] **MEDIUM** `backtest.engine` (`returns_input=False`) : 1er turnover de position non facturé.
-- [ ] **MEDIUM (docs)** `backtest.print_stats` : `underly` traité comme log-returns mais doc dit "prices".
-- [ ] **MEDIUM (tests)** `resample`, méthodes `core` (`to_prices`/`apply`/`cumulative`), `_exceptions.ArraySizeError`, branche `value_col` de `frame_to_series`, `strategy.run(X=)` non testés.
-- [ ] **LOW** `strategy.run_walk_forward` zéro-te le 1er rendement de chaque bloc test ; doc index `to_prices` ; doc `backtest.loss`/`result` ; doc état initial des mappers.
-
-### 1.H — research : guards & robustesse · `[fix/research]`
-- [ ] **HIGH** `ledger.deflated_sharpe` injecte le Sharpe **annualisé** dans `deflated_sharpe_ratio` (qui attend un SR par-période ×√(n-1)) → DSR sature (~0/~1) = confiance fausse. Dé-annualiser.
-- [ ] **HIGH** `Ledger` "append-only" mais nom dupliqué **écrase** → `n_trials` sous-compte → corrompt le compte multiple-testing du DSR.
-- [ ] **HIGH** `runner.run_experiment` mute `strategy.cost` de l'appelant (jamais restauré) — restaurer en `finally`.
-- [ ] **MEDIUM** `leaderboard` trie mal une clé NaN (flotte en tête) ; `Experiment.from_dict` lève sur clé inconnue (pas forward-compatible) ; `load()` laisse échapper `JSONDecodeError`.
-- [ ] **MEDIUM** `_seed_everything` utilise `np.random.seed` global (biaise la variance nulle de `permutation_test` pour modèles stochastiques).
-- [ ] **MEDIUM (tests)** guards sans assert sur valeur publiée (PSR/DSR Bailey & LdP) ; pas de test corrupt-input / schema-evolution / nom dupliqué.
-- [ ] **LOW** `synthetic.regime_switching` démarre toujours en régime 0 ; `_callable_name` renvoie `<lambda>` ; doc `sr_variance=1.0` placeholder + précondition prix>0.
-
-### 1.I — docs : CONTRIBUTING / status / README / Sphinx · `[docs/audit-doc-drift]`
-- [ ] **CRITICAL** `CONTRIBUTING.md` : encore `python setup.py build_ext`, "recompile .pyx", `fynance.algorithms`, cadre de déprécation "1.x → 2.0". Tout est pré-2.1 — réécrire pour 2.9 (pure-Python/Numba, `pip install -e ".[dev]"`).
-- [ ] **HIGH** `doc/dev/06-status.md` (v2.8.0, comptes 518/593, ATR/ADX/regime/adaptive/market-impact en "Deferred"), `01-overview.md` (v2.8.0 + 518), `05-testing.md` (518) — rafraîchir (v2.9.0 ; ~569 unit + doctests = 658).
-- [ ] **MEDIUM** `README.md` : liste de features omet le headline v2.9 (indicateurs OHLCV, feature GARCH causale, fenêtres adaptatives, `RegimeMoE`, `MarketImpactCost`).
-- [ ] **MEDIUM/LOW** Sphinx : `iso_vol` (dans `features.__all__`) et l'API registry data (`BaseDataSource`/`register`/`get_source`) non documentés ; `METRICS` dict ; doc/dev/README "NumPy over polars".
 
 ## 3. Chore — CI / hygiène
 

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -12,7 +12,7 @@ shipped, `03-decisions.md` for *why*. Keep it short and true.
 > Loop : `/pick-task` → `/plan` (arbre dans `plans/`) → `/execute-leaf` →
 > `/finish-task`. Release : `/release` quand `[Unreleased]` est suffisamment rempli.
 
-> **fynance 2.x livré** (v2.8.0 sur `master`/PyPI). Le refactor en couches, le port
+> **fynance 2.x livré** (v2.9.0 sur `master`/PyPI). Le refactor en couches, le port
 > Cython→Numba (build pure-Python), le harnais R&D `fynance.research` (S1–S3), la
 > brique d'entraînement aligné-objectif (`ObjectiveModel`) et les **bricks de
 > librairie** (conteneur `OHLCV` + indicateurs ATR/ADX/Williams %R/OBV/VWAP, feature
@@ -27,6 +27,17 @@ shipped, `03-decisions.md` for *why*. Keep it short and true.
 > code de librairie réutilisable, data-agnostique.
 
 ---
+
+## 3. Chore — CI / hygiène
+
+Dette d'outillage repérée pendant le batch library-bricks (v2.9.0). Non bloquant.
+
+- [ ] **CI sur les PR vers `develop`.** `ci.yml` ne s'est pas déclenché sur les PR
+  de feature ciblant `develop` (la suite n'a tourné qu'en local) — vérifier les
+  triggers du workflow pour que les 4 gates s'exécutent aussi sur ces PR.
+- [ ] **Job « Update badges » en échec.** L'étape « Commit badge if changed »
+  (workflow `Badges`) échoue à chaque push sur `develop` (problème de push du badge
+  de couverture docstring) — corriger les permissions / la condition de commit.
 
 ## 2. Research harness — extension optionnelle
 

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -17,8 +17,9 @@ shipped, `03-decisions.md` for *why*. Keep it short and true.
 > brique d'entraînement aligné-objectif (`ObjectiveModel`) et les **bricks de
 > librairie** (conteneur `OHLCV` + indicateurs ATR/ADX/Williams %R/OBV/VWAP, feature
 > GARCH causale, `RegimeMoE`, fenêtres adaptatives, coût market-impact non-linéaire)
-> sont **terminés** — voir `CHANGELOG.md` / `03-decisions.md`. Il ne reste qu'un
-> item optionnel ci-dessous.
+> sont **terminés** — voir `CHANGELOG.md` / `03-decisions.md`. Un **audit complet** (2026-06-22) a relevé des bugs de
+> correctness, des trous de tests et des dérives de doc non couverts par les
+> gates — backlog détaillé en **section 1** ci-dessous.
 
 > ⚠️ **Hors scope ici** : la recherche de stratégie sur **vraie data** (benchmarks
 > empiriques loss / architecture / normalisation, évaluation Sharpe out-of-sample,
@@ -27,6 +28,93 @@ shipped, `03-decisions.md` for *why*. Keep it short and true.
 > code de librairie réutilisable, data-agnostique.
 
 ---
+
+## 1. Remédiation audit — correctness / tests / docs (2026-06)
+
+Audit complet du 2026-06-22 : les 5 gates (pytest/ruff/mypy/interrogate/sphinx)
+passaient déjà ; les points ci-dessous sont des **bugs de logique**, des **trous
+de tests** et des **dérives de doc** que les gates ne voient pas. Regroupés en PR
+atomiques **parallélisables** (fichiers disjoints). Sévérité notée par point.
+
+### 1.A — features : chemin 2-D `axis=1` cassé · `[fix/features-axis1]`
+- [ ] **CRITICAL** `Scale.scale`/`Scale.revert` : la branche `axis==1` est calculée puis jetée (pas de `return`) → axis=1 silencieusement ignoré.
+- [ ] **CRITICAL** `_wrappers.wrap_window` : fenêtre clampée sur `X.shape[0]` (axe séries) **avant** la transposition → `w > n_colonnes` rétréci en silence sur axis=1 (sma/wma/smstd/roll_*/z_score/cci/hma/rsi/roc/realized_volatility…).
+- [ ] **CRITICAL** `momentums.z_score`/`roll_z_score` (kind='e') : conversion `α=1-2/(1+w)` appliquée **deux fois** sur axis=1.
+- [ ] **HIGH** `_wrappers` : `np.AxisError` supprimé en NumPy 2 → utiliser `np.exceptions.AxisError` ; valider `axis < ndim` avant `shape[axis]`.
+- [ ] **HIGH** `stats.mad(axis=1)` lève (broadcast) — câbler le wrapper `axis`.
+- [ ] **HIGH (tests)** tous les asserts axis=1 utilisent un tableau `(6,1)` dégénéré → ajouter de vrais tests multi-colonnes (parité `f(X,axis=1)` vs per-row 1-D).
+- [ ] **MEDIUM (docs)** formules `wma`/`wmstd`/`emstd` ne correspondent pas au code (normalisateur, terme de déviation).
+
+### 1.B — features : guards & docs indicateurs · `[fix/features-guards]`
+- [ ] **MEDIUM** `ohlcv.atr`/`adx` : pas de garde `w>=1` (ZeroDivisionError pour `w=0`).
+- [ ] **MEDIUM** `ohlcv.williams_r` : doc annonce `[-100,0]` mais pas de clamp (borne conditionnelle à OHLC valide) — documenter ou clamper.
+- [ ] **MEDIUM** `indicators.bollinger_band` : `DeprecationWarning` morte ("removed in fynance 2.0") émise à chaque appel — supprimer.
+- [ ] **MEDIUM (docs)** `roll_functions.roll_min`/`roll_max` : math off-by-one (`w+1` vs fenêtre `w`) ; `roll_max` "See Also" se référence lui-même.
+- [ ] **MEDIUM** `money_management.iso_vol` : rendement réciproque `s_{t-1}/s_t-1` au lieu de `s_t/s_{t-1}-1` ; + tests (causalité, cap, plancher).
+- [ ] **LOW** `regime.regime_features` : ligne 0 `(0,0)` parasite injectée dans le clustering ; garde cluster vide.
+- [ ] **LOW (tests)** `garch` : balayage causalité par-index + corriger commentaire trompeur ; borne `min_train`. `engineering` : granger lag>1, `IncrementalMoments` n=1. `filters` : fit multivarié n>1. Sections `Raises:` manquantes (ohlcv, garch, filters).
+
+### 1.C — portfolio : optimiseurs · `[fix/portfolio-optimizers]`
+- [ ] **CRITICAL** `ERC` reste bloqué sur 1/N : objectif quartique (~1e-8) < `ftol=1e-6` SLSQP → renvoie le guess initial (contributions au risque non égalisées). API publique stable.
+- [ ] **HIGH** `MVP_uc` : même fragilité d'échelle (échoue sur variances faibles) — rescaler l'objectif / `ftol`.
+- [ ] **HIGH** entrée mono-actif (N=1) : `np.cov` scalaire → crash IVP/MVP/ERC/HRP. Garder N==1.
+- [ ] **HIGH (tests)** tests ERC/MVP_uc tautologiques (variances égales = 1/N) → cas variances inégales + assert contributions au risque / forme fermée MVP.
+- [ ] **MEDIUM** `IVP(normalize=True)` double-traite et distord la pondération `1/σ²` ; `_normalize` mute son entrée (copier).
+- [ ] **MEDIUM (docs)** `sizing.vol_target` : double-backslash dans la r-string (math non rendue) ; docstrings "Initial weights to maximize" (copier-coller).
+- [ ] **MEDIUM (tests)** HRP/MDP : seulement shape/sum → assert comportemental.
+
+### 1.D — metrics / econométrie · `[fix/metrics-econometrics]`
+- [ ] **HIGH** `calmar`/`roll_calmar` renvoient `0.0` sur MDD nulle (courbe profitable sans drawdown) alors que `sharpe`/`sortino` renvoient `inf` — convention dénominateur-nul incohérente.
+- [ ] **HIGH** `estimator.loglikelihood` mute `h` en place (`h[h==0]=1e-8`) + nom/doc trompeurs (c'est la LL **négative**).
+- [ ] **MEDIUM** `econometric_models.ARMA`/`ARMA_GARCH`/`ARMAX_GARCH` crashent sur entrée `list` (MA l'accepte) — `np.asarray`.
+- [ ] **MEDIUM** `diversified_ratio` renvoie un array `(1,1)` mais typé `float`.
+- [ ] **MEDIUM (docs)** `ARMAX_GARCH` : param `omega` manquant + somme sur régresseurs `Σ_k ψ_k x_{t,k}`.
+- [ ] **MEDIUM (tests)** `test_get_parameters` ordres tautologiques (p=q=P=Q=1) ; chemin calmar MDD-nulle non testé.
+- [ ] **LOW** `summary` mélange vol `log=True` et sharpe `log=False` ; `target_function` sans docstring ; TeX rendement annualisé + typos.
+
+### 1.E — models : training & losses · `[fix/models-training-loss]`
+- [ ] **HIGH** `rolling` (`roll_period > train_period`) : slices à index négatif → wrap sur la queue du tableau = **fuite de futur** dans train/eval. Clamp/garde.
+- [ ] **HIGH (docs)** `rolling.run` : `eval_set = slice(t-r,t)` = queue **in-sample** du train, pas OOS — relibeller / corriger.
+- [ ] **HIGH** `loss/calmar` : `eps=1e-8` mal dimensionné vs dénominateur (drawdowns O(rendements)) → ratio explose (-3.78e7) et domine le gradient.
+- [ ] **MEDIUM** `loss/omega` (et `sortino` plus doux) : même explosion d'échelle eps.
+- [ ] **MEDIUM** `rolling._training` : perte train normalisée par `n` et non par nb de batches (insensée selon batch) ; `_display_kpi` lit `loss_eval[-1]` au lieu de `[self.i]`.
+- [ ] **MEDIUM** `rolling.run` : fork d'un `multiprocessing.Process` partageant une figure matplotlib (non fork-safe) — rendre en process.
+- [ ] **MEDIUM (docs)** `objective.predict` : borne `[-1,1]` vraie seulement pour `position_fn=tanh` par défaut.
+- [ ] **LOW** `loss/_base._rf_per_period` mis en cache (muter `rf` = no-op) ; `loss/__init__` omet Calmar/Omega/Hybrid.
+- [ ] **LOW (tests)** convention de signe Sortino ; finitude edge calmar/omega/sortino ; reproductibilité refit `ObjectiveModel` ; aucun test du chemin `run()`/`__next__`/`_training` walk-forward.
+
+### 1.F — models : contrat NN · `[fix/models-nn-contract]`
+- [ ] **CRITICAL / design** `RNN`/`GRU`/`LSTM` ne récurrent **pas** dans le temps (axe T = batch de `nn.Linear`, aucun état threadé) → implémenter une vraie récurrence séquentielle **ou** redocumenter honnêtement comme couches gated stateless + retirer le contrat `(T,S,N)` impossible.
+- [ ] **HIGH** `_base.set_data` ignore `dtype`/`x_type`/`y_type` (float32 demandé → float64) ; float64-input + params float32 crashe.
+- [ ] **HIGH** `_base.predict` n'appelle pas `eval()` / `train_on` pas `train()` → dropout fuit en inférence.
+- [ ] **MEDIUM** arg `bias` no-op sur RNN/GRU/LSTM ; `predict` récurrent ne respecte pas `predict(X)` du protocole ; `forward_activation=Softmax` par défaut sur cibles de régression.
+- [ ] **MEDIUM (tests)** aucun test de causalité RNN/GRU/LSTM ; masquage attention non testé directement.
+- [ ] **LOW** `set_seed` bornes + reseed numpy global ; aliasing `from_numpy` ; device `predict` ; typos (`load_model` "Save", type `criterion`) ; pas de doctest mlp/_base/rnn ; asserts loss `>=0` tautologiques + pas de sanity overfit-tiny-batch.
+
+### 1.G — data / core / signal / backtest · `[fix/data-core-signal-backtest]`
+- [ ] **HIGH** `signal.rank` : `top+bottom>n_assets` écrase les jambes → non dollar-neutral ; pas de garde négatifs.
+- [ ] **HIGH** `data.align.resample` ne marche que sur index `datetime64` (object/int lèvent) + **zéro test**.
+- [ ] **MEDIUM** `data.split.walk_forward` : train vide silencieux si `purge>=train` (garde) ; `train_test_split` borne exclusive surprenante (1.0 → 1).
+- [ ] **MEDIUM** `core.price_series.to_returns("log"/"pct")` : inf/nan sur prix ≤0 (garde).
+- [ ] **MEDIUM** `backtest.engine` (`returns_input=False`) : 1er turnover de position non facturé.
+- [ ] **MEDIUM (docs)** `backtest.print_stats` : `underly` traité comme log-returns mais doc dit "prices".
+- [ ] **MEDIUM (tests)** `resample`, méthodes `core` (`to_prices`/`apply`/`cumulative`), `_exceptions.ArraySizeError`, branche `value_col` de `frame_to_series`, `strategy.run(X=)` non testés.
+- [ ] **LOW** `strategy.run_walk_forward` zéro-te le 1er rendement de chaque bloc test ; doc index `to_prices` ; doc `backtest.loss`/`result` ; doc état initial des mappers.
+
+### 1.H — research : guards & robustesse · `[fix/research]`
+- [ ] **HIGH** `ledger.deflated_sharpe` injecte le Sharpe **annualisé** dans `deflated_sharpe_ratio` (qui attend un SR par-période ×√(n-1)) → DSR sature (~0/~1) = confiance fausse. Dé-annualiser.
+- [ ] **HIGH** `Ledger` "append-only" mais nom dupliqué **écrase** → `n_trials` sous-compte → corrompt le compte multiple-testing du DSR.
+- [ ] **HIGH** `runner.run_experiment` mute `strategy.cost` de l'appelant (jamais restauré) — restaurer en `finally`.
+- [ ] **MEDIUM** `leaderboard` trie mal une clé NaN (flotte en tête) ; `Experiment.from_dict` lève sur clé inconnue (pas forward-compatible) ; `load()` laisse échapper `JSONDecodeError`.
+- [ ] **MEDIUM** `_seed_everything` utilise `np.random.seed` global (biaise la variance nulle de `permutation_test` pour modèles stochastiques).
+- [ ] **MEDIUM (tests)** guards sans assert sur valeur publiée (PSR/DSR Bailey & LdP) ; pas de test corrupt-input / schema-evolution / nom dupliqué.
+- [ ] **LOW** `synthetic.regime_switching` démarre toujours en régime 0 ; `_callable_name` renvoie `<lambda>` ; doc `sr_variance=1.0` placeholder + précondition prix>0.
+
+### 1.I — docs : CONTRIBUTING / status / README / Sphinx · `[docs/audit-doc-drift]`
+- [ ] **CRITICAL** `CONTRIBUTING.md` : encore `python setup.py build_ext`, "recompile .pyx", `fynance.algorithms`, cadre de déprécation "1.x → 2.0". Tout est pré-2.1 — réécrire pour 2.9 (pure-Python/Numba, `pip install -e ".[dev]"`).
+- [ ] **HIGH** `doc/dev/06-status.md` (v2.8.0, comptes 518/593, ATR/ADX/regime/adaptive/market-impact en "Deferred"), `01-overview.md` (v2.8.0 + 518), `05-testing.md` (518) — rafraîchir (v2.9.0 ; ~569 unit + doctests = 658).
+- [ ] **MEDIUM** `README.md` : liste de features omet le headline v2.9 (indicateurs OHLCV, feature GARCH causale, fenêtres adaptatives, `RegimeMoE`, `MarketImpactCost`).
+- [ ] **MEDIUM/LOW** Sphinx : `iso_vol` (dans `features.__all__`) et l'API registry data (`BaseDataSource`/`register`/`get_source`) non documentés ; `METRICS` dict ; doc/dev/README "NumPy over polars".
 
 ## 3. Chore — CI / hygiène
 

--- a/doc/dev/README.md
+++ b/doc/dev/README.md
@@ -20,8 +20,8 @@ live in the repo-root `CLAUDE.md`.
    Numba kernels (golden-value parity), the rolling/walk-forward pattern, the
    estimator→models pipeline.
 3. [`03-decisions.md`](03-decisions.md) — the design choices and *why* (Numba over
-   new Cython, PyTorch over Keras, the loss-function split, NumPy over polars),
-   plus the running ADR journal.
+   new Cython, PyTorch over Keras, the loss-function split, polars at the edges
+   with NumPy at the core), plus the running ADR journal.
 4. [`04-subpackages.md`](04-subpackages.md) — the per-subpackage map, public API
    surface, and the stability/modernisation policy that governs each.
 5. [`05-testing.md`](05-testing.md) — the testing layers (pytest + doctests +

--- a/doc/source/data.rst
+++ b/doc/source/data.rst
@@ -17,3 +17,16 @@ alignment/resampling, and no-lookahead temporal splits.
    resample
    train_test_split
    walk_forward
+
+Custom sources
+==============
+
+The registry extension API: subclass :class:`BaseDataSource`, `register` it under
+a file extension, and :func:`load` (or :func:`get_source`) will dispatch to it.
+
+.. autosummary::
+   :toctree: generated/
+
+   BaseDataSource
+   register
+   get_source

--- a/doc/source/features.stats.rst
+++ b/doc/source/features.stats.rst
@@ -19,3 +19,17 @@ z-score, and mean absolute deviation.
    roll_z_score
    mad
    roll_mad
+
+Money management
+================
+
+Volatility-targeted position sizing as a **causal** feature: the
+:func:`~fynance.features.money_management.iso_vol` leverage scales an exposure so
+its realized volatility tracks a target, using only the past.
+
+.. currentmodule:: fynance.features.money_management
+
+.. autosummary::
+   :toctree: generated/
+
+   iso_vol

--- a/doc/source/metrics.rst
+++ b/doc/source/metrics.rst
@@ -54,3 +54,10 @@ Aggregated report
    :toctree: generated/
 
    summary
+
+:func:`summary` is driven by the ``METRICS`` registry — a name → callable
+mapping (``annual_return``, ``annual_volatility``, ``sharpe``, ``sortino``,
+``calmar``, ``max_drawdown``) you can read or extend.
+
+.. autodata:: METRICS
+   :no-value:

--- a/fynance/_wrappers.py
+++ b/fynance/_wrappers.py
@@ -61,13 +61,13 @@ def wrap_axis(func):
                 stacklevel=2,
             )
 
-        if shape[axis] < min_size:
+        if X.ndim <= axis:
+
+            raise np.exceptions.AxisError(axis, X.ndim)
+
+        elif shape[axis] < min_size:
 
             raise ArraySizeError(shape[axis], axis=axis, min_size=min_size)
-
-        elif X.ndim <= axis:
-
-            raise np.AxisError(axis, len(X.shape))
 
         elif axis == 1 and X.ndim == 2:
 
@@ -105,8 +105,13 @@ def wrap_window(func):
     """ Check if the lagged window `w` is available for `X` array. """
     @wraps(func)
     def check_window(X, w=None, **kwargs):
+        # The window must be validated against the time axis. `wrap_window`
+        # runs before `wrap_axis` transposes the array, so the time axis is
+        # still `axis` (default 0) of the input array here.
+        axis = kwargs.get('axis', 0)
+        size = X.shape[axis] if axis < X.ndim else X.shape[0]
         if w == 0 or w is None:
-            w = X.shape[0]
+            w = size
 
         elif 'min_size' in kwargs.keys() and w < kwargs['min_size']:
 
@@ -118,14 +123,14 @@ def wrap_window(func):
             raise ValueError('lagged window of size {} is not available, \
                 must be positive.'.format(w))
 
-        elif w > X.shape[0]:
+        elif w > size:
             warn(
                 'lagged window of size {} is out of bounds with time axis '
-                'of size {}'.format(w, X.shape[0]),
+                'of size {}'.format(w, size),
                 category=UserWarning,
                 stacklevel=2,
             )
-            w = X.shape[0]
+            w = size
 
         return func(X, w=int(w), **kwargs)
 

--- a/fynance/backtest/engine.py
+++ b/fynance/backtest/engine.py
@@ -61,6 +61,13 @@ def backtest(
     arr = np.asarray(data, dtype=np.float64)
     pos = np.asarray(positions, dtype=np.float64)
 
+    # ``cost_book`` is the full position book the cost model sees: it must
+    # retain the initial trade so turnover is charged from the first entry. On
+    # a prices input the trailing position earns no return and is dropped, but
+    # its turnover is never incurred either, so we drop it from the cost book
+    # too (charging only trades into positions that actually earn a return).
+    cost_book = pos
+
     if returns_input:
         returns = arr
 
@@ -68,7 +75,11 @@ def backtest(
         returns = arr[1:] / arr[:-1] - 1.0
 
         if pos.shape[0] == arr.shape[0]:
+            # Drop the first position (it predates the first return): the
+            # decision at price index k earns the return over [k, k+1].
             pos = pos[1:]
+            # The last decision earns no return; charge turnover up to it only.
+            cost_book = cost_book[:-1]
 
     if pos.shape[0] != returns.shape[0]:
 
@@ -91,7 +102,7 @@ def backtest(
         gross = gross.sum(axis=1)
 
     costs = (
-        np.asarray(cost(pos), dtype=np.float64)
+        np.asarray(cost(cost_book), dtype=np.float64)
         if cost is not None
         else np.zeros(returns.shape[0], dtype=np.float64)
     )

--- a/fynance/backtest/loss.py
+++ b/fynance/backtest/loss.py
@@ -30,8 +30,10 @@ class LossSeries:
 
     Methods
     -------
+    append
+    reset
     set_plot
-    plot
+    update_plot
 
     """
 

--- a/fynance/backtest/print_stats.py
+++ b/fynance/backtest/print_stats.py
@@ -42,7 +42,10 @@ def set_text_stats(
     Parameters
     ----------
     underly : np.ndarray[ndim=1, dtype=np.float64]
-        Series of underlying prices.
+        Series of underlying **log-returns** (not prices). The price path is
+        reconstructed internally as ``np.exp(np.cumsum(underly))``, and each
+        strategy's simple return is recovered as ``np.exp(underly) - 1`` before
+        applying the position and fees.
     period : int, optional
         Number of period per day, default is 252.
     accur : bool, optional

--- a/fynance/backtest/result.py
+++ b/fynance/backtest/result.py
@@ -42,6 +42,12 @@ class BacktestResult:
     index : numpy.ndarray, optional
         Temporal index carried from the input.
 
+    Methods
+    -------
+    to_numpy
+    to_price_series
+    summary
+
     """
 
     equity: NDArray

--- a/fynance/core/price_series.py
+++ b/fynance/core/price_series.py
@@ -268,6 +268,16 @@ class PriceSeries:
             The return series (strictly causal: ``r_t`` uses only ``p_t`` and
             ``p_{t-1}``).
 
+        Raises
+        ------
+        ValueError
+            For ``kind="pct"`` or ``"log"`` when any price is non-positive
+            (``<= 0``). Both conventions divide by the previous price (and
+            ``log`` takes its logarithm), so a zero or negative price would
+            otherwise yield silent ``inf``/``nan`` with only a bare
+            ``RuntimeWarning``. Use ``kind="raw"`` for series that legitimately
+            cross or touch zero.
+
         Examples
         --------
         >>> PriceSeries([100., 110., 99.]).to_returns("pct").values
@@ -277,9 +287,25 @@ class PriceSeries:
         p = self.values
 
         if kind == "pct":
+            if np.any(p <= 0.0):
+
+                raise ValueError(
+                    "to_returns(kind='pct') requires strictly positive prices; "
+                    "a zero or negative price yields inf/nan. Use kind='raw' "
+                    "for series that touch or cross zero."
+                )
+
             r = p[1:] / p[:-1] - 1.0
 
         elif kind == "log":
+            if np.any(p <= 0.0):
+
+                raise ValueError(
+                    "to_returns(kind='log') requires strictly positive prices; "
+                    "log of a non-positive ratio is undefined. Use kind='raw' "
+                    "for series that touch or cross zero."
+                )
+
             r = np.log(p[1:] / p[:-1])
 
         elif kind == "raw":
@@ -313,7 +339,11 @@ class PriceSeries:
         Returns
         -------
         PriceSeries
-            Price path of length ``len(self) + 1``.
+            Price path of length ``len(self) + 1``. The index is **reset** to
+            the default ``0..n`` range: the reconstructed path has one extra
+            leading point (the ``base`` price) with no corresponding timestamp
+            in the original return index, so a meaningful index cannot be
+            carried through. Re-attach an index explicitly if needed.
 
         """
         r = self.values
@@ -425,5 +455,13 @@ class PriceSeries:
         return out
 
     def apply(self, func: Callable[[float], float]) -> PriceSeries:
-        """ Apply an element-wise function to the values. """
+        """ Apply an element-wise function to the values.
+
+        On an empty series this short-circuits to an empty result (``np.vectorize``
+        cannot infer an output dtype from zero inputs).
+        """
+        if self.values.size == 0:
+
+            return self._new(self.values.copy())
+
         return self._new(np.vectorize(func)(self.values))

--- a/fynance/data/align.py
+++ b/fynance/data/align.py
@@ -90,19 +90,45 @@ def resample(
 ) -> PriceSeries | dict[str, PriceSeries]:
     """ Downsample a series to a coarser frequency.
 
+    The series index must be a NumPy ``datetime64`` array; polars'
+    ``group_by_dynamic`` resampling is defined only over a temporal axis. An
+    integer or object-dtype (e.g. ``datetime.datetime``) index is rejected with
+    an explanatory :class:`ValueError` rather than surfacing an opaque polars
+    error.
+
     Parameters
     ----------
     ps : PriceSeries
-        Series with a datetime index.
+        Series with a ``datetime64`` index.
     freq : str
         Target polars frequency (e.g. ``"1w"``, ``"1mo"``).
     agg : {"last", "mean", "ohlc"}
         Aggregation. ``ohlc`` returns a mapping with open/high/low/close.
 
+    Returns
+    -------
+    PriceSeries or dict of str to PriceSeries
+        The resampled series (or an open/high/low/close mapping for ``ohlc``).
+
+    Raises
+    ------
+    ValueError
+        If the index is not a ``datetime64`` array, or if ``agg`` is unknown.
+
     """
     import polars as pl
 
-    df = pl.DataFrame({"_t": ps.index, "_v": ps.values}).sort("_t")
+    index = np.asarray(ps.index)
+
+    if index.dtype.kind != "M":
+
+        raise ValueError(
+            "resample requires a datetime64 index, got an index of dtype "
+            f"{index.dtype!r}; convert the index to numpy datetime64 first "
+            "(integer and object/datetime.datetime indexes are not supported)"
+        )
+
+    df = pl.DataFrame({"_t": index, "_v": ps.values}).sort("_t")
     gb = df.group_by_dynamic("_t", every=freq)
 
     if agg == "last":

--- a/fynance/data/split.py
+++ b/fynance/data/split.py
@@ -34,7 +34,13 @@ def train_test_split(
     n : int
         Number of observations.
     test_size : float or int
-        Fraction (``0 < x < 1``) or absolute count of the trailing test set.
+        Trailing test set size. A value strictly inside ``(0, 1)`` is read as a
+        **fraction** of ``n`` (e.g. ``0.2`` -> ``round(0.2 * n)``); any other
+        value -- including the bounds ``0.0`` and ``1.0`` -- is read as an
+        **absolute count** (``int(test_size)``). In particular ``1.0`` means a
+        single observation (count ``1``), not the whole series, and ``0.0``
+        means an empty test set; pass a fraction strictly between the bounds to
+        get a proportional split.
     gap : int
         Embargo: observations dropped between train end and test start.
 
@@ -84,7 +90,25 @@ def walk_forward(
     (train_idx, test_idx) : tuple of numpy.ndarray
         Index arrays with ``test_idx`` strictly after ``train_idx``.
 
+    Raises
+    ------
+    ValueError
+        If ``train <= 0`` or ``purge >= train``: either would yield empty train
+        windows (``[t-train : t-purge]`` becomes empty), which silently breaks a
+        downstream ``fit`` with an opaque error instead of failing here.
+
     """
+    if train <= 0:
+
+        raise ValueError(f"train must be > 0, got {train}")
+
+    if purge >= train:
+
+        raise ValueError(
+            f"purge must be < train, got purge={purge}, train={train} "
+            "(otherwise every train window is empty)"
+        )
+
     if step is None:
         step = test
 

--- a/fynance/estimator/estimator.py
+++ b/fynance/estimator/estimator.py
@@ -50,7 +50,48 @@ def estimation(y, x0, p=0, q=0, Q=0, P=0, cons=True, model='arch'):
 
 
 def target_function(params, y, p=0, q=0, Q=0, P=0, cons=True, model='arch'):
-    """ Target function """
+    """ Objective (cost) to minimise when fitting an ARMA/GARCH model.
+
+    Splits the flat ``params`` vector with :func:`get_parameters`, runs the
+    selected model recursion over ``y`` to obtain the residuals ``u`` (and the
+    conditional volatility ``h`` for GARCH models), then returns the negative
+    Gaussian log-likelihood (see :func:`loglikelihood`). Smaller is better, so
+    the value can be handed straight to a minimiser.
+
+    Parameters
+    ----------
+    params : np.ndarray[np.float64, ndim=1]
+        Flat parameter vector laid out as expected by :func:`get_parameters`
+        for the given ``p, q, Q, P, cons`` configuration.
+    y : np.ndarray[np.float64, ndim=1]
+        Time series to fit.
+    p, q : int, optional
+        Orders of the AR and MA parts of the ARMA mean equation. Default is 0.
+    Q, P : int, optional
+        Orders of the ARCH and GARCH parts of the conditional variance.
+        Default is 0.
+    cons : bool, optional
+        Whether ``params`` includes a leading constant term. Default is True.
+    model : {'arch', 'garch', 'arma'}, optional
+        Model family driving the residual recursion. ``'arch'`` and
+        ``'garch'`` both use the ARMA-GARCH recursion; ``'arma'`` uses the ARMA
+        recursion with unit conditional volatility. Default is ``'arch'``.
+
+    Returns
+    -------
+    np.float64
+        Negative Gaussian log-likelihood of the residuals (cost to minimise).
+
+    Raises
+    ------
+    ValueError
+        If ``model`` is not one of ``'arch'``, ``'garch'`` or ``'arma'``.
+
+    See Also
+    --------
+    loglikelihood, get_parameters
+
+    """
     phi, theta, alpha, beta, c, omega = get_parameters(
         params, p, q, Q, P, cons
     )
@@ -86,23 +127,38 @@ def _loglikelihood(u, h):
 
 
 def loglikelihood(u, h):
-    """ Normal log-likelihood function.
+    r""" Negative Gaussian log-likelihood (a cost to minimise).
+
+    Despite its name, this function returns the *negative* of the Normal
+    log-likelihood of the residuals, i.e. a cost suitable for direct
+    minimisation by an optimiser (smaller is better). The likelihood itself is
+    the opposite of the returned value.
+
+    .. math::
+
+        -\ln \mathcal{L} = \frac{1}{2}\left(T \ln(2\pi)
+        + \sum_t \ln(h_t^2) + \sum_t \left(\frac{u_t}{h_t}\right)^2\right)
+
+    The input ``h`` is left unchanged: a working copy is used and its zero
+    entries are floored to ``1e-8`` to avoid division by zero.
 
     Parameters
     ----------
     u : np.ndarray[dtype=np.float64, ndim=1]
         Standardized residuals series.
     h : np.ndarray[dtype=np.float64, ndim=1]
-        Conditional standard deviation series of residuals.
+        Conditional standard deviation series of residuals. Not modified in
+        place.
 
     Returns
     -------
     np.float64
-        Normal log likelihood of residuals.
+        Negative Gaussian log-likelihood of the residuals (cost to minimise).
 
     """
     l_sq_pi = np.log(2 * np.pi)
     T = h.size
+    h = np.array(h, dtype=np.float64, copy=True)
     h[h == 0] = 1e-8
     L = T * l_sq_pi + np.sum(np.log(np.square(h))) + np.sum(np.square(u / h))
 

--- a/fynance/features/garch.py
+++ b/fynance/features/garch.py
@@ -125,6 +125,11 @@ def garch_volatility(
         Conditional volatility :math:`\sigma_t`, same length as ``returns``,
         ``NaN`` on the warmup.
 
+    Raises
+    ------
+    ValueError
+        If ``min_train`` is not in ``[2, len(returns))``.
+
     Examples
     --------
     >>> import numpy as np

--- a/fynance/features/indicators.py
+++ b/fynance/features/indicators.py
@@ -28,8 +28,6 @@ Main entry points
 from __future__ import annotations
 
 # Built-in packages
-from warnings import warn
-
 # External packages
 import numpy as np
 from numpy.typing import NDArray
@@ -118,11 +116,8 @@ def bollinger_band(
 
     Examples
     --------
-    >>> import warnings
     >>> X = np.array([60, 100, 80, 120, 160, 80]).astype(np.float64)
-    >>> with warnings.catch_warnings():
-    ...     warnings.simplefilter("ignore", DeprecationWarning)
-    ...     upper_band, lower_band = bollinger_band(X, w=3, n=2)
+    >>> upper_band, lower_band = bollinger_band(X, w=3, n=2)
     >>> upper_band
     array([ 60.        , 120.        , 112.65986324, 132.65986324,
            185.31972647, 185.31972647])
@@ -143,14 +138,6 @@ def bollinger_band(
 
     if kind == 'e':
         w = 1 - 2 / (1 + w)  # type: ignore[assignment]
-
-    warn(
-        'Since version 1.1.0, bollinger_band returns upper and lower bands. '
-        'The single-array return path is deprecated and will be removed in '
-        'fynance 2.0.',
-        category=DeprecationWarning,
-        stacklevel=2,
-    )
 
     if axis == 1:
         avg = _handler_ma[kind.lower()](X.T, w).T

--- a/fynance/features/momentums.py
+++ b/fynance/features/momentums.py
@@ -296,7 +296,10 @@ def wma(X: NDArray, w: int | None = None, axis: int = 0, dtype=None) -> NDArray:
 
     .. math::
 
-        wma^w_t(X) = \frac{2}{w (w-1)} \sum^{w-1}_{i=0} (w-i) \times X_{t-i}
+        wma^w_t(X) = \frac{2}{w (w+1)} \sum^{w-1}_{i=0} (w-i) \times X_{t-i}
+
+    The weights :math:`(w - i)` decrease linearly with the lag and sum to
+    :math:`w (w + 1) / 2`, which is the normalizer applied above.
 
     Parameters
     ----------
@@ -498,9 +501,12 @@ def wmstd(X: NDArray, w: int | None = None, axis: int = 0, dtype=None) -> NDArra
 
     .. math::
 
-        wma^w_t(X) = \frac{2}{w (w-1)} \sum^{w-1}_{i=0} (w-i) \times X_{t-i} \\
-        wmstd^w_t(X) = \sqrt{\frac{2}{w(w-1)} \sum^{w-1}_{i=0}
+        wma^w_t(X) = \frac{2}{w (w+1)} \sum^{w-1}_{i=0} (w-i) \times X_{t-i} \\
+        wmstd^w_t(X) = \sqrt{\frac{2}{w(w+1)} \sum^{w-1}_{i=0}
         (w-i) \times (X_{t-i} - wma^w_t(X))^2}
+
+    As for :func:`wma`, the linearly decreasing weights :math:`(w - i)` sum
+    to :math:`w (w + 1) / 2`.
 
     Parameters
     ----------
@@ -552,8 +558,12 @@ def emstd(X: NDArray, alpha: float = 0.94, w: int | None = None, axis: int = 0, 
 
     .. math::
 
-        emstd^{\alpha}_t(X) = \sqrt{\alpha\times emstd^{\alpha}_{t-1}^2 +
-        (1-\alpha) \times X_t^2}
+        emstd^{\alpha}_t(X) = \sqrt{\alpha \times {emstd^{\alpha}_{t-1}}^2 +
+        (1-\alpha) \times (X_t - ema^{\alpha}_t(X))^2}
+
+    Where :math:`ema^{\alpha}_t(X)` is the exponential moving average (see
+    :func:`ema`); the squared deviation is taken around it rather than around
+    zero.
 
     Parameters
     ----------

--- a/fynance/features/money_management.py
+++ b/fynance/features/money_management.py
@@ -48,18 +48,19 @@ def iso_vol(series, target_vol=0.20, leverage=1., period=252, half_life=11):
     --------
     >>> series = np.array([95, 100, 85, 105, 110, 90]).astype(np.float64)
     >>> iso_vol(series, target_vol=0.5, leverage=2, period=12, half_life=3)
-    array([1.        , 1.        , 2.        , 1.11289534, 0.88580571,
-           1.20664917])
+    array([1.        , 1.        , 2.        , 1.28407693, 0.78278978,
+           1.07186485])
 
     """
     # Set iso-vol vector
     iv = np.ones([series.size])
-    # Compute squared daily return vector
-    ret2 = np.square(series[:-1] / series[1:] - 1)
+    # Compute squared daily return vector (standard return s_t / s_{t-1} - 1)
+    ret2 = np.square(series[1:] / series[:-1] - 1)
     # Compute volatility vector
     vol = np.sqrt(period * ema(ret2, w=half_life))
     vol[vol <= 0.] = 1e-8
-    # Compute iso-vol coefficient
+    # Compute iso-vol coefficient (iv[t] uses only vol[t - 2], i.e. data up to
+    # series[t - 1] -- strictly causal w.r.t. the signal applied at t)
     iv[2:] = target_vol / vol[:-1]
     # Cap with the max leverage available
     iv[iv > leverage] = leverage

--- a/fynance/features/ohlcv.py
+++ b/fynance/features/ohlcv.py
@@ -44,6 +44,24 @@ def _unpack_hlc(high, low, close):
     return _as1d(high), _as1d(low), _as1d(close)
 
 
+def _check_window(w: int) -> int:
+    """ Validate a smoothing/look-back window and return it as an ``int``.
+
+    Raises
+    ------
+    ValueError
+        If ``w < 1`` (a window of ``0`` would divide by zero in the Wilder
+        recursion and a negative window is meaningless).
+    """
+    w = int(w)
+
+    if w < 1:
+
+        raise ValueError(f"w must be >= 1, got {w}")
+
+    return w
+
+
 # =========================================================================== #
 #                              Numba kernels                                  #
 # =========================================================================== #
@@ -202,6 +220,12 @@ def atr(high, low=None, close=None, w: int = 14) -> NDArray[np.float64]:
     numpy.ndarray
         ATR series, ``>= 0``, aligned with the input.
 
+    Raises
+    ------
+    ValueError
+        If ``w < 1``, or if ``low`` / ``close`` are missing without an
+        ``OHLCV`` first argument.
+
     Examples
     --------
     >>> import numpy as np
@@ -212,9 +236,10 @@ def atr(high, low=None, close=None, w: int = 14) -> NDArray[np.float64]:
     array([1.    , 1.25  , 1.375 , 1.1875])
 
     """
+    w = _check_window(w)
     high, low, close = _unpack_hlc(high, low, close)
 
-    return _atr_kernel(high, low, close, int(w))
+    return _atr_kernel(high, low, close, w)
 
 
 def adx(high, low=None, close=None, w: int = 14) -> NDArray[np.float64]:
@@ -235,6 +260,12 @@ def adx(high, low=None, close=None, w: int = 14) -> NDArray[np.float64]:
     numpy.ndarray
         ADX series in ``[0, 100]``, aligned with the input.
 
+    Raises
+    ------
+    ValueError
+        If ``w < 1``, or if ``low`` / ``close`` are missing without an
+        ``OHLCV`` first argument.
+
     Examples
     --------
     >>> import numpy as np
@@ -248,16 +279,17 @@ def adx(high, low=None, close=None, w: int = 14) -> NDArray[np.float64]:
     True
 
     """
+    w = _check_window(w)
     high, low, close = _unpack_hlc(high, low, close)
 
-    return _adx_kernel(high, low, close, int(w))
+    return _adx_kernel(high, low, close, w)
 
 
 def williams_r(high, low=None, close=None, w: int = 14) -> NDArray[np.float64]:
     r""" Williams %R over a trailing window, causal.
 
     :math:`\%R_t = -100 \cdot (HH_t - C_t) / (HH_t - LL_t)`, where ``HH``/``LL``
-    are the rolling high/low of window ``w``. Bounded in ``[-100, 0]``.
+    are the rolling high/low of window ``w``.
 
     Parameters
     ----------
@@ -269,7 +301,23 @@ def williams_r(high, low=None, close=None, w: int = 14) -> NDArray[np.float64]:
     Returns
     -------
     numpy.ndarray
-        Williams %R in ``[-100, 0]``, aligned with the input.
+        Williams %R, aligned with the input.
+
+    Raises
+    ------
+    ValueError
+        If ``w < 1``, or if ``low`` / ``close`` are missing without an
+        ``OHLCV`` first argument.
+
+    Notes
+    -----
+    %R is bounded in ``[-100, 0]`` **only when the bars are valid OHLC**, i.e.
+    each close lies within its window's high/low range
+    (:math:`LL_t \le C_t \le HH_t`). The raw values are returned unclamped, so a
+    close outside ``[LL_t, HH_t]`` — e.g. corrupt or mismatched series — yields
+    values outside ``[-100, 0]`` (a close above the rolling high gives ``%R > 0``,
+    below the rolling low gives ``%R < -100``). This is intentional: clamping
+    would silently mask such data issues.
 
     Examples
     --------
@@ -281,9 +329,10 @@ def williams_r(high, low=None, close=None, w: int = 14) -> NDArray[np.float64]:
     array([-50.  , -25.  , -16.67, -75.  ])
 
     """
+    w = _check_window(w)
     high, low, close = _unpack_hlc(high, low, close)
 
-    return _williams_kernel(high, low, close, int(w))
+    return _williams_kernel(high, low, close, w)
 
 
 def obv(close, volume=None) -> NDArray[np.float64]:

--- a/fynance/features/regime.py
+++ b/fynance/features/regime.py
@@ -11,6 +11,9 @@ embedding) — see the notes on causality.
 
 from __future__ import annotations
 
+# Built-in packages
+import warnings
+
 # Third-party packages
 import numpy as np
 from numpy.typing import NDArray
@@ -20,6 +23,27 @@ from scipy.cluster.vq import kmeans2
 from fynance.features.indicators import realized_volatility
 
 __all__ = ['detect_regimes', 'regime_features', 'RegimeDetector']
+
+
+def _vol_order(vol: NDArray, labels: NDArray, n_regimes: int) -> NDArray:
+    """ Order cluster labels by increasing mean volatility, empty-safe.
+
+    An empty cluster has a ``nan`` mean; treat it as ``+inf`` so it sorts last
+    instead of corrupting the ordering (``argsort`` places ``nan`` last but its
+    relative order is undefined). Empty clusters are unreachable through the
+    ``kmeans2(..., missing='raise')`` path, but this keeps the ordering robust
+    if that guard is ever relaxed.
+    """
+    with np.errstate(invalid='ignore'), warnings.catch_warnings():
+        # An empty cluster triggers a "Mean of empty slice" warning; expected.
+        warnings.simplefilter('ignore', category=RuntimeWarning)
+        means = np.array(
+            [vol[labels == k].mean() for k in range(n_regimes)]
+        )
+
+    means[np.isnan(means)] = np.inf
+
+    return np.argsort(means)
 
 
 def regime_features(X: NDArray, w: int = 21, period: int = 252) -> NDArray:
@@ -41,6 +65,14 @@ def regime_features(X: NDArray, w: int = 21, period: int = 252) -> NDArray:
     -------
     np.ndarray
         Shape ``(len(X), 2)`` — ``[realized_volatility, rolling_mean_log_return]``.
+
+    Notes
+    -----
+    Row ``0`` is a deterministic warmup point: there is no prior observation, so
+    both the realized volatility and the mean log-return are ``0`` (an
+    artificially "ultra-calm" point). It is kept so the matrix stays aligned with
+    ``X``; callers fitting a clustering on the matrix may wish to drop or mask
+    this row.
 
     """
     X = np.asarray(X, dtype=np.float64).reshape(-1)
@@ -108,7 +140,7 @@ class RegimeDetector:
 
         # Order clusters by mean (unstandardized) volatility for stable labels.
         vol = feats[:, 0]
-        order = np.argsort([vol[labels == k].mean() for k in range(self.n_regimes)])
+        order = _vol_order(vol, labels, self.n_regimes)
         remap = np.empty(self.n_regimes, dtype=int)
         remap[order] = np.arange(self.n_regimes)
         self._remap = remap
@@ -175,7 +207,7 @@ def detect_regimes(
     _, labels = kmeans2(z, n_regimes, seed=seed, minit='++', missing='raise')
 
     # Re-order labels by increasing mean volatility for stable interpretation.
-    order = np.argsort([vol[labels == k].mean() for k in range(n_regimes)])
+    order = _vol_order(vol, labels, n_regimes)
     remap = np.empty(n_regimes, dtype=int)
     remap[order] = np.arange(n_regimes)
 

--- a/fynance/features/roll_functions.py
+++ b/fynance/features/roll_functions.py
@@ -112,7 +112,7 @@ def roll_min(X: NDArray, w: int | None = None, axis: int = 0, dtype=None) -> NDA
 
     .. math::
 
-        roll\_min^w_t(X) = min(X_{t - w}, ..., X_t)
+        roll\_min^w_t(X) = min(X_{t - w + 1}, ..., X_t)
 
     Parameters
     ----------
@@ -177,7 +177,7 @@ def roll_max(X: NDArray, w: int | None = None, axis: int = 0, dtype=None) -> NDA
 
     .. math::
 
-        roll\_max^w_t(X) = max(X_{t - w}, ..., X_t)
+        roll\_max^w_t(X) = max(X_{t - w + 1}, ..., X_t)
 
     Parameters
     ----------
@@ -222,7 +222,7 @@ def roll_max(X: NDArray, w: int | None = None, axis: int = 0, dtype=None) -> NDA
 
     See Also
     --------
-    roll_max
+    roll_min
 
     """
     return _roll_max(X, w)

--- a/fynance/features/scale.py
+++ b/fynance/features/scale.py
@@ -280,7 +280,8 @@ class Scale:
             axis = self.axis
 
         if axis == 1:
-            self.func(X.T, **self.params).T
+
+            return self._apply(self.func, X)
 
         return self.func(X, **self.params)
 
@@ -302,9 +303,40 @@ class Scale:
             axis = self.axis
 
         if axis == 1:
-            self.revert_func(X.T, **self.params).T
+
+            return self._apply(self.revert_func, X)
 
         return self.revert_func(X, **self.params)
+
+    def _apply(self, func, X):
+        """ Apply `func` along axis 1 with fitted parameters.
+
+        The fitted parameters were computed along ``axis=1`` and therefore
+        share the orientation of ``X``. The data is transposed so that the
+        time axis lands on axis 0; any array-valued parameter that matches
+        the dimensionality of ``X`` is transposed as well to keep the
+        orientation consistent before broadcasting.
+
+        Parameters
+        ----------
+        func : callable
+            The scale (or revert) function to apply.
+        X : np.ndarray[dtype, ndim=1 or 2]
+            Data to transform along axis 1.
+
+        Returns
+        -------
+        np.ndarray[dtype, ndim=1 or 2]
+            The transformed data, with the original orientation restored.
+
+        """
+        params = dict(self.params)
+        for key in ("m", "s"):
+            value = params.get(key)
+            if isinstance(value, np.ndarray) and value.ndim == X.ndim:
+                params[key] = value.T
+
+        return func(X.T, **params).T
 
 
 def standardize(X, a=0, b=1, axis=0):

--- a/fynance/features/stats.py
+++ b/fynance/features/stats.py
@@ -340,7 +340,7 @@ def mad(X: NDArray, axis: int = 0, dtype=None) -> NDArray:
     roll_mad
 
     """
-    return np.mean(np.abs(X.T - np.mean(X, axis=axis)).T, axis=axis)
+    return np.mean(np.abs(X - np.mean(X, axis=axis, keepdims=True)), axis=axis)
 
 
 @WrapperArray('dtype', 'axis', 'window')

--- a/fynance/metrics/ratios.py
+++ b/fynance/metrics/ratios.py
@@ -269,7 +269,7 @@ def calmar(X: NDArray, period: int = 252, axis: int = 0, dtype=None, ddof: int =
 
     Notes
     -----
-    Calmar ratio [3]_ is the compouned annual return
+    Calmar ratio [3]_ is the compounded annual return
     (:func:`~fynance.metrics.annual_return`) over the maximum drawdown
     (:func:`~fynance.metrics.mdd`). Let :math:`T` the number of time
     observations, DD the vector of drawdown:
@@ -278,11 +278,16 @@ def calmar(X: NDArray, period: int = 252, axis: int = 0, dtype=None, ddof: int =
 
         calmarRatio = \frac{annualReturn}{MDD}
 
-    With, :math:`annualReturn = \frac{X_T}{X_1}^{\frac{period}{T}} - 1` and
-    :math:`MDD = max(DD_{1:T})`.
+    With, :math:`annualReturn = \left(\frac{X_T}{X_1}\right)^{\frac{period}{T}}
+    - 1` and :math:`MDD = max(DD_{1:T})`.
 
     Where, :math:`DD_t = 1 - \frac{X_t}{max(X_{1:t})}`,
     :math:`\forall t \in [1:T]`.
+
+    A drawdown-free curve has a zero maximum drawdown, which leaves the ratio
+    undefined: it is ``+inf`` when the annual return is positive (a riskless
+    gain) and ``0`` when the annual return is also zero (a flat curve). This is
+    the same zero-denominator convention as :func:`sharpe` and :func:`sortino`.
 
     Parameters
     ----------
@@ -315,9 +320,14 @@ def calmar(X: NDArray, period: int = 252, axis: int = 0, dtype=None, ddof: int =
 
     >>> X = np.array([70, 100, 80, 120, 160, 105, 80]).astype(np.float64)
     >>> calmar(X, period=12, ddof=1)
-    array(0.6122449)
+    0.6122448979591835
     >>> calmar(X.reshape([7, 1]), period=12)
     array([0.51446018])
+
+    A drawdown-free (monotonically increasing) curve yields ``inf``:
+
+    >>> calmar(np.array([100., 101., 102., 103., 104.]), period=12)
+    inf
 
     See Also
     --------
@@ -327,11 +337,8 @@ def calmar(X: NDArray, period: int = 252, axis: int = 0, dtype=None, ddof: int =
     ret = _annual_return(X, period, ddof)
     dd = _drawdown(X, False)
     mdd = np.max(dd, axis=axis)
-    calmar = np.zeros(ret.shape)
-    slice_bool = (mdd != 0)
-    calmar[slice_bool] = ret[slice_bool] / mdd[slice_bool]
 
-    return calmar
+    return _safe_ratio(ret, mdd)
 
 
 @WrapperArray('axis')
@@ -341,7 +348,7 @@ def diversified_ratio(X: NDArray, W: NDArray | None = None, std_method: str = 's
     Notes
     -----
     Diversification ratio, denoted D, is defined as the ratio of the
-    portfolio's weighted average volatility to its overll volatility,
+    portfolio's weighted average volatility to its overall volatility,
     developed by Choueifaty and Coignard [4]_.
 
     .. math:: D(P) = \\frac{P' \\Sigma}{\\sqrt{P'VP}}
@@ -364,7 +371,7 @@ def diversified_ratio(X: NDArray, W: NDArray | None = None, std_method: str = 's
 
     Returns
     -------
-    np.float64
+    float
         Value of diversification ratio of the portfolio.
 
     References
@@ -386,7 +393,7 @@ def diversified_ratio(X: NDArray, W: NDArray | None = None, std_method: str = 's
     sigma = np.std(X, axis=0).reshape([N, 1])
     V = np.cov(X, rowvar=False, bias=True).reshape([N, N])
 
-    return (W.T @ sigma) / np.sqrt(W.T @ V @ W)
+    return ((W.T @ sigma) / np.sqrt(W.T @ V @ W)).item()
 
 
 @WrapperArray('dtype', 'axis', 'null', 'window', 'ddof', min_size=3)
@@ -566,7 +573,7 @@ def roll_calmar(X: NDArray, period: float = 252., w: int | None = None, axis: in
 
     Notes
     -----
-    Calmar ratio [3]_ is the rolling compouned annual return
+    Calmar ratio [3]_ is the rolling compounded annual return
     (:func:`~fynance.metrics.roll_annual_return`) over the rolling
     maximum drawdown (:func:`~fynance.metrics.roll_mdd`). Let
     :math:`T` the number of time observations, DD the vector of drawdown,
@@ -576,9 +583,13 @@ def roll_calmar(X: NDArray, period: float = 252., w: int | None = None, axis: in
 
         calmarRatio_t = \frac{annualReturn_t}{MDD_t} \\ \\
 
-    With, :math:`annualReturn_t = \frac{X_t}{X_1}^{\frac{period}{t}} - 1` and
-    :math:`MDD_t = max(DD_t)`, where
+    With, :math:`annualReturn_t = \left(\frac{X_t}{X_1}\right)^{\frac{period}{t}}
+    - 1` and :math:`MDD_t = max(DD_t)`, where
     :math:`DD_t = 1 - \frac{X_t}{max(X_{1:t})}`.
+
+    As for :func:`calmar`, a drawdown-free window has a zero maximum drawdown
+    and the ratio is ``+inf`` when its annual return is positive and ``0`` when
+    that return is also zero — the same convention as :func:`roll_sharpe`.
 
     Parameters
     ----------
@@ -614,7 +625,7 @@ def roll_calmar(X: NDArray, period: float = 252., w: int | None = None, axis: in
 
     >>> X = np.array([70, 100, 80, 120, 160, 80]).astype(np.float64)
     >>> roll_calmar(X, period=12)
-    array([ 0.        ,  0.        ,  3.52977926, 20.18950437, 31.35989887,
+    array([ 0.        ,         inf,  3.52977926, 20.18950437, 31.35989887,
             0.6122449 ])
 
     See Also
@@ -624,9 +635,6 @@ def roll_calmar(X: NDArray, period: float = 252., w: int | None = None, axis: in
     """
     ret = _roll_annual_return(X, period, w, ddof)
     mdd = _roll_mdd(X, w, False)
-    calmar = np.zeros(X.shape)
-    slice_bool = (mdd != 0)
-    calmar[slice_bool] = ret[slice_bool] / mdd[slice_bool]
 
-    return calmar
+    return _safe_ratio(ret, mdd)
 

--- a/fynance/metrics/returns.py
+++ b/fynance/metrics/returns.py
@@ -19,19 +19,19 @@ __all__ = ['annual_return', 'perf_index', 'perf_returns', 'roll_annual_return']
 
 @WrapperArray('dtype', 'axis', 'ddof', min_size=2)
 def annual_return(X: NDArray, period: int = 252, axis: int = 0, dtype=None, ddof: int = 0) -> NDArray:
-    r""" Compute compouned annual returns of each `X`' series.
+    r""" Compute compounded annual returns of each `X`' series.
 
     The annualised return [1]_ is the process of converting returns on a whole
     period to returns per year.
 
     Notes
     -----
-    Let T the number of timeframes in `X`' series, the annual compouned returns
+    Let T the number of timeframes in `X`' series, the annual compounded returns
     is computed such that:
 
     .. math::
 
-        annualReturn = \frac{X_T}{X_1}^{\frac{period}{T}} - 1
+        annualReturn = \left(\frac{X_T}{X_1}\right)^{\frac{period}{T}} - 1
 
     Parameters
     ----------
@@ -40,7 +40,7 @@ def annual_return(X: NDArray, period: int = 252, axis: int = 0, dtype=None, ddof
     period : int, optional
         Number of period per year, default is 252 (trading days per year).
     axis : {0, 1}, optional
-        Axis along wich the computation is done. Default is 0.
+        Axis along which the computation is done. Default is 0.
     dtype : np.dtype, optional
         The type of the output array.  If `dtype` is not given, infer the data
         type from `X` input.
@@ -52,7 +52,7 @@ def annual_return(X: NDArray, period: int = 252, axis: int = 0, dtype=None, ddof
     Returns
     -------
     dtype or np.ndarray[dtype, ndim=1]
-        Values of compouned annual returns of each series.
+        Values of compounded annual returns of each series.
 
     References
     ----------
@@ -322,19 +322,19 @@ def returns_strat(X: NDArray, S: NDArray | None = None, kind: str = 'pct', base:
 
 @WrapperArray('dtype', 'axis', 'window', 'ddof', min_size=2)
 def roll_annual_return(X: NDArray, period: int = 252, w: int | None = None, axis: int = 0, dtype=None, ddof: int = 0) -> NDArray:
-    r""" Compute rolling compouned annual returns of each `X`' series.
+    r""" Compute rolling compounded annual returns of each `X`' series.
 
     The annualised return [1]_ is the process of converting returns on a whole
     period to returns per year.
 
     Notes
     -----
-    The rolling annual compouned returns is computed such that :math:`\forall t
+    The rolling annual compounded returns is computed such that :math:`\forall t
     \in [1: T]`:
 
     .. math::
 
-        annualReturn_t = \frac{X_t}{X_1}^{\frac{period}{t}} - 1
+        annualReturn_t = \left(\frac{X_t}{X_1}\right)^{\frac{period}{t}} - 1
 
     Parameters
     ----------
@@ -346,7 +346,7 @@ def roll_annual_return(X: NDArray, period: int = 252, w: int | None = None, axis
         Size of the lagged window of the rolling function, must be positive. If
         ``w is None`` or ``w=0``, then ``w=X.shape[axis]``. Default is None.
     axis : {0, 1}, optional
-        Axis along wich the computation is done. Default is 0.
+        Axis along which the computation is done. Default is 0.
     dtype : np.dtype, optional
         The type of the output array.  If `dtype` is not given, infer the data
         type from `X` input.
@@ -358,7 +358,7 @@ def roll_annual_return(X: NDArray, period: int = 252, w: int | None = None, axis
     Returns
     -------
     np.ndarray[dtype, ndim=1 or 2]
-        Values of rolling compouned annual returns of each series.
+        Values of rolling compounded annual returns of each series.
 
     References
     ----------

--- a/fynance/metrics/summary.py
+++ b/fynance/metrics/summary.py
@@ -69,11 +69,16 @@ def summary(prices: NDArray, period: int = 252, rf: float = 0.0) -> dict[str, fl
     """
     p = np.asarray(prices, dtype=np.float64)
 
+    # ``sharpe`` and ``sortino`` default to ``log=False``; report the volatility
+    # under the same convention so the displayed vol is the one implied by the
+    # displayed Sharpe ratio.
+    log = False
+
     return {
         'annual_return': float(annual_return(p, period=period)),
-        'annual_volatility': float(annual_volatility(p, period=period)),
-        'sharpe': float(sharpe(p, period=period, rf=rf)),
-        'sortino': float(sortino(p, period=period)),
+        'annual_volatility': float(annual_volatility(p, period=period, log=log)),
+        'sharpe': float(sharpe(p, period=period, rf=rf, log=log)),
+        'sortino': float(sortino(p, period=period, log=log)),
         'calmar': float(calmar(p, period=period)),
         'max_drawdown': float(mdd(p)),
     }

--- a/fynance/models/_base.py
+++ b/fynance/models/_base.py
@@ -63,21 +63,23 @@ class BaseNeuralNet(torch.nn.Module):
 
     **Public API contract (stable for the 1.x series)**
 
-    - **Shapes** — feed-forward subclasses (e.g.
-      :class:`~fynance.models.mlp.MultiLayerPerceptron`)
-      expect ``X`` of shape ``(T, N)`` and ``y`` of shape ``(T, M)``,
-      where ``T`` is the number of observations, ``N`` the number of
-      input features and ``M`` the number of targets. Recurrent
-      subclasses in :mod:`fynance.models.rnn`,
-      :mod:`fynance.models.gru`, :mod:`fynance.models.lstm`
-      consume ``X`` of shape ``(T, S, N)``, where ``S`` is the sequence
-      length.
+    - **Shapes** — all current subclasses (the feed-forward
+      :class:`~fynance.models.mlp.MultiLayerPerceptron`, the gated
+      cells in :mod:`fynance.models.rnn`, :mod:`fynance.models.gru`,
+      :mod:`fynance.models.lstm`, and the convolutional / attention
+      models) expect ``X`` of shape ``(T, N)`` and ``y`` of shape
+      ``(T, M)``, where ``T`` is the number of observations, ``N`` the
+      number of input features and ``M`` the number of targets. The
+      gated "recurrent" cells process each of the ``T`` rows
+      independently (they are stateless gated feed-forward cells — see
+      their own class docstrings); they do **not** thread a hidden state
+      across a time axis.
     - **Dtypes** — :meth:`set_data` coerces inputs through
-      :meth:`_set_data`. The expected default for both ``X`` and ``y``
-      is a floating tensor (``torch.float32`` is the de-facto convention
-      in the project doctests). Pass ``x_type`` / ``y_type`` explicitly
-      to override; mismatched dtypes between ``X``, ``y`` and the model
-      parameters will raise at the first ``forward`` pass.
+      :meth:`_set_data`, which casts floating-point inputs to
+      ``torch.get_default_dtype()`` (``float32`` by default) so plain
+      ``float64`` NumPy arrays train without manual ``.astype``. Integer
+      inputs keep their dtype. Pass ``x_type`` / ``y_type`` explicitly to
+      force a specific dtype.
     - **Device** — the wrapper does **not** move tensors automatically.
       Models live on CPU unless the caller explicitly calls ``.to(device)``
       on both the module and the data tensors before training.
@@ -134,7 +136,7 @@ class BaseNeuralNet(torch.nn.Module):
 
         Parameters
         ----------
-        criterion : Callabletorch.nn.modules.loss
+        criterion : Callable, torch.nn.modules.loss
             A loss function.
         optimizer : torch.optim.Optimizer
             An optimizer algorithm.
@@ -200,11 +202,12 @@ class BaseNeuralNet(torch.nn.Module):
         """ Trains the neural network model on a single batch.
 
         Runs one forward / backward / optimizer-step cycle on the batch
-        ``(X, y)``. As a side effect, gradients of all parameters are
-        zeroed before the forward pass and the optimizer state is
-        advanced afterwards. If a learning-rate scheduler has been
-        registered via :meth:`set_lr_scheduler`, its ``step`` is also
-        called.
+        ``(X, y)``. The module is switched to training mode (so dropout
+        and batch-norm behave as expected) before the forward pass. As a
+        side effect, gradients of all parameters are zeroed before the
+        forward pass and the optimizer state is advanced afterwards. If a
+        learning-rate scheduler has been registered via
+        :meth:`set_lr_scheduler`, its ``step`` is also called.
 
         Parameters
         ----------
@@ -225,6 +228,7 @@ class BaseNeuralNet(torch.nn.Module):
             If :meth:`set_optimizer` has not been called yet.
 
         """
+        self.train()
         self.optimizer.zero_grad()  # type: ignore[attr-defined]
         outputs = self(X)
         loss = self.criterion(outputs, y)
@@ -271,11 +275,15 @@ class BaseNeuralNet(torch.nn.Module):
     def predict(self, X) -> torch.Tensor:
         """ Predicts outputs of neural network model.
 
-        Runs ``self.forward(X)`` under :func:`torch.no_grad`, so no
-        autograd graph is built. The returned tensor is detached and
-        lives on the same device as the model parameters. Array-like inputs
-        (numpy / polars) are coerced to a tensor first, so the method also
-        satisfies the :class:`~fynance.core.protocols.SignalModel` contract.
+        Runs ``self.forward(X)`` under :func:`torch.no_grad` with the
+        module switched to evaluation mode, so no autograd graph is built
+        and stochastic layers (dropout, batch-norm) behave
+        deterministically. The previous training/eval mode is restored on
+        exit. The returned tensor is detached and lives on the same device
+        as the model parameters; the coerced input is moved to that device
+        too. Array-like inputs (numpy / polars) are coerced to a tensor
+        first, so the method also satisfies the
+        :class:`~fynance.core.protocols.SignalModel` contract.
 
         Parameters
         ----------
@@ -292,7 +300,22 @@ class BaseNeuralNet(torch.nn.Module):
         if not isinstance(X, torch.Tensor):
             X = self._set_data(X)
 
-        return self(X).detach()
+        try:
+            device = next(self.parameters()).device
+            X = X.to(device)
+
+        except StopIteration:
+            pass
+
+        was_training = self.training
+        self.eval()
+        try:
+            output = self(X).detach()
+
+        finally:
+            self.train(was_training)
+
+        return output
 
     def set_data(self, X: NDArray | torch.Tensor | pl.DataFrame, y: NDArray | torch.Tensor | pl.DataFrame, x_type=None, y_type=None):
         """ Set data inputs and outputs.
@@ -311,7 +334,9 @@ class BaseNeuralNet(torch.nn.Module):
             ``(T, M)`` respectively.
         x_type, y_type : torch.dtype, optional
             Target dtypes for the resulting tensors. Default is `None`,
-            which preserves the input dtype.
+            which casts floating-point inputs to
+            ``torch.get_default_dtype()`` (``float32`` by default) and
+            leaves integer inputs unchanged. See :meth:`_set_data`.
 
         Returns
         -------
@@ -345,41 +370,96 @@ class BaseNeuralNet(torch.nn.Module):
     def set_seed(self, seed_torch=None, seed_numpy=None):
         r""" Set seed for PyTorch and NumPy random number generator.
 
+        Each generator is only (re)seeded when its argument is provided:
+        passing ``seed_torch`` alone leaves the global NumPy RNG
+        untouched, and vice versa.
+
         Parameters
         ----------
         seed_torch, seed_numpy : bool or int, optional
-            If `seed` is an int :math:`0 < seed < 2^32` set respectively
-            PyTorch and NumPy seed with the number. Otherwise if is True
-            then choose a random number, else doesn't set seed.
+            If an int :math:`0 \leq seed < 2^{32}`, seed respectively the
+            PyTorch and NumPy generator with that number. If ``True``,
+            draw a random seed. If ``None`` (default), leave that
+            generator untouched.
+
+        Examples
+        --------
+        >>> from fynance.models.mlp import MultiLayerPerceptron
+        >>> model = MultiLayerPerceptron(3, 1, layers=[4])
+        >>> model.set_seed(seed_torch=42)
+        >>> model.seed_torch
+        42
+        >>> model.seed_numpy is None
+        True
 
         """
-        self.seed_torch = self._set_seed(seed_torch)
-        self.seed_numpy = self._set_seed(seed_numpy)
-        torch.manual_seed(self.seed_torch)
-        np.random.seed(self.seed_numpy)
+        if seed_torch is not None:
+            self.seed_torch = self._set_seed(seed_torch)
+            torch.manual_seed(self.seed_torch)
+
+        if seed_numpy is not None:
+            self.seed_numpy = self._set_seed(seed_numpy)
+            np.random.seed(self.seed_numpy)
 
     def _set_seed(self, seed):
-        if isinstance(seed, int) and 0 <= seed < 2 ** 32:
+        if isinstance(seed, int) and not isinstance(seed, bool) and 0 <= seed < 2 ** 32:
 
             return seed
 
         return np.random.randint(0, 2 ** 32)
 
     def _set_data(self, X, dtype=None):
-        """ Convert array-like data to tensor. """
-        if isinstance(X, np.ndarray):
+        """ Convert array-like data to a tensor of a consistent dtype.
 
-            return torch.from_numpy(X)
+        Coerces ``X`` (NumPy array, polars ``DataFrame`` or tensor) to a
+        :class:`torch.Tensor`. When ``dtype`` is given the tensor is cast
+        to it. When ``dtype`` is ``None`` and the input is floating point,
+        the tensor is cast to ``torch.get_default_dtype()`` (``float32``
+        by default) so that plain ``float64`` NumPy input does not clash
+        with the model's ``float32`` parameters at the first ``forward``
+        pass. Integer inputs keep their dtype when ``dtype`` is ``None``.
+
+        Parameters
+        ----------
+        X : numpy.ndarray, polars.DataFrame or torch.Tensor
+            Array-like data to convert.
+        dtype : torch.dtype, optional
+            Target dtype. Default is ``None`` (see above).
+
+        Returns
+        -------
+        torch.Tensor
+            The converted tensor.
+
+        Raises
+        ------
+        ValueError
+            If ``X`` is not one of the accepted types.
+
+        """
+        if isinstance(X, np.ndarray):
+            # ``torch.from_numpy`` aliases the caller's memory; clone so a
+            # later in-place edit on the tensor cannot mutate the source.
+            tensor = torch.from_numpy(X).clone()
 
         elif isinstance(X, pl.DataFrame):
-            return torch.from_numpy(X.to_numpy())
+            tensor = torch.from_numpy(X.to_numpy()).clone()
 
         elif isinstance(X, torch.Tensor):
-
-            return X
+            tensor = X
 
         else:
             raise ValueError('Unkwnown data type: {}'.format(type(X)))
+
+        if dtype is not None:
+
+            return tensor.to(dtype)
+
+        if tensor.is_floating_point() and tensor.dtype != torch.get_default_dtype():
+
+            return tensor.to(torch.get_default_dtype())
+
+        return tensor
 
     def save_model(self, path, save_optimizer=False):
         """ Save the model with this weights and parameters.
@@ -399,7 +479,7 @@ class BaseNeuralNet(torch.nn.Module):
         torch.save(state_dict, path)
 
     def load_model(self, path, load_optimizer=False):
-        """ Save the model with this weights and parameters.
+        """ Load the model weights and parameters from a file.
 
         Parameters
         ----------

--- a/fynance/models/_recurrent_base.py
+++ b/fynance/models/_recurrent_base.py
@@ -1,15 +1,19 @@
 #!/usr/bin/env python3
 # coding: utf-8
 
-""" Internal building blocks for recurrent neural network models.
+""" Internal building blocks for the gated cell models.
 
-Defines two private classes used by all RNN variants:
+Defines two private classes shared by the gated-cell variants
+(:mod:`fynance.models.rnn`, :mod:`fynance.models.gru`,
+:mod:`fynance.models.lstm`):
 
-- :class:`_RecurrentBase` — shared backbone that sets up the recurrent
-  weight matrix ``W_h``, the hidden activation ``f_h``, and dropout.
-  Its ``forward(X, H)`` implements the vanilla Elman RNN step
-  (concatenate input with hidden state, apply linear + activation).
-  :class:`~fynance.models.gru._GRUCell` and
+- :class:`_RecurrentBase` — shared backbone that sets up the weight
+  matrix ``W_h``, the hidden activation ``f_h``, and dropout. Its
+  ``forward(X, H)`` implements one Elman-style step (concatenate input
+  with the supplied hidden state, apply linear + activation). **Each row
+  of the input is processed independently**: the backbone does not loop
+  over a time axis or thread state across rows — it is a *stateless*
+  gated feed-forward cell. :class:`~fynance.models.gru._GRUCell` and
   :class:`~fynance.models.lstm._LSTMCell` override ``forward`` to add
   their gating logic on top of this backbone.
 
@@ -37,12 +41,15 @@ from fynance.models._base import BaseNeuralNet
 
 
 class _RecurrentBase(BaseNeuralNet):
-    """ Shared recurrent backbone for all RNN-flavored models.
+    """ Shared backbone for the gated cell models.
 
-    Sets up the recurrent weight matrix ``W_h``, the hidden-state
-    activation ``f_h``, and the dropout layer. Its ``forward(X, H)``
-    implements the vanilla Elman RNN step: concatenate input with hidden
-    state, apply ``W_h`` + ``f_h``.
+    Sets up the weight matrix ``W_h``, the hidden-state activation
+    ``f_h``, and the dropout layer. Its ``forward(X, H)`` implements one
+    Elman-style step: concatenate input with the supplied hidden state,
+    apply ``W_h`` + ``f_h``. Each row of ``X`` is processed
+    independently against the matching row of ``H``; no state is threaded
+    across rows, so this is a *stateless* gated feed-forward cell rather
+    than a sequence model.
 
     :class:`~fynance.models.gru._GRUCell` and
     :class:`~fynance.models.lstm._LSTMCell` subclass this and override
@@ -61,6 +68,8 @@ class _RecurrentBase(BaseNeuralNet):
         projection (e.g. :class:`~fynance.models.gru.GRUCell`).
     drop : float, optional
         Probability of an element to be zeroed.
+    bias : bool, optional
+        If ``True`` (default), the linear layers learn an additive bias.
     hidden_activation : torch.nn.Module, optional
         Activation functions, default is Tanh function.
     hidden_state_size : int, optional
@@ -107,9 +116,10 @@ class _RecurrentBase(BaseNeuralNet):
         else:
             self.set_data(X=X, y=y, x_type=x_type, y_type=y_type)  # type: ignore[arg-type]
 
+        self.bias = bias
         self.H = self.N if hidden_state_size is None else hidden_state_size
 
-        self.W_h = nn.Linear(self.N + self.H, self.H)
+        self.W_h = nn.Linear(self.N + self.H, self.H, bias=bias)
 
         self.f_h = hidden_activation()
 
@@ -161,8 +171,8 @@ class _OutputLayerMixin:
 
     """
 
-    def __init__(self, forward_activation=nn.Softmax):
-        self.W_y = nn.Linear(self.H, self.M)
+    def __init__(self, forward_activation=nn.Identity):
+        self.W_y = nn.Linear(self.H, self.M, bias=getattr(self, 'bias', True))
         self.f_y = nn.Softmax(dim=-1) if forward_activation is nn.Softmax else forward_activation()
 
     @torch.enable_grad()
@@ -182,6 +192,7 @@ class _OutputLayerMixin:
             Updated states of the model.
 
         """
+        self.train()  # type: ignore[attr-defined]
         self.optimizer.zero_grad()  # type: ignore[attr-defined]
         outputs, H = self(X, H)  # type: ignore[operator]
         loss = self.criterion(outputs, y)  # type: ignore[attr-defined]
@@ -212,6 +223,12 @@ class _OutputLayerMixin:
            Updated states of the model.
 
         """
-        Y, H = self(X, H)  # type: ignore[operator]
+        was_training = self.training  # type: ignore[attr-defined]
+        self.eval()  # type: ignore[attr-defined]
+        try:
+            Y, H = self(X, H)  # type: ignore[operator]
+
+        finally:
+            self.train(was_training)  # type: ignore[attr-defined]
 
         return Y.detach(), H.detach()

--- a/fynance/models/econometric_models.py
+++ b/fynance/models/econometric_models.py
@@ -297,7 +297,8 @@ def ARMA(y, phi, theta, c, p, q):
 
     """
     # Set type variables and parameters
-    y = np.asarray(y, dtype=np.float64).reshape([y.size])
+    y = np.asarray(y, dtype=np.float64)
+    y = y.reshape([y.size])
     theta = np.asarray(theta, dtype=np.float64)
     phi = np.asarray(phi, dtype=np.float64)
 
@@ -361,7 +362,8 @@ def ARMA_GARCH(y, phi, theta, alpha, beta, c, omega, p, q, Q, P):
     ARMAX_GARCH, ARMA, MA.
 
     """
-    y = np.asarray(y, dtype=np.float64).reshape([y.size])
+    y = np.asarray(y, dtype=np.float64)
+    y = y.reshape([y.size])
     theta = np.asarray(theta, dtype=np.float64)
     phi = np.asarray(phi, dtype=np.float64)
     alpha = np.asarray(alpha, dtype=np.float64)
@@ -380,7 +382,8 @@ def ARMAX_GARCH(y, x, phi, psi, theta, alpha, beta, c, omega, p, q, Q, P):
 
     .. math::
 
-        y_t = c + \phi_1 * y_{t-1} + ... + \phi_p * y_{t-p} + \psi_t * x_t
+        y_t = c + \phi_1 * y_{t-1} + ... + \phi_p * y_{t-p}
+        + \sum_k \psi_k * x_{t,k}
         + \theta_1 * u_{t-1} + ... + \theta_q * u_{t-q} + u_t
 
     With Generalized AutoRegressive Conditional Heteroskedasticity volatility
@@ -409,7 +412,9 @@ def ARMAX_GARCH(y, x, phi, psi, theta, alpha, beta, c, omega, p, q, Q, P):
     beta : np.ndarray[np.float64, ndim=1]
         Coefficients of AR part of GARCH.
     c : np.float64
-        Constant of the model.
+        Constant of ARMA model.
+    omega : np.float64
+        Constant of GARCH model.
     p : int
         Order of AR(p) model.
     q : int
@@ -432,7 +437,8 @@ def ARMAX_GARCH(y, x, phi, psi, theta, alpha, beta, c, omega, p, q, Q, P):
 
     """
     # Set array variables
-    y = np.asarray(y, dtype=np.float64).reshape([y.size])
+    y = np.asarray(y, dtype=np.float64)
+    y = y.reshape([y.size])
     x = np.asarray(x, dtype=np.float64)
     theta = np.asarray(theta, dtype=np.float64)
     phi = np.asarray(phi, dtype=np.float64)

--- a/fynance/models/gru.py
+++ b/fynance/models/gru.py
@@ -94,8 +94,8 @@ class _GRUCell(_RecurrentBase):
             hidden_state_size=hidden_state_size,
         )
 
-        self.W_u = nn.Linear(self.N + self.H, self.H)
-        self.W_r = nn.Linear(self.N + self.H, self.H)
+        self.W_u = nn.Linear(self.N + self.H, self.H, bias=bias)
+        self.W_r = nn.Linear(self.N + self.H, self.H, bias=bias)
 
         self.f_u = update_activation()
         self.f_r = reset_activation()
@@ -173,13 +173,18 @@ class GRUCell(_GRUCell):
 
 
 class GatedRecurrentUnit(_OutputLayerMixin, GRUCell):  # type: ignore[misc]
-    """ Gated Recurrent Unit neural network.
+    """ Gated Recurrent Unit cell with output projection.
 
-    Full GRU model: :class:`_GRUCell` gating logic followed by a
-    forward output projection. Mitigates vanishing gradients compared to
-    :class:`~fynance.models.rnn.RecurrentNeuralNetwork` via reset and
-    update gates. Use :class:`~fynance.models.lstm.LongShortTermMemory`
-    when you need an explicit memory cell state (longer dependencies).
+    GRU gating logic (:class:`_GRUCell`) followed by a forward output
+    projection. Like :class:`~fynance.models.rnn.RecurrentNeuralNetwork`,
+    this is a *stateless* gated feed-forward cell: each of the ``T`` rows
+    of ``X`` is processed independently against the supplied hidden state
+    ``H``, and no state is threaded across rows. The gating mitigates the
+    vanishing-gradient pathology *within* a step but does not, on its
+    own, model temporal dependencies — the caller must thread ``H``
+    explicitly. For built-in sequence modeling use
+    :class:`~fynance.models.tcn.TemporalConvNet` or
+    :class:`~fynance.models.transformer.Transformer`.
 
     Parameters
     ----------
@@ -188,9 +193,13 @@ class GatedRecurrentUnit(_OutputLayerMixin, GRUCell):  # type: ignore[misc]
         - If it's an integer, respectively dimension of inputs and outputs.
     drop : float, optional
         Probability of an element to be zeroed.
+    bias : bool, optional
+        If ``True`` (default), the linear layers learn an additive bias.
     forward_activation, hidden_activation : torch.nn.Module, optional
-        Activation functions, default is respectively Softmax and Tanh
-        function.
+        Activation functions, default is respectively Identity and Tanh
+        function. The output activation defaults to Identity so the cell
+        produces unconstrained regression outputs (pass ``nn.Softmax`` for
+        a probability-simplex output).
     hidden_state_size : int, optional
         Size of hidden states, default is the same size than input.
     reset_activation, update_activation : torch.nn.Module, optional
@@ -217,7 +226,7 @@ class GatedRecurrentUnit(_OutputLayerMixin, GRUCell):  # type: ignore[misc]
 
     def __init__(
         self, X, y, drop=None, x_type=None, y_type=None, bias=True,
-        forward_activation=nn.Softmax, hidden_activation=nn.Tanh,
+        forward_activation=nn.Identity, hidden_activation=nn.Tanh,
         hidden_state_size=None, reset_activation=nn.Sigmoid,
         update_activation=nn.Sigmoid,
     ):

--- a/fynance/models/loss/__init__.py
+++ b/fynance/models/loss/__init__.py
@@ -16,6 +16,12 @@ Main entry points
   proxy; only penalizes negative excess returns).
 - :class:`DirectionalAccuracyLoss` — sigmoid surrogate for directional
   accuracy (differentiable approximation of sign-prediction rate).
+- :class:`CalmarLoss` — negative Calmar ratio (return per unit of
+  maximum drawdown).
+- :class:`OmegaLoss` — negative Omega ratio (expected gains over
+  expected losses relative to a threshold).
+- :class:`HybridLoss` — convex combination of two losses with a fixed or
+  learnable weight.
 
 Notes
 -----

--- a/fynance/models/loss/_base.py
+++ b/fynance/models/loss/_base.py
@@ -16,6 +16,13 @@ import torch.nn
 
 __all__ = ['BaseLoss']
 
+#: Hard magnitude bound for ratio-style losses (Sharpe / Sortino / Calmar /
+#: Omega). It is far above any plausible real ratio (which are O(1)-O(10)), so
+#: it never touches a normal-case value; it only caps the runaway that a
+#: collapsing risk denominator would otherwise produce, keeping the loss finite
+#: and its gradients well-scaled.
+MAX_RATIO: float = 1e3
+
 
 class BaseLoss(torch.nn.Module):
     """ Base class for differentiable financial loss functions.
@@ -41,7 +48,16 @@ class BaseLoss(torch.nn.Module):
         self.rf = rf
         self.period = period
         self.eps = eps
-        self._rf_per_period: float = rf / period
+
+    @property
+    def _rf_per_period(self) -> float:
+        """ Per-period risk-free rate, recomputed from the live ``rf``/``period``.
+
+        Computed as a property (not cached in ``__init__``) so that mutating
+        ``loss.rf`` or ``loss.period`` after construction takes effect on the
+        next :meth:`forward` instead of being a silent no-op.
+        """
+        return self.rf / self.period
 
     def _check_tensor(self, x: object) -> None:
         """ Raise TypeError if *x* is not a :class:`torch.Tensor`. """

--- a/fynance/models/loss/calmar.py
+++ b/fynance/models/loss/calmar.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import torch
 
 # Local packages
+from ._base import MAX_RATIO as _MAX_RATIO
 from ._base import BaseLoss
 
 __all__ = ['CalmarLoss']
@@ -24,6 +25,15 @@ class CalmarLoss(BaseLoss):
 
     Parameters are inherited from :class:`BaseLoss` (``period``, ``eps``).
 
+    Notes
+    -----
+    Drawdowns are :math:`O(\text{returns})`, so a fixed absolute ``eps``
+    (e.g. ``1e-8``) is dimensionally wrong: on a low- or zero-drawdown
+    batch the ratio would explode and dominate gradients. The drawdown is
+    therefore floored with a **returns-scaled** epsilon,
+    ``eps * |equity|.mean()``, keeping the loss finite and bounded while
+    preserving its sign convention (minimizing it maximizes the ratio).
+
     """
 
     def forward(
@@ -35,5 +45,13 @@ class CalmarLoss(BaseLoss):
         running_max, _ = torch.cummax(equity, dim=0)
         max_drawdown = (running_max - equity).max()
         annual_return = y_pred.mean() * self.period
+        # Returns-scaled floor: a fixed absolute eps is dimensionally wrong for
+        # an O(returns) drawdown and lets the ratio explode on a low-drawdown
+        # batch. Scaling by the equity magnitude keeps the floor on the right
+        # scale; the bare eps backstop guards the degenerate all-zero-return
+        # case and the final clamp bounds the magnitude when the drawdown is
+        # near zero (so the loss stays finite with well-scaled gradients).
+        floor = self.eps * equity.abs().mean() + self.eps
+        ratio = annual_return / torch.clamp(max_drawdown, min=floor)
 
-        return -(annual_return / (max_drawdown + self.eps))
+        return -torch.clamp(ratio, min=-_MAX_RATIO, max=_MAX_RATIO)

--- a/fynance/models/loss/omega.py
+++ b/fynance/models/loss/omega.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import torch
 
 # Local packages
+from ._base import MAX_RATIO as _MAX_RATIO
 from ._base import BaseLoss
 
 __all__ = ['OmegaLoss']
@@ -21,6 +22,15 @@ class OmegaLoss(BaseLoss):
     the ratio of expected gains to expected losses relative to a threshold
     ``L``. Fully differentiable through :func:`torch.relu`. Minimizing the
     loss maximizes the Omega ratio.
+
+    Notes
+    -----
+    Both gains and losses are :math:`O(|r - L|)`, so a fixed absolute
+    ``eps`` is dimensionally wrong: on an all-gains batch (zero losses) the
+    ratio would explode (e.g. ``-1e6``) and dominate gradients. The
+    denominator is therefore floored with a **returns-scaled** epsilon,
+    ``eps * |r - L|.mean()``, keeping the loss finite and bounded while
+    preserving the sign convention (minimizing it maximizes the ratio).
 
     Parameters
     ----------
@@ -43,5 +53,11 @@ class OmegaLoss(BaseLoss):
         diff = y_pred - self.threshold
         gains = torch.relu(diff).mean()
         losses = torch.relu(-diff).mean()
+        # Returns-scaled floor: a fixed absolute eps is dimensionally wrong for
+        # O(|r - L|) losses and lets the ratio explode on an all-gains batch.
+        # The bare eps backstop guards the degenerate all-zero-diff case and
+        # the final clamp bounds the magnitude when losses are near zero.
+        floor = self.eps * diff.abs().mean() + self.eps
+        ratio = gains / torch.clamp(losses, min=floor)
 
-        return -(gains / (losses + self.eps))
+        return -torch.clamp(ratio, min=-_MAX_RATIO, max=_MAX_RATIO)

--- a/fynance/models/loss/sortino.py
+++ b/fynance/models/loss/sortino.py
@@ -10,6 +10,7 @@ import torch
 import torch.nn.functional as F
 
 # Local packages
+from ._base import MAX_RATIO as _MAX_RATIO
 from ._base import BaseLoss
 
 __all__ = ['SortinoLoss']
@@ -38,6 +39,13 @@ class SortinoLoss(BaseLoss):
     **This is a training proxy** — the value is not comparable to the
     numpy :func:`~fynance.metrics.sortino` evaluation metric.
 
+    The downside deviation is :math:`O(\text{returns})`, so a fixed
+    absolute ``eps`` inside the square root is dimensionally wrong: on an
+    all-gains batch (zero downside) the loss would explode (e.g. ``-100``).
+    The downside is therefore floored with a **returns-scaled** epsilon
+    proportional to the excess-return magnitude, keeping the loss finite
+    and bounded while preserving the sign convention.
+
     Parameters
     ----------
     rf : float, optional
@@ -45,7 +53,8 @@ class SortinoLoss(BaseLoss):
     period : int, optional
         Number of periods per year. Default is 252.
     eps : float, optional
-        Numerical stabilizer added inside the square root. Default is 1e-8.
+        Relative numerical stabilizer scaling the downside-deviation floor
+        (see Notes). Default is 1e-8.
 
     Examples
     --------
@@ -88,5 +97,13 @@ class SortinoLoss(BaseLoss):
         """
         self._check_tensor(y_pred)
         excess = y_pred - self._rf_per_period
-        downside = torch.sqrt(torch.mean(F.relu(-excess) ** 2) + self.eps)
-        return -(excess.mean() / downside)
+        downside = torch.sqrt(torch.mean(F.relu(-excess) ** 2))
+        # Floor the downside relative to the return scale: a fixed absolute eps
+        # inside the sqrt is dimensionally wrong for an O(returns) downside and
+        # lets the ratio explode on an all-gains batch. ``eps`` backstops the
+        # degenerate all-zero case; the final clamp bounds the magnitude in the
+        # near-zero-downside regime (where pushing for more gains is fine, so
+        # saturating the gradient there is harmless for this training proxy).
+        floor = self.eps * excess.abs().mean() + self.eps
+        ratio = excess.mean() / torch.clamp(downside, min=floor)
+        return -torch.clamp(ratio, min=-_MAX_RATIO, max=_MAX_RATIO)

--- a/fynance/models/lstm.py
+++ b/fynance/models/lstm.py
@@ -108,19 +108,19 @@ class _LSTMCell(_RecurrentBase):
         self.C = self.H if memory_state_size is None else memory_state_size
 
         # Forget gate
-        self.W_f = nn.Linear(self.N + self.H, self.C)
+        self.W_f = nn.Linear(self.N + self.H, self.C, bias=bias)
         self.f_f = forget_activation()
 
         # Update gate
-        self.W_i = nn.Linear(self.N + self.H, self.C)
+        self.W_i = nn.Linear(self.N + self.H, self.C, bias=bias)
         self.f_i = update_activation()
 
         # Candidate value
-        self.W_c = nn.Linear(self.N + self.H, self.C)
+        self.W_c = nn.Linear(self.N + self.H, self.C, bias=bias)
         self.f_c = memory_activation()
 
         # Output gate
-        self.W_o = nn.Linear(self.N + self.H, self.C)
+        self.W_o = nn.Linear(self.N + self.H, self.C, bias=bias)
         self.f_o = output_activation()
 
         # Hidden activation (applied to cell state before output gate)
@@ -210,17 +210,19 @@ class LSTMCell(_LSTMCell):
 
 
 class LongShortTermMemory(_OutputLayerMixin, LSTMCell):
-    """ Long Short-Term Memory neural network.
+    """ Long Short-Term Memory cell with output projection.
 
-    Full LSTM model: :class:`_LSTMCell` four-gate architecture followed
-    by a forward output projection. The cell state ``C`` and hidden
-    state ``H`` are threaded through the sequence, allowing the model to
-    carry information across many time steps without the
-    vanishing-gradient pathology that limits
-    :class:`~fynance.models.rnn.RecurrentNeuralNetwork`. Use it for
-    sequence modeling tasks where dependencies span dozens of steps
-    (intraday return series, multi-day momentum signals, regime
-    detection).
+    LSTM four-gate architecture (:class:`_LSTMCell`) followed by a
+    forward output projection. The caller supplies the hidden state ``H``
+    and cell state ``C``; :meth:`forward` returns updated ``(Y, H, C)``.
+    Like the other gated cells in this package, **each of the ``T`` rows
+    of ``X`` is processed independently** — the cell does *not* loop over
+    a time axis or thread ``H`` / ``C`` across rows on its own, so it is a
+    *stateless* gated feed-forward cell. To model temporal dependencies
+    the caller must thread ``H`` and ``C`` across successive steps
+    explicitly. For built-in, causal sequence modeling prefer
+    :class:`~fynance.models.tcn.TemporalConvNet` or
+    :class:`~fynance.models.transformer.Transformer`.
 
     Parameters
     ----------
@@ -229,8 +231,11 @@ class LongShortTermMemory(_OutputLayerMixin, LSTMCell):
         - If it's an integer, respectively dimension of inputs and outputs.
     drop : float, optional
         Probability of an element to be zeroed.
+    bias : bool, optional
+        If ``True`` (default), the linear layers learn an additive bias.
     forward_activation : torch.nn.Module, optional
-        Activation functions, default is Softmax.
+        Output activation, default is Identity (unconstrained regression
+        output; pass ``nn.Softmax`` for a probability-simplex output).
     hidden_activation, memory_activation : torch.nn.Module, optional
         Activation functions for respectively hidden and memory state,
         default both are Tanh function.
@@ -266,7 +271,7 @@ class LongShortTermMemory(_OutputLayerMixin, LSTMCell):
 
     def __init__(
         self, X, y, drop=None, x_type=None, y_type=None, bias=True,
-        forward_activation=nn.Softmax, hidden_activation=nn.Tanh,
+        forward_activation=nn.Identity, hidden_activation=nn.Tanh,
         hidden_state_size=None, memory_activation=nn.Tanh,
         memory_state_size=None, forget_activation=nn.Sigmoid,
         update_activation=nn.Sigmoid, output_activation=nn.Sigmoid,
@@ -334,6 +339,7 @@ class LongShortTermMemory(_OutputLayerMixin, LSTMCell):
             Cell memory of the model.
 
         """
+        self.train()
         self.optimizer.zero_grad()  # type: ignore[attr-defined]
         outputs, H, C = self(X, H, C)
         loss = self.criterion(outputs, y)
@@ -368,6 +374,12 @@ class LongShortTermMemory(_OutputLayerMixin, LSTMCell):
             Cell memory of the model.
 
         """
-        Y, H, C = self(X, H, C)
+        was_training = self.training
+        self.eval()
+        try:
+            Y, H, C = self(X, H, C)
+
+        finally:
+            self.train(was_training)
 
         return Y.detach(), H.detach(), C.detach()

--- a/fynance/models/mlp.py
+++ b/fynance/models/mlp.py
@@ -153,7 +153,9 @@ class MultiLayerPerceptron(BaseNeuralNet):
             return lambda x: x
 
     def _set_dropout(self, drop):
-        # Set dropout parameters
+        # Set dropout parameters. Use a ModuleList (with nn.Identity for
+        # the no-dropout slots) so the dropout layers are registered as
+        # submodules and respond to ``model.eval()`` / ``model.train()``.
         if isinstance(drop, list):
 
             if len(drop) != self.n_layers:
@@ -161,15 +163,17 @@ class MultiLayerPerceptron(BaseNeuralNet):
                 raise ValueError('if you pass a list of drop parameters '
                                  'this one must be of size of layers list + 1')
 
-            return [torch.nn.Dropout(p=p) for p in drop]
+            modules = [torch.nn.Dropout(p=p) for p in drop]
 
         elif drop is not None:
 
-            return [torch.nn.Dropout(p=drop) for _ in range(self.n_layers)]
+            modules = [torch.nn.Dropout(p=drop) for _ in range(self.n_layers)]
 
         else:
 
-            return [lambda x: x for _ in range(self.n_layers)]
+            modules = [torch.nn.Identity() for _ in range(self.n_layers)]
+
+        return torch.nn.ModuleList(modules)
 
     def forward(self, x):
         """ Forward computation. """

--- a/fynance/models/objective.py
+++ b/fynance/models/objective.py
@@ -18,7 +18,9 @@ protocol (``fit``/``predict``), so it drops into the harness via the precomputed
     run_experiment(strat, prices, X=features, y=returns, walk_forward=...)
 
 ``fit(X, y)`` interprets ``y`` as the **realized per-bar returns** aligned with
-``X``; ``predict(X)`` returns positions in ``[-1, 1]`` (via ``tanh``).
+``X``; ``predict(X)`` returns positions. With the default ``position_fn``
+(``tanh``) these are bounded in ``[-1, 1]``; a custom ``position_fn`` may be
+unbounded.
 
 """
 
@@ -209,7 +211,11 @@ class ObjectiveModel:
 
     @torch.no_grad()
     def predict(self, X: NDArray) -> NDArray:
-        """ Return positions in ``[-1, 1]`` for each row of ``X``. """
+        """ Return a position for each row of ``X``.
+
+        With the default ``position_fn`` (``tanh``) positions are bounded in
+        ``[-1, 1]``; a custom ``position_fn`` may produce unbounded values.
+        """
         self.net.eval()  # type: ignore[union-attr]
         Xt = torch.as_tensor(np.asarray(X, dtype=np.float32))
 

--- a/fynance/models/rnn.py
+++ b/fynance/models/rnn.py
@@ -1,19 +1,26 @@
 #!/usr/bin/env python3
 # coding: utf-8
 
-""" Vanilla Elman recurrent neural network model.
+""" Single-step Elman-style recurrent cell.
 
-Defines :class:`RecurrentNeuralNetwork`, the simplest recurrent model:
-a single recurrent layer (Elman RNN) followed by a forward output
-projection. For longer temporal dependencies, prefer
-:class:`~fynance.models.gru.GatedRecurrentUnit` (GRU) or
-:class:`~fynance.models.lstm.LongShortTermMemory` (LSTM), which
-mitigate the vanishing-gradient problem via explicit gating.
+Defines :class:`RecurrentNeuralNetwork`, an Elman-style cell: it
+concatenates an input row with a supplied hidden-state row, applies one
+linear layer plus activation, and projects to the output. Each of the
+``T`` rows of the input is processed **independently** — the class does
+**not** thread a hidden state across a time axis, so it is a *stateless*
+gated feed-forward cell rather than a sequence model. The caller is
+responsible for any state threading (e.g. by looping over time steps and
+feeding the returned ``H`` back in).
+
+For genuine sequence modeling with temporal state, use a dedicated
+sequence architecture such as :class:`~fynance.models.tcn.TemporalConvNet`
+or :class:`~fynance.models.transformer.Transformer`, which enforce
+causality over an explicit time axis.
 
 Main entry points
 -----------------
-- :class:`RecurrentNeuralNetwork` — vanilla Elman RNN ready for
-  walk-forward training via :meth:`~fynance.models._base.BaseNeuralNet.set_optimizer`.
+- :class:`RecurrentNeuralNetwork` — single-step Elman cell ready for
+  training via :meth:`~fynance.models._base.BaseNeuralNet.set_optimizer`.
 
 References
 ----------
@@ -33,15 +40,20 @@ __all__ = ['RecurrentNeuralNetwork']
 
 
 class RecurrentNeuralNetwork(_OutputLayerMixin, _RecurrentBase):  # type: ignore[misc]
-    """ Neural network with vanilla Elman recurrent architecture.
+    """ Single-step Elman-style gated cell.
 
-    A single recurrent linear layer followed by a forward output layer.
-    Each call to :meth:`forward` updates the hidden state ``H`` and
-    emits a prediction ``Y``. Suitable as a baseline for short-horizon
-    sequence prediction; for longer dependencies, use
-    :class:`~fynance.models.gru.GatedRecurrentUnit` or
-    :class:`~fynance.models.lstm.LongShortTermMemory` to mitigate
-    vanishing gradients.
+    A single linear layer (over the input concatenated with a supplied
+    hidden state) followed by an output projection. Each call to
+    :meth:`forward` consumes ``X`` of shape ``(T, N)`` and ``H`` of shape
+    ``(T, H)`` and returns ``(Y, H_new)`` with the same leading dimension
+    ``T``; **every row is processed independently** and no state is
+    threaded across rows. This is therefore a *stateless* gated
+    feed-forward cell, not a sequence model — the caller must perform any
+    temporal state threading explicitly.
+
+    For sequence modeling with built-in temporal state and causality,
+    prefer :class:`~fynance.models.tcn.TemporalConvNet` or
+    :class:`~fynance.models.transformer.Transformer`.
 
     Parameters
     ----------
@@ -50,9 +62,13 @@ class RecurrentNeuralNetwork(_OutputLayerMixin, _RecurrentBase):  # type: ignore
         - If it's an integer, respectively dimension of inputs and outputs.
     drop : float, optional
         Probability of an element to be zeroed.
+    bias : bool, optional
+        If ``True`` (default), the linear layers learn an additive bias.
     forward_activation, hidden_activation : torch.nn.Module, optional
-        Activation functions, default is respectively Softmax and Tanh
-        function.
+        Activation functions, default is respectively Identity and Tanh
+        function. The output activation defaults to Identity so the cell
+        produces unconstrained regression outputs (pass ``nn.Softmax`` for
+        a probability-simplex output).
     hidden_state_size : int, optional
         Size of hidden states, default is the same size than input.
 
@@ -67,6 +83,18 @@ class RecurrentNeuralNetwork(_OutputLayerMixin, _RecurrentBase):  # type: ignore
     f_y, f_h : torch.nn.Module
         Respectively forward and hidden activation functions.
 
+    Examples
+    --------
+    >>> import torch
+    >>> from fynance.models.rnn import RecurrentNeuralNetwork
+    >>> _ = torch.manual_seed(0)
+    >>> model = RecurrentNeuralNetwork(4, 1, hidden_state_size=3)
+    >>> X = torch.zeros(5, 4)
+    >>> H = torch.zeros(5, 3)
+    >>> Y, H_new = model(X, H)
+    >>> Y.shape, H_new.shape
+    (torch.Size([5, 1]), torch.Size([5, 3]))
+
     See Also
     --------
     fynance.models.gru.GatedRecurrentUnit,
@@ -76,7 +104,7 @@ class RecurrentNeuralNetwork(_OutputLayerMixin, _RecurrentBase):  # type: ignore
 
     def __init__(
         self, X, y, drop=None, x_type=None, y_type=None, bias=True,
-        forward_activation=nn.Softmax, hidden_activation=nn.Tanh,
+        forward_activation=nn.Identity, hidden_activation=nn.Tanh,
         hidden_state_size=None,
     ):
         _RecurrentBase.__init__(

--- a/fynance/models/rolling.py
+++ b/fynance/models/rolling.py
@@ -9,6 +9,11 @@ window. The pattern enforces strict temporal ordering, eliminating
 lookahead bias and matching how a strategy would actually be retrained
 in production.
 
+Each step trains on ``X[t-n:t]`` and yields two slices: ``eval_set =
+slice(t-r, t)`` — the last ``r`` bars of the **training** window, used
+for an in-sample fit-quality check — and ``test_set = slice(t, t+s)`` —
+the next strictly out-of-sample window.
+
 A concrete :class:`RollMultiLayerPerceptron` combines this iterator
 with :class:`fynance.models.mlp.MultiLayerPerceptron`. The
 same pattern is applied to portfolio allocation in
@@ -17,7 +22,8 @@ same pattern is applied to portfolio allocation in
 Main entry points
 -----------------
 - :class:`_RollingBasis` — iterator that yields ``(eval_set,
-  test_set)`` slices and tracks training/evaluation/test losses.
+  test_set)`` slices (in-sample tail + out-of-sample window) and tracks
+  training/evaluation/test losses.
 - :class:`RollMultiLayerPerceptron` — walk-forward MLP, ready to use
   via :meth:`RollMultiLayerPerceptron.set_roll_period` and
   :meth:`RollMultiLayerPerceptron.run`.
@@ -27,7 +33,6 @@ Main entry points
 from __future__ import annotations
 
 # Built-in packages
-from multiprocessing import Process
 from typing import Callable
 
 # External packages
@@ -126,7 +131,9 @@ class _RollingBasis:
         end : int, optional
             Ending observation, default is last observation.
         roll_period : int, optional
-            Size of the rolling period, default equals ``test_period``.
+            Size of the rolling period, default equals ``test_period``. Must
+            not exceed ``train_period`` — the in-sample ``eval_set`` is the
+            last ``roll_period`` bars of the training window.
         eval_period : int, optional
             Size of the evaluating period (unused, kept for API compat).
         batch_size : int, optional
@@ -138,6 +145,12 @@ class _RollingBasis:
         -------
         _RollingBasis
 
+        Raises
+        ------
+        ValueError
+            If ``roll_period`` exceeds ``train_period`` (would push the
+            in-sample evaluation window outside the training window).
+
         """
         self.n = train_period
         self.s = test_period
@@ -145,8 +158,23 @@ class _RollingBasis:
         self.b = batch_size
         self.e = epochs
 
+        # Causality guards. The eval window is the last ``r`` bars of the
+        # training window (``slice(t - r, t)``), so a roll larger than the
+        # train length (``r > n``) would make the eval window reach outside
+        # the in-sample window. Combined with a negative ``t0`` it also turns
+        # the eval / train slices into negative indices that wrap to the tail
+        # of the array — i.e. silently leak FUTURE bars into training and
+        # evaluation. Reject ``r > n`` and clamp the window start to ``>= 0``.
+        if self.r > self.n:
+            raise ValueError(
+                f"roll_period ({self.r}) must not exceed train_period "
+                f"({self.n}): the evaluation window is the last roll_period "
+                "bars of the training window, so r > n would reach outside "
+                "the in-sample window (lookahead leak)."
+            )
+
         self.T = self.T if end is None else min(self.T, end)
-        self.t0 = max(self.n - self.r, min(start, self.T - self.n - self.s))
+        self.t0 = max(0, self.n - self.r, min(start, self.T - self.n - self.s))
         self.n_iter = (self.T - self.t0 - self.s) // self.r * self.e
         self.log = []
 
@@ -174,6 +202,9 @@ class _RollingBasis:
             self.t += self.r
             self.t_idx = np.arange(self.t - self.n, self.t)
 
+        # ``eval_set`` is the last ``r`` bars of the *training* window
+        # (in-sample): an enforced ``r <= n`` keeps it inside ``[t - n, t)``.
+        # ``test_set`` is the next, strictly out-of-sample window.
         eval_set = slice(self.t - self.r, self.t)
         test_set = slice(self.t, self.t + self.s)
 
@@ -334,6 +365,7 @@ class _RollingBasis:
 
     def _training(self):
         loss_epoch = 0.
+        n_batches = 0
         np.random.shuffle(self.t_idx)
         for t in range(0, self.n, self.b):
             s = min(t + self.b, self.n)
@@ -343,8 +375,14 @@ class _RollingBasis:
                 y=self.f(self.y[train_slice]),
             )
             loss_epoch += lo.item()
+            n_batches += 1
 
-        self.loss_train[self.i] = loss_epoch / s
+        # ``lo`` is already a per-batch *mean* loss, so the epoch loss is the
+        # mean over batches — divide by the batch count, not by the train
+        # length ``n`` (the stale ``s`` from the last batch) which made the
+        # reported loss depend on the batch size and span a different scale
+        # than a single-batch loss.
+        self.loss_train[self.i] = loss_epoch / n_batches
 
     def run(self, backtest_plot=True, backtest_kpi=True, figsize=(9, 6),
             func=np.sign):
@@ -371,7 +409,6 @@ class _RollingBasis:
 
         self.bnn = BacktestNeuralNet(figsize)
         self.log = []
-        p_print = None
 
         for eval_set, test_set in self:
             self._training()
@@ -398,14 +435,13 @@ class _RollingBasis:
                     r[test_set], func(self.y_test[test_set]), v0=v0
                 )
 
+            # Render in-process. A forked multiprocessing.Process is not
+            # fork-safe here: it would share live torch tensors and the
+            # matplotlib figure across the fork. Display is cheap and purely
+            # a side effect, so do it inline.
             if self.t > self.t0 + self.r:
-                if p_print is None or not p_print.is_alive():
-                    p_print = Process(
-                        target=self._print,
-                        args=(self.t, self.i, r, y_perf, func,
-                              backtest_plot, backtest_kpi)
-                    )
-                    p_print.start()
+                self._print(self.t, self.i, r, y_perf, func,
+                            backtest_plot, backtest_kpi)
 
         self._print(self.t, self.i, r, y_perf, func, backtest_plot,
                     backtest_kpi)
@@ -434,8 +470,10 @@ class _RollingBasis:
         pct = t - self.n - self.s
         pct = pct / (self.T - self.n - self.T % self.s)
         txt = '{:5.2%} is done | '.format(pct)
-        txt += 'Eval loss is {:5.2} | '.format(self.loss_eval[-1])
-        txt += 'Test loss is {:5.2} | '.format(self.loss_test[-1])
+        # Use the current iteration index ``self.i`` — ``[-1]`` is the last
+        # array slot, which stays 0 until the final iteration.
+        txt += 'Eval loss is {:5.2} | '.format(self.loss_eval[self.i])
+        txt += 'Test loss is {:5.2} | '.format(self.loss_test[self.i])
         print(txt, end='\r')
 
     def _display_plot_loss(self, bnn, i):
@@ -459,10 +497,12 @@ class RollMultiLayerPerceptron(MultiLayerPerceptron, _RollingBasis):
 
     End-to-end walk-forward training pipeline for an MLP: at each step
     the model is fitted on a sliding window of length ``n``, evaluated
-    on the previous out-of-sample slice, then used to predict the next
-    slice. Losses (train, eval, test) and out-of-sample predictions are
-    accumulated step by step in ``self.log``, ``self.y_eval`` and
-    ``self.y_test`` for downstream analysis.
+    on the last ``r`` bars of that **training** window (the in-sample
+    ``eval_set = slice(t-r, t)``, a fit-quality check — *not* out-of-sample
+    data), then used to predict the next, strictly out-of-sample slice
+    ``test_set = slice(t, t+s)``. Losses (train, eval, test) and
+    out-of-sample predictions are accumulated step by step in ``self.log``,
+    ``self.y_eval`` and ``self.y_test`` for downstream analysis.
 
     Use :meth:`set_roll_period` to configure window sizes and batch
     options, then :meth:`run` to execute the loop. ``run`` can also

--- a/fynance/portfolio/allocation.py
+++ b/fynance/portfolio/allocation.py
@@ -590,7 +590,7 @@ def MDP(
 
     # Set function to minimze
     def f_max_divers_weights(w):
-        return - diversified_ratio(X, W=w).flatten()
+        return -diversified_ratio(X, W=w)
 
     # Set inital weights
     if w0 is None:

--- a/fynance/portfolio/allocation.py
+++ b/fynance/portfolio/allocation.py
@@ -93,7 +93,7 @@ def ERC(
     X : array_like
         Each column is a series of price or return's asset.
     w0 : array_like, optional
-        Initial weights to maximize.
+        Initial weights for the optimizer.
     up_bound, low_bound : float, optional
         Respectively maximum and minimum values of weights, such that low_bound
         :math:`\leq w_i \leq` up_bound :math:`\forall i`. Default is 0 and 1.
@@ -109,8 +109,21 @@ def ERC(
 
     """
     T, N = X.shape
-    SIGMA = np.cov(X, rowvar=False)
+    SIGMA = np.atleast_2d(np.cov(X, rowvar=False))
+    if N == 1:
+        return np.ones([1, 1])
+
     up_bound = max(up_bound, 1 / N)
+    # The risk-contribution surrogate is quartic in the covariance, so on
+    # return-scale inputs (values ~1e-4) it collapses to ~1e-16, far below
+    # SLSQP's default ftol and the optimizer stops at the 1/N start. Rescale
+    # the covariance to unit trace so the objective is O(1) regardless of the
+    # input scale; this leaves the argmin (the weights) unchanged.
+    scale = np.trace(SIGMA) / N
+    if scale <= 0:
+        return np.ones([N, 1]) / N
+
+    SIGMA = SIGMA / scale
 
     def f_ERC(w):
         w = w.reshape([N, 1])
@@ -129,7 +142,8 @@ def ERC(
         w0,
         method='SLSQP',
         constraints=[const_sum],
-        bounds=const_ind
+        bounds=const_ind,
+        options={'ftol': 1e-12, 'maxiter': 1000},
     )
 
     return result.x.reshape([N, 1])
@@ -307,10 +321,13 @@ def HRP(
     """
     X = np.asarray(X, dtype=np.float64)
     T, N = X.shape
+    if N == 1:
+        return np.ones([1, 1])
+
     up_bound = max(up_bound, 1.0 / N)
     low_bound = min(low_bound, 1.0 / N)
 
-    mat_cov = np.cov(X, rowvar=False)
+    mat_cov = np.atleast_2d(np.cov(X, rowvar=False))
     diag_cov = np.sqrt(np.diag(mat_cov))
     outer_diag = np.outer(diag_cov, diag_cov)
     with np.errstate(invalid='ignore', divide='ignore'):
@@ -358,8 +375,11 @@ def IVP(
     X : array_like
         Each column is a price or return's asset series.
     normalize : bool, optional
-        If True normalize the weights such that :math:`\sum_{i=1}^{N} w_i = 1`
-        and :math:`0 \leq w_i \leq 1`. Default is False.
+        If True clip the weights to the ``[low_bound, up_bound]`` box and
+        renormalize them to sum to one (via :func:`_normalize`), preserving
+        the inverse-variance ordering. If False (default) return the raw
+        inverse-variance weights :math:`w_i \propto 1 / \sigma_i^2`, which
+        already sum to one and lie in :math:`[0, 1]`.
     low_bound, up_bound : float, optional
         Respectively minimum and maximum values of weights, such that low_bound
         :math:`\leq w_i \leq` up_bound :math:`\forall i`. Default is 0 and 1.
@@ -374,20 +394,19 @@ def IVP(
     .. [3] https://en.wikipedia.org/wiki/Inverse-variance_weighting
 
     """
-    mat_cov = np.cov(X, rowvar=False)
+    mat_cov = np.atleast_2d(np.cov(X, rowvar=False))
+    N = mat_cov.shape[0]
+    if N == 1:
+        return np.ones([1, 1])
+
     w = _get_IVP(mat_cov)
-    up_bound = max(up_bound, 1 / X.shape[1])
-    low_bound = min(low_bound, 1 / X.shape[1])
 
     if normalize:
-        w = w - np.min(w)
-        w = w / np.sum(w)
+        up_bound = max(up_bound, 1 / N)
+        low_bound = min(low_bound, 1 / N)
+        w = _normalize(w, up_bound=up_bound, low_bound=low_bound)
 
-    #    return w.reshape([mat_cov.shape[0], 1])
-    w = _normalize(w, up_bound=up_bound, low_bound=low_bound)
-    # w = w * (up_bound - low_bound) + low_bound
-
-    return w.reshape([mat_cov.shape[0], 1])
+    return w.reshape([N, 1])
 
 
 # =========================================================================== #
@@ -443,16 +462,16 @@ def MVP(
     HRP
 
     """
-    mat_cov = np.cov(X, rowvar=False)
+    mat_cov = np.atleast_2d(np.cov(X, rowvar=False))
+    if mat_cov.shape[0] == 1:
+        return np.ones([1, 1])
+
     # Inverse variance matrix
     try:
         iv = np.linalg.inv(mat_cov)
 
     except np.linalg.LinAlgError:
-        try:
-            iv = np.linalg.pinv(mat_cov)
-        except np.linalg.LinAlgError:
-            raise
+        iv = np.linalg.pinv(mat_cov)
 
     e = np.ones([iv.shape[0], 1])
     w = (iv @ e) / (e.T @ iv @ e)
@@ -497,7 +516,7 @@ def MVP_uc(
     X : array_like
         Each column is a series of price or return's asset.
     w0 : array_like, optional
-        Initial weights to maximize.
+        Initial weights for the optimizer.
     up_bound, low_bound : float, optional
         Respectively maximum and minimum values of weights, such that low_bound
         :math:`\leq w_i \leq` up_bound :math:`\forall i`. Default is 0 and 1.
@@ -508,9 +527,21 @@ def MVP_uc(
         Weights that minimize the variance of the portfolio.
 
     """
-    mat_cov = np.cov(X, rowvar=False)
+    mat_cov = np.atleast_2d(np.cov(X, rowvar=False))
     N = X.shape[1]
+    if N == 1:
+        return np.ones([1, 1])
+
     up_bound = max(up_bound, 1 / N)
+    # On return-scale inputs the portfolio variance w'Sigma w is ~1e-4 or
+    # smaller, which can sit below SLSQP's default ftol so the optimizer stops
+    # at the 1/N start. Rescale the covariance to unit trace so the objective
+    # is O(1); the variance-minimizing weights are invariant to this scaling.
+    scale = np.trace(mat_cov) / N
+    if scale <= 0:
+        return np.ones([N, 1]) / N
+
+    mat_cov = mat_cov / scale
 
     def f_MVP(w):
         w = w.reshape([N, 1])
@@ -528,7 +559,8 @@ def MVP_uc(
         w0,
         method='SLSQP',
         constraints=[const_sum],
-        bounds=const_ind
+        bounds=const_ind,
+        options={'ftol': 1e-12, 'maxiter': 1000},
     )
 
     return result.x.reshape([N, 1])
@@ -564,7 +596,7 @@ def MDP(
     X : array_like
         Each column is a series of price or return's asset.
     w0 : array_like, optional
-        Initial weights to maximize.
+        Initial weights for the optimizer.
     up_bound, low_bound : float, optional
         Respectively maximum and minimum values of weights, such that low_bound
         :math:`\leq w_i \leq` up_bound :math:`\forall i`. Default is 0 and 1.
@@ -586,6 +618,9 @@ def MDP(
 
     """
     T, N = X.shape
+    if N == 1:
+        return np.ones([1, 1])
+
     up_bound = max(up_bound, 1 / N)
 
     # Set function to minimze
@@ -780,7 +815,9 @@ def _perf_alloc(X: NDArray[np.float64], w: NDArray[np.float64], drift: bool = Tr
 
 
 def _normalize(w: NDArray[np.float64], low_bound: float = 0., up_bound: float = 1., sum_w: float = 1., max_iter: int = 1000) -> NDArray[np.float64]:
-    # Iterative algorithm to set bounds
+    # Iterative algorithm to set bounds. Copy the input so the caller's array
+    # is never mutated in place.
+    w = np.array(w, dtype=np.float64)
     if up_bound < sum_w / w.size or low_bound > sum_w / w.size:
 
         raise ValueError('Low or up bound exceeded sum weight constraint.')

--- a/fynance/portfolio/sizing.py
+++ b/fynance/portfolio/sizing.py
@@ -73,7 +73,7 @@ def vol_target(
 
     Leverage that scales inversely with the *past* realized volatility so the
     strategy targets a constant annualized volatility ``target_vol``:
-    :math:`\\ell_t = target\\_vol / \\hat\\sigma_t`, capped at ``max_leverage``.
+    :math:`\ell_t = target\_vol / \hat\sigma_t`, capped at ``max_leverage``.
     Strictly causal — uses :func:`fynance.features.indicators.realized_volatility`.
 
     Parameters
@@ -109,7 +109,7 @@ def transaction_cost(
     r""" Per-step transaction cost from weight turnover.
 
     Cost at each step is ``fee`` times the traded amount (turnover):
-    :math:`c_t = fee \\cdot \\sum_i |w_{t,i} - w_{t-1,i}|`, with the first step
+    :math:`c_t = fee \cdot \sum_i |w_{t,i} - w_{t-1,i}|`, with the first step
     charging the initial position.
 
     Parameters

--- a/fynance/research/compare.py
+++ b/fynance/research/compare.py
@@ -37,7 +37,8 @@ def leaderboard(
     experiments : list of Experiment
         The runs to rank.
     sort_by : str
-        Metric key to sort on (missing values sink to the bottom).
+        Metric key to sort on. Rows missing the metric **or** holding a NaN for
+        it sink to the bottom of the ranking.
     descending : bool
         Higher is better when True.
 
@@ -51,8 +52,18 @@ def leaderboard(
         {"name": e.name, **{k: float(v) for k, v in e.metrics.items()}}
         for e in experiments
     ]
+    # NaN must rank as "worst", not float to the top: a present-but-NaN metric
+    # is treated like a missing value (the docstring's promise).
     worst = float("-inf") if descending else float("inf")
-    rows.sort(key=lambda r: r.get(sort_by, worst), reverse=descending)  # type: ignore[arg-type]
+
+    def _key(row: dict[str, float | str]) -> float:
+        value = row.get(sort_by, worst)
+        if isinstance(value, float) and np.isnan(value):
+            return worst
+
+        return value  # type: ignore[return-value]
+
+    rows.sort(key=_key, reverse=descending)
 
     return rows
 

--- a/fynance/research/experiment.py
+++ b/fynance/research/experiment.py
@@ -15,7 +15,7 @@ to a caller-provided ``output_dir``.
 from __future__ import annotations
 
 import json
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, fields
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -85,8 +85,25 @@ class Experiment:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Experiment:
-        """ Rebuild an :class:`Experiment` from a :meth:`to_dict` mapping. """
-        return cls(**data)
+        """ Rebuild an :class:`Experiment` from a :meth:`to_dict` mapping.
+
+        Unknown keys are **ignored** rather than raising, so an artifact written
+        by a newer fynance (carrying extra fields) still loads on an older one.
+
+        Parameters
+        ----------
+        data : dict
+            Mapping produced by :meth:`to_dict` (extra keys tolerated).
+
+        Returns
+        -------
+        Experiment
+            The rebuilt experiment.
+
+        """
+        known = {f.name for f in fields(cls)}
+
+        return cls(**{k: v for k, v in data.items() if k in known})
 
     def save(self, output_dir: str | Path, *, name: str | None = None) -> Path:
         """ Write ``<output_dir>/<name>/experiment.json`` and return its path.
@@ -117,7 +134,32 @@ class Experiment:
 
     @classmethod
     def load(cls, path: str | Path) -> Experiment:
-        """ Load an :class:`Experiment` from an ``experiment.json`` file. """
-        data = json.loads(Path(path).read_text(encoding="utf-8"))
+        """ Load an :class:`Experiment` from an ``experiment.json`` file.
+
+        Parameters
+        ----------
+        path : str or pathlib.Path
+            Path to the ``experiment.json`` artifact.
+
+        Returns
+        -------
+        Experiment
+            The loaded experiment.
+
+        Raises
+        ------
+        ValueError
+            If the file is not valid JSON (corrupt or truncated) — re-raised
+            with the offending path for a clear diagnostic.
+
+        """
+        path = Path(path)
+        text = path.read_text(encoding="utf-8")
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"corrupt or truncated experiment artifact at {path}: {exc}"
+            ) from exc
 
         return cls.from_dict(data)

--- a/fynance/research/guards.py
+++ b/fynance/research/guards.py
@@ -58,18 +58,28 @@ def permutation_test(
     the asset's returns (which destroys any temporal structure). If the strategy
     scores as well on shuffled data as on the real data, its edge is not real.
 
+    The price series must be strictly positive: the null is built on log-returns
+    (``np.diff(np.log(prices))``), so a non-positive price would yield ``nan`` /
+    ``-inf`` returns.
+
+    Each run is seeded with a **distinct** seed derived from ``seed`` (the
+    observed run and every permutation), so a stochastic strategy does not see
+    the *same* model RNG draws on every path — which would bias the null
+    variance. The whole test stays reproducible for a fixed ``seed``.
+
     Parameters
     ----------
     strategy : fynance.strategy.Strategy
         The strategy to evaluate.
     data : PriceSeries or array-like
-        Price series.
+        Strictly positive price series (``np.log`` is taken).
     metric : str
         Metric key from the run summary (default ``"sharpe"``).
     n_permutations : int
         Number of shuffles forming the null distribution.
     seed : int
-        Seed for the shuffles and the runs.
+        Master seed for the shuffles and the runs (per-run seeds are derived
+        from it, so the test is fully reproducible).
 
     Returns
     -------
@@ -85,8 +95,13 @@ def permutation_test(
     log_ret = np.diff(np.log(prices))
     s0 = float(prices[0])
 
+    # Draw distinct per-run seeds from the master seed so stochastic strategies
+    # do not replay identical RNG draws on every path (which biases the null).
+    seed_rng = np.random.default_rng(seed)
+    run_seeds = seed_rng.integers(0, 2**31 - 1, size=n_permutations + 1)
+
     observed = run_experiment(strategy, prices, name="observed",
-                              seed=seed).metrics[metric]
+                              seed=int(run_seeds[0])).metrics[metric]
 
     rng = np.random.default_rng(seed)
     null = np.empty(n_permutations, dtype=np.float64)
@@ -94,7 +109,7 @@ def permutation_test(
         shuffled = rng.permutation(log_ret)
         path = s0 * np.exp(np.concatenate([[0.0], np.cumsum(shuffled)]))
         null[i] = run_experiment(strategy, path, name="perm",
-                                 seed=seed).metrics[metric]
+                                 seed=int(run_seeds[i + 1])).metrics[metric]
 
     # Smoothed p-value (never exactly 0): (#{null >= observed} + 1) / (n + 1).
     p_value = float((np.sum(null >= observed) + 1) / (n_permutations + 1))
@@ -167,7 +182,9 @@ def deflated_sharpe_ratio(
     Parameters
     ----------
     sr : float
-        Observed (non-annualized) Sharpe ratio of the selected strategy.
+        Observed **per-observation** (non-annualized) Sharpe ratio of the
+        selected strategy. An annualized Sharpe must be divided by
+        ``sqrt(period)`` first, or the DSR saturates to ~1.
     n_obs : int
         Number of return observations.
     n_trials : int
@@ -175,7 +192,11 @@ def deflated_sharpe_ratio(
     skew, kurt : float
         Skewness / kurtosis of the selected strategy's returns.
     sr_variance : float
-        Variance of the Sharpe estimates **across the trials**.
+        Variance of the (per-observation) Sharpe estimates **across the
+        trials**. The default ``1.0`` is a conservative placeholder — it
+        overstates the expected-maximum benchmark and so understates the DSR;
+        pass the empirical variance of the trial Sharpes whenever available
+        (as :meth:`fynance.research.Ledger.deflated_sharpe` does).
 
     Returns
     -------

--- a/fynance/research/ledger.py
+++ b/fynance/research/ledger.py
@@ -56,8 +56,37 @@ class Ledger:
         self.root = Path(root)
 
     def append(self, experiment: Experiment) -> Path:
-        """ Persist ``experiment`` under the ledger root; return its json path. """
+        """ Persist ``experiment`` under the ledger root; return its json path.
+
+        The store is **append-only**: appending an experiment whose ``name``
+        already exists raises :class:`FileExistsError` rather than silently
+        overwriting the prior run. Overwriting would undercount
+        :attr:`n_trials` and so deflate the multiple-testing correction fed to
+        the deflated Sharpe ratio. Pick a unique ``name`` (e.g. version-suffix
+        a re-run) before appending.
+
+        Parameters
+        ----------
+        experiment : Experiment
+            The experiment to persist.
+
+        Returns
+        -------
+        pathlib.Path
+            Path to the written ``experiment.json``.
+
+        Raises
+        ------
+        FileExistsError
+            If an experiment with the same ``name`` is already stored.
+
+        """
         self.root.mkdir(parents=True, exist_ok=True)
+        if (self.root / experiment.name / "experiment.json").exists():
+            raise FileExistsError(
+                f"experiment {experiment.name!r} already in the ledger; the "
+                f"store is append-only — use a unique name for a re-run"
+            )
 
         return experiment.save(self.root)
 
@@ -89,15 +118,50 @@ class Ledger:
         Uses the ledger's :attr:`n_trials` as the number of trials and the
         dispersion of the stored Sharpe metrics as the trial variance, so a
         selected strategy is judged against the multiple testing it came from.
+
+        The stored ``sharpe`` metric is **annualized** (by the ``period`` used
+        at run time, recorded in ``spec``), whereas
+        :func:`~fynance.research.deflated_sharpe_ratio` expects a
+        **per-observation** Sharpe (it scales by ``sqrt(n_obs - 1)``
+        internally). This method therefore de-annualizes both the selected
+        strategy's Sharpe and the across-trial variance before the call:
+        ``sr_obs = sr_annual / sqrt(period)`` and ``var_obs = var_annual /
+        period``. Skipping this de-annualization saturates the DSR to ~1
+        (a modest per-period edge looks certain), defeating the guard.
+
+        Parameters
+        ----------
+        experiment : Experiment
+            The selected experiment to deflate.
+        metric : str
+            Metric key holding the (annualized) Sharpe (default ``"sharpe"``).
+
+        Returns
+        -------
+        float
+            Deflated Sharpe ratio in ``[0, 1]``.
+
         """
-        sharpes = [float(e.metrics[metric]) for e in self.load()
-                   if metric in e.metrics]
+        period = self._period(experiment)
+        sharpes = [float(e.metrics[metric]) / np.sqrt(self._period(e))
+                   for e in self.load() if metric in e.metrics]
         sr_variance = float(np.var(sharpes)) if len(sharpes) > 1 else 1.0
 
         n_obs = len(experiment.series["returns"]) if (
             experiment.series and experiment.series.get("returns")) else 0
 
         return deflated_sharpe_ratio(
-            float(experiment.metrics[metric]), n_obs, max(self.n_trials, 1),
-            sr_variance=sr_variance,
+            float(experiment.metrics[metric]) / np.sqrt(period), n_obs,
+            max(self.n_trials, 1), sr_variance=sr_variance,
         )
+
+    @staticmethod
+    def _period(experiment: Experiment) -> float:
+        """ Annualization factor used to compute ``experiment``'s Sharpe. """
+        period = experiment.spec.get("period") if experiment.spec else None
+        try:
+            value = float(period)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return 252.0
+
+        return value if value > 0.0 else 252.0

--- a/fynance/research/runner.py
+++ b/fynance/research/runner.py
@@ -63,7 +63,14 @@ def _callable_name(fn: Any) -> str | None:
 
 
 def _seed_everything(seed: int) -> None:
-    """ Seed numpy (and torch if present) for reproducibility. """
+    """ Seed the global numpy (and torch) RNGs for reproducibility.
+
+    This mutates process-global RNG state via :func:`numpy.random.seed` so that
+    legacy strategies / models drawing from the global numpy RNG run
+    deterministically. Callers that need *independent* runs (e.g.
+    :func:`permutation_test`) must pass a **distinct** ``seed`` per run rather
+    than reusing one — otherwise every run replays the same global draws.
+    """
     np.random.seed(seed)
     try:  # torch is optional at call time
         import torch
@@ -145,18 +152,27 @@ def run_experiment(
     """
     _seed_everything(seed)
 
-    if costs is not None:
-        strategy.cost = costs
-
     prices = _to_array(data)
     n = prices.shape[0]
 
-    if walk_forward is not None:
-        target = np.zeros(n) if y is None else np.asarray(y)  # preserve dtype
-        result = strategy.run_walk_forward(data, target, **walk_forward, X=X)
+    # Overriding the cost model must not leak past this run: save and restore
+    # the strategy's own cost in a ``finally`` so a later run (or a sibling
+    # iteration of a permutation loop sharing the strategy) is unaffected.
+    _sentinel = object()
+    original_cost: Any = getattr(strategy, "cost", _sentinel)
+    try:
+        if costs is not None:
+            strategy.cost = costs
 
-    else:
-        result = strategy.run(data, y, X=X)
+        if walk_forward is not None:
+            target = np.zeros(n) if y is None else np.asarray(y)  # preserve dtype
+            result = strategy.run_walk_forward(data, target, **walk_forward, X=X)
+
+        else:
+            result = strategy.run(data, y, X=X)
+    finally:
+        if costs is not None and original_cost is not _sentinel:
+            strategy.cost = original_cost
 
     metrics = result.summary(period=period)
 

--- a/fynance/research/synthetic.py
+++ b/fynance/research/synthetic.py
@@ -83,8 +83,10 @@ def regime_switching(
 ) -> PriceSeries:
     """ Markov regime-switching price path.
 
-    At each step the active regime switches (to a uniformly-drawn regime) with
-    probability ``p_switch``; log-returns are then drawn from the active
+    The initial regime is drawn uniformly (rather than always starting in
+    regime 0, which biased short paths toward the first regime). At each
+    subsequent step the active regime switches (to a uniformly-drawn regime)
+    with probability ``p_switch``; log-returns are then drawn from the active
     regime's ``(mu, sigma)``. The varying volatility makes it a natural input
     for :func:`fynance.detect_regimes`.
 
@@ -122,7 +124,9 @@ def regime_switching(
 
     steps = max(n - 1, 0)
     states: NDArray[np.int_] = np.empty(steps, dtype=np.int_)
-    state = 0
+    # Draw the initial regime uniformly so short paths are not biased toward
+    # regime 0; subsequent steps switch with probability ``p_switch``.
+    state = int(rng.integers(0, k))
     for t in range(steps):
         if rng.random() < p_switch:
             state = int(rng.integers(0, k))

--- a/fynance/signal/mappers.py
+++ b/fynance/signal/mappers.py
@@ -11,6 +11,11 @@ The **anti-churn** mappers — :func:`ema_smooth`, :func:`deadband`,
 strictly causal; compose them to cut turnover where transaction costs would
 otherwise eat the edge (high fees / high frequency).
 
+Initial-state convention: the stateful mappers seed their running state from
+the first input (``out[0] == pred[0]``) rather than from zero, so the first
+bar is passed through unchanged and the smoothing/holding logic starts from a
+realistic position rather than an artificial flat one.
+
 """
 
 from __future__ import annotations
@@ -75,12 +80,28 @@ def rank(pred: NDArray, top: int, bottom: int) -> NDArray[np.float64]:
     pred : array-like, shape (T, n_assets)
         Cross-sectional predictions.
     top, bottom : int
-        Number of assets in the long and short legs.
+        Number of assets in the long and short legs. Both must be ``>= 0`` and
+        ``top + bottom`` must not exceed ``n_assets`` -- otherwise the legs
+        would overlap and the long assignment would silently overwrite the
+        short, breaking dollar-neutrality.
 
     Returns
     -------
     numpy.ndarray
         Weights of shape ``(T, n_assets)``.
+
+    Raises
+    ------
+    ValueError
+        If ``pred`` is not 2-D, if ``top`` or ``bottom`` is negative, or if
+        ``top + bottom`` exceeds the number of assets.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> w = rank(np.array([[1.0, 2.0, 3.0, 4.0]]), top=1, bottom=1)
+    >>> w.sum()  # dollar-neutral
+    0.0
 
     """
     p = np.asarray(pred, dtype=np.float64)
@@ -88,6 +109,21 @@ def rank(pred: NDArray, top: int, bottom: int) -> NDArray[np.float64]:
     if p.ndim != 2:
 
         raise ValueError("rank expects a 2-D (T, n_assets) prediction")
+
+    if top < 0 or bottom < 0:
+
+        raise ValueError(
+            f"top and bottom must be >= 0, got top={top}, bottom={bottom}"
+        )
+
+    n_assets = p.shape[1]
+
+    if top + bottom > n_assets:
+
+        raise ValueError(
+            f"overlapping legs: top + bottom = {top + bottom} > "
+            f"n_assets = {n_assets}; the long and short legs would overlap"
+        )
 
     weights = np.zeros_like(p)
     order = np.argsort(p, axis=1)

--- a/fynance/strategy/strategy.py
+++ b/fynance/strategy/strategy.py
@@ -160,6 +160,17 @@ class Strategy:
         positions are stitched together and backtested. Strictly no-lookahead.
         This per-window refit *is* the rolling-NN pattern when ``model`` is a net.
 
+        .. note::
+           The **first realized return of every test block is discarded** (set
+           to ``0``): within a block the return at bar ``k`` is computed from
+           prices ``k-1`` and ``k``, so the opening bar has no in-block prior
+           and earns nothing. With the default ``step == test`` this drops one
+           bar per block (roughly ``1 / test`` of the out-of-sample sample);
+           the dropped return is the gap return across the block join, which
+           would require carrying the previous block's closing position to
+           realize causally. This conservative choice avoids any cross-block
+           lookahead at the cost of a slightly truncated OOS sample.
+
         Parameters
         ----------
         data : PriceSeries or array-like
@@ -211,8 +222,10 @@ class Strategy:
 
             pos = np.asarray(self.signal(preds), dtype=np.float64).reshape(-1)
 
-            # Return realized over each test step (causal: position at t earns r_t
-            # within the OOS block; the engine applies the one-step shift).
+            # Return realized over each test step (causal: position at t earns
+            # r_t within the OOS block; the engine applies the one-step shift).
+            # The opening bar has no in-block prior price, so its return is
+            # discarded (NaN -> 0 below). See the method docstring note.
             block = prices[te]
             ret = np.empty(block.shape[0])
             ret[0] = np.nan

--- a/fynance/tests/backtest/test_backtest.py
+++ b/fynance/tests/backtest/test_backtest.py
@@ -101,3 +101,21 @@ def test_set_text_stats_no_strategies(synthetic_returns):
     txt = set_text_stats(synthetic_returns)
     assert isinstance(txt, str)
     assert 'Performance' in txt
+
+
+def test_set_text_stats_underly_is_log_returns():
+    # Documented convention: `underly` is a LOG-RETURNS series, reconstructed
+    # internally as exp(cumsum(underly)). A constant positive log-return must
+    # yield a positive underlying performance line; the same series with the
+    # sign flipped (a losing path) must yield a negative one.
+    period = 252
+    up = np.full(period, np.log(1.001))      # +0.1% compounded each step
+    down = -up
+    txt_up = set_text_stats(up, period=period, accur=False, vol=False,
+                            sharp=False, calma=False)
+    txt_down = set_text_stats(down, period=period, accur=False, vol=False,
+                              sharp=False, calma=False)
+    # A rising log-return path -> positive annualized performance ('+' or no '-')
+    assert '-' not in txt_up.split('Underlying')[1].split('\n')[0]
+    # A falling path -> negative performance.
+    assert '-' in txt_down.split('Underlying')[1].split('\n')[0]

--- a/fynance/tests/backtest/test_engine.py
+++ b/fynance/tests/backtest/test_engine.py
@@ -69,3 +69,49 @@ def test_two_asset_book():
 def test_returns_result_type():
     res = backtest(np.array([0.01, 0.02]), np.array([1.0, 1.0]))
     assert isinstance(res, BacktestResult)
+
+
+def test_prices_input_cost_turnover_timing():
+    # On a prices input the engine drops the first position (it predates the
+    # first return). The cost model must still see the full book so the initial
+    # trade is charged once and a *constant* book then incurs no further cost.
+    prices = np.array([100.0, 110.0, 99.0, 108.9])
+    positions = np.ones(prices.size)          # constant full long
+    cost = ProportionalCost(fee=0.01)
+    res = backtest(prices, positions, cost=cost, returns_input=False, shift=True)
+    # 3 returns; only the initial entry is charged, no spurious re-entry.
+    assert res.costs.shape == res.returns.shape
+    assert np.allclose(res.costs, [0.01, 0.0, 0.0])
+
+
+def test_prices_input_cost_matches_returns_input():
+    # The prices path and the equivalent returns path must agree on cost timing.
+    prices = np.array([100.0, 110.0, 99.0, 108.9, 120.0])
+    positions = np.array([1.0, 1.0, -1.0, -1.0, 0.0])
+    cost = ProportionalCost(fee=0.02)
+
+    res_p = backtest(prices, positions, cost=cost,
+                     returns_input=False, shift=True)
+
+    returns = prices[1:] / prices[:-1] - 1.0
+    # Equivalent returns-input call uses the same surviving positions and the
+    # full book (including the dropped first entry) as the cost reference.
+    res_r = backtest(returns, positions[1:], cost=cost,
+                     returns_input=True, shift=True)
+    expected_costs = cost(positions[:-1])      # turnover into earning positions
+    assert np.allclose(res_p.costs, expected_costs)
+    assert np.allclose(res_p.gross_returns, res_r.gross_returns)
+
+
+def test_prices_input_cost_preserves_no_lookahead():
+    # Re-assert causality on the prices+cost path (no regression of the shift).
+    prices = np.array([100.0, 101.0, 102.0, 99.0, 105.0, 110.0])
+    positions = np.array([1.0, -1.0, 1.0, -1.0, 1.0, -1.0])
+    cost = ProportionalCost(fee=0.01)
+    base = backtest(prices, positions, cost=cost,
+                    returns_input=False, shift=True).equity.copy()
+    pert = prices.copy()
+    pert[-1] = 999.0                            # perturb the future only
+    res = backtest(pert, positions, cost=cost,
+                   returns_input=False, shift=True).equity
+    assert np.allclose(base[:-1], res[:-1])

--- a/fynance/tests/core/test_price_series.py
+++ b/fynance/tests/core/test_price_series.py
@@ -75,6 +75,64 @@ def test_to_returns_dropna_false_keeps_length():
     assert np.isnan(r.values[0])
 
 
+def test_to_returns_unknown_kind_raises():
+    ps = PriceSeries([100.0, 110.0, 99.0])
+    with pytest.raises(ValueError, match="unknown kind"):
+        ps.to_returns("geometric")
+
+
+@pytest.mark.parametrize("kind", ["pct", "log"])
+def test_to_returns_rejects_nonpositive_prices(kind):
+    # A zero or negative price would silently yield inf/-inf/nan.
+    with pytest.raises(ValueError, match="positive"):
+        PriceSeries([0.0, 10.0, 20.0]).to_returns(kind)
+    with pytest.raises(ValueError, match="positive"):
+        PriceSeries([100.0, -10.0, 20.0]).to_returns(kind)
+
+
+def test_to_returns_raw_allows_nonpositive_prices():
+    # raw differences are well-defined through zero / negatives.
+    r = PriceSeries([0.0, -5.0, 5.0]).to_returns("raw")
+    assert np.allclose(r.values, [-5.0, 10.0])
+
+
+def test_to_prices_inverts_returns_and_resets_index():
+    ps = PriceSeries([100.0, 110.0, 99.0], index=[10, 11, 12])
+    r = ps.to_returns("pct")               # index [11, 12]
+    rebuilt = r.to_prices(base=100.0, kind="pct")
+    assert np.allclose(rebuilt.values, [100.0, 110.0, 99.0])
+    # one extra leading point with no timestamp -> default 0..n index
+    assert np.array_equal(rebuilt.index, np.arange(len(rebuilt)))
+
+
+def test_to_prices_unknown_kind_raises():
+    r = PriceSeries([0.1, -0.1])
+    with pytest.raises(ValueError, match="unknown kind"):
+        r.to_prices(kind="geometric")
+
+
+def test_cumulative_equity_curve():
+    r = PriceSeries([0.1, -0.1, 0.05])
+    eq = r.cumulative()
+    assert np.allclose(eq.values, np.cumprod([1.1, 0.9, 1.05]))
+    # cumulative preserves the index
+    assert np.array_equal(eq.index, r.index)
+
+
+def test_apply_elementwise():
+    ps = PriceSeries([1.0, 2.0, 3.0], index=[7, 8, 9])
+    out = ps.apply(lambda x: x ** 2)
+    assert np.allclose(out.values, [1.0, 4.0, 9.0])
+    assert np.array_equal(out.index, [7, 8, 9])
+
+
+def test_apply_empty_series():
+    ps = PriceSeries([])
+    out = ps.apply(lambda x: x + 1.0)
+    assert len(out) == 0
+    assert out.values.dtype == np.float64
+
+
 def test_returns_prices_roundtrip():
     rng = np.random.default_rng(0)
     prices = 100.0 * np.cumprod(1.0 + rng.normal(0, 0.01, 50))

--- a/fynance/tests/data/test_align.py
+++ b/fynance/tests/data/test_align.py
@@ -3,12 +3,16 @@
 
 """ Tests for alignment and resampling. """
 
+# Built-in packages
+import datetime
+
 # Third-party packages
 import numpy as np
+import pytest
 
 # Local packages
 from fynance.core import PriceSeries
-from fynance.data import align
+from fynance.data import align, resample
 
 
 def test_outer_align_ffill_is_causal():
@@ -44,3 +48,58 @@ def test_ffill_leading_nan_stays_nan():
     assert np.isnan(out["b"].values[0])
     assert np.isnan(out["b"].values[1])
     assert out["b"].values[2] == 30.0
+
+
+# --- resample ----------------------------------------------------------------
+
+def _weekly_ps():
+    # Two calendar weeks (Wed/Thu then next Wed/Thu).
+    idx = np.array(
+        ["2020-01-01", "2020-01-02", "2020-01-08", "2020-01-09"],
+        dtype="datetime64[D]",
+    )
+    return PriceSeries([1.0, 2.0, 3.0, 4.0], index=idx, name="x")
+
+
+def test_resample_last_datetime64():
+    out = resample(_weekly_ps(), "1w", agg="last")
+    assert isinstance(out, PriceSeries)
+    assert np.allclose(out.values, [2.0, 4.0])     # last of each week
+    assert out.index.dtype.kind == "M"
+
+
+def test_resample_mean_datetime64():
+    out = resample(_weekly_ps(), "1w", agg="mean")
+    assert np.allclose(out.values, [1.5, 3.5])
+
+
+def test_resample_ohlc_datetime64():
+    out = resample(_weekly_ps(), "1w", agg="ohlc")
+    assert set(out) == {"open", "high", "low", "close"}
+    assert np.allclose(out["open"].values, [1.0, 3.0])
+    assert np.allclose(out["high"].values, [2.0, 4.0])
+    assert np.allclose(out["low"].values, [1.0, 3.0])
+    assert np.allclose(out["close"].values, [2.0, 4.0])
+
+
+def test_resample_unknown_agg_raises():
+    with pytest.raises(ValueError):
+        resample(_weekly_ps(), "1w", agg="median")
+
+
+def test_resample_integer_index_raises_clean_error():
+    # Default int index: previously a cryptic polars 'every' error.
+    ps = PriceSeries([1.0, 2.0, 3.0, 4.0], index=[0, 1, 2, 3])
+    with pytest.raises(ValueError, match="datetime64"):
+        resample(ps, "1w", agg="last")
+
+
+def test_resample_object_datetime_index_raises_clean_error():
+    # Object-dtype datetime.datetime index: previously an opaque polars error.
+    idx = np.array(
+        [datetime.datetime(2020, 1, 1), datetime.datetime(2020, 1, 2)],
+        dtype=object,
+    )
+    ps = PriceSeries([1.0, 2.0], index=idx)
+    with pytest.raises(ValueError, match="datetime64"):
+        resample(ps, "1w", agg="last")

--- a/fynance/tests/data/test_base.py
+++ b/fynance/tests/data/test_base.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for :func:`fynance.data.base.frame_to_series`. """
+
+# Third-party packages
+import numpy as np
+import pytest
+
+# Local packages
+from fynance.core import PriceSeries
+from fynance.data.base import frame_to_series
+
+
+def test_frame_to_series_explicit_value_col():
+    pl = pytest.importorskip("polars")
+    df = pl.DataFrame(
+        {
+            "date": ["2020-01-01", "2020-01-02"],
+            "a": [1.0, 2.0],
+            "b": [10.0, 20.0],
+        }
+    ).with_columns(pl.col("date").str.to_date())
+    # Explicit value_col selects a single column even though several exist.
+    out = frame_to_series(df, value_col="b")
+    assert isinstance(out, PriceSeries)
+    assert out.name == "b"
+    assert np.allclose(out.values, [10.0, 20.0])
+    # the temporal column is resolved as the index
+    assert out.index.dtype.kind == "M"
+
+
+def test_frame_to_series_explicit_value_col_no_index():
+    pl = pytest.importorskip("polars")
+    df = pl.DataFrame({"a": [1.0, 2.0, 3.0], "b": [4.0, 5.0, 6.0]})
+    out = frame_to_series(df, value_col="a")
+    assert isinstance(out, PriceSeries)
+    assert out.name == "a"
+    assert np.allclose(out.values, [1.0, 2.0, 3.0])
+
+
+def test_frame_to_series_multi_column_mapping():
+    pl = pytest.importorskip("polars")
+    df = pl.DataFrame({"a": [1.0, 2.0], "b": [10.0, 20.0]})
+    out = frame_to_series(df)
+    assert isinstance(out, dict)
+    assert set(out) == {"a", "b"}

--- a/fynance/tests/data/test_split.py
+++ b/fynance/tests/data/test_split.py
@@ -5,6 +5,7 @@
 
 # Third-party packages
 import numpy as np
+import pytest
 
 # Local packages
 from fynance.data import train_test_split, walk_forward
@@ -43,3 +44,30 @@ def test_walk_forward_no_future_leak():
     # every train index must be strictly before its test window
     for tr, te in walk_forward(60, train=20, test=5, step=5):
         assert np.all(tr < te[0])
+
+
+def test_walk_forward_rejects_purge_geq_train():
+    # purge >= train would silently yield EMPTY train windows.
+    with pytest.raises(ValueError, match="purge"):
+        list(walk_forward(20, train=5, test=3, purge=5))
+    with pytest.raises(ValueError, match="purge"):
+        list(walk_forward(20, train=5, test=3, purge=6))
+
+
+def test_walk_forward_rejects_nonpositive_train():
+    with pytest.raises(ValueError, match="train"):
+        list(walk_forward(20, train=0, test=3))
+
+
+def test_train_test_split_fraction_one_is_count():
+    # Documented: 1.0 is an absolute count (1), NOT the whole series.
+    train, test = train_test_split(100, test_size=1.0)
+    assert len(test) == 1
+    assert len(train) == 99
+
+
+def test_train_test_split_zero_is_empty_test():
+    # Documented: 0.0 is the absolute count 0 -> empty test set.
+    train, test = train_test_split(100, test_size=0.0)
+    assert len(test) == 0
+    assert len(train) == 100

--- a/fynance/tests/estimator/test_estimator.py
+++ b/fynance/tests/estimator/test_estimator.py
@@ -41,6 +41,31 @@ def test_loglikelihood_handles_zero_h():
     assert np.isfinite(loglikelihood(u, h))
 
 
+def test_loglikelihood_does_not_mutate_input_h():
+    # The zero-flooring must happen on a copy: the caller's h is preserved
+    # (in particular its zero entries are not overwritten by 1e-8).
+    u = np.array([0.0, 1.0, -1.0])
+    h = np.array([0.0, 1.0, 2.0])
+    h_before = h.copy()
+    loglikelihood(u, h)
+    assert np.array_equal(h, h_before)
+    assert h[0] == 0.0
+
+
+def test_loglikelihood_returns_negative_log_likelihood():
+    # Documented as the negative LL (a cost): it equals -(true Gaussian LL),
+    # which for non-degenerate residuals is a positive number.
+    rng = np.random.RandomState(0)
+    u = rng.randn(50)
+    h = np.abs(rng.randn(50)) + 0.5
+    true_ll = -0.5 * (
+        u.size * np.log(2 * np.pi)
+        + np.sum(np.log(np.square(h)))
+        + np.sum(np.square(u / h))
+    )
+    assert np.isclose(loglikelihood(u, h), -true_ll)
+
+
 def test_target_function_arma_returns_finite():
     import numpy as np
 

--- a/fynance/tests/features/test_engineering.py
+++ b/fynance/tests/features/test_engineering.py
@@ -41,6 +41,24 @@ def test_granger_too_short_raises():
         granger_causality(np.arange(3.0), np.arange(3.0), lag=1)
 
 
+def test_granger_detects_causality_lag2():
+    # y_t driven by x_{t-2}: lag=2 must pick up the two-step-ahead causality.
+    rng = np.random.RandomState(5)
+    x = rng.standard_normal(400)
+    y = np.r_[0.0, 0.0, 0.7 * x[:-2]] + 0.1 * rng.standard_normal(400)
+    f, p = granger_causality(x, y, lag=2)
+    assert f > 0.0
+    assert p < 0.01
+
+
+def test_granger_independent_not_significant_lag2():
+    rng = np.random.RandomState(0)
+    _, p = granger_causality(
+        rng.standard_normal(400), rng.standard_normal(400), lag=2
+    )
+    assert p > 0.05
+
+
 def test_incremental_moments_matches_numpy():
     rng = np.random.RandomState(2)
     data = rng.standard_normal(100)
@@ -56,3 +74,23 @@ def test_incremental_moments_matches_numpy():
 def test_incremental_update_returns_self():
     im = IncrementalMoments()
     assert im.update(1.0) is im
+
+
+def test_incremental_single_observation_zero_variance():
+    # After a single observation the variance/std are well-defined and zero (no
+    # division-by-zero, no nan), and the mean equals that observation.
+    im = IncrementalMoments()
+    im.update(3.5)
+    assert im.n == 1
+    assert im.mean == 3.5
+    assert im.var == 0.0
+    assert im.std == 0.0
+
+
+def test_incremental_empty_is_zero():
+    # Before any observation, the moments default to zero rather than raising.
+    im = IncrementalMoments()
+    assert im.n == 0
+    assert im.mean == 0.0
+    assert im.var == 0.0
+    assert im.std == 0.0

--- a/fynance/tests/features/test_filters.py
+++ b/fynance/tests/features/test_filters.py
@@ -139,3 +139,46 @@ class TestFitKalman:
         assert result['success']
         np.testing.assert_allclose(result['W'], W_TRUE)
         np.testing.assert_allclose(result['V'], V_TRUE)
+
+
+class TestMultivariate:
+    """ State-dimension n > 1: filter, smoother and fit on a 2-D state. """
+
+    N2 = 2
+    T2 = 150
+
+    def _data(self):
+        rng = np.random.default_rng(7)
+        n, T = self.N2, self.T2
+        G2 = F2 = np.eye(n)
+        W2 = np.diag([0.3, 0.8])
+        V2 = np.diag([1.0, 0.5])
+        x = np.cumsum(rng.multivariate_normal(np.zeros(n), W2, T), axis=0)
+        y = x + rng.multivariate_normal(np.zeros(n), V2, T)
+
+        return y, G2, F2, W2, V2
+
+    def test_filter_smoother_shapes_n2(self):
+        y, G2, F2, W2, V2 = self._data()
+        m, C, a, R, e, S = kalman_filter(y, G2, F2, W2, V2)
+        assert m.shape == (self.T2, self.N2)
+        assert C.shape == (self.T2, self.N2, self.N2)
+        ms, Cs = rts_smoother(m, C, a, R, G2)
+        assert ms.shape == (self.T2, self.N2)
+        assert Cs.shape == (self.T2, self.N2, self.N2)
+
+    def test_fit_n2_converges_and_shapes(self):
+        y, G2, F2, _, _ = self._data()
+        result = fit_kalman(y, G2, F2)
+        assert result['success']
+        assert result['W'].shape == (self.N2, self.N2)
+        assert result['V'].shape == (self.N2, self.N2)
+
+    def test_fit_n2_beats_identity(self):
+        y, G2, F2, _, _ = self._data()
+        result = fit_kalman(y, G2, F2)
+        _, _, _, _, e_id, S_id = kalman_filter(
+            y, G2, F2, np.eye(self.N2), np.eye(self.N2)
+        )
+        ll_id = kalman_loglikelihood(e_id, S_id)
+        assert result['loglik'] >= ll_id - 1e-6

--- a/fynance/tests/features/test_garch.py
+++ b/fynance/tests/features/test_garch.py
@@ -58,12 +58,25 @@ def test_refit_is_causal_and_changes_results():
     refit = garch_volatility(r, min_train=500, refit=200)
     # refit produces a (generally) different series ...
     assert not np.allclose(once[500:], refit[500:])
-    # ... but stays causal: a value is unchanged when the series is extended,
-    # as long as the truncation lands on a refit checkpoint (500 + k*200).
-    t = 900   # = 500 + 2 * 200
+    # ... but stays causal at EVERY index, not only on refit checkpoints: within
+    # the block [start, end) the value sigma_t is filtered with params fit on
+    # r[:start] (start <= t), so it never sees r[t:]. A value is therefore
+    # unchanged when the series is extended, regardless of where we truncate.
+    t = 850   # mid-block (500 + 2*200 = 900 is the next checkpoint)
     a = garch_volatility(r[:t], min_train=500, refit=200)[-1]
     b = garch_volatility(r[:t + 50], min_train=500, refit=200)[t - 1]
     assert a == b
+
+
+def test_per_index_causality_sweep_with_refit():
+    # The strong causality guarantee: sigma_t is F_{t-1}-measurable at *every* t,
+    # including between refit checkpoints. Truncating the series just after t
+    # leaves sigma_t bit-identical -- no future leakage anywhere.
+    r, _ = _simulate_garch(T=900)
+    full = garch_volatility(r, min_train=500, refit=150)
+    for t in range(500, r.size):
+        trunc = garch_volatility(r[:t + 1], min_train=500, refit=150)
+        assert trunc[t] == full[t], t
 
 
 def test_bad_min_train_raises():

--- a/fynance/tests/features/test_indicators.py
+++ b/fynance/tests/features/test_indicators.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 # coding: utf-8
 
+import warnings
+
 import numpy as np
-import pytest
 
 from fynance.features.indicators import (
     bollinger_band,
@@ -12,13 +13,6 @@ from fynance.features.indicators import (
     macd_line,
     rsi,
     signal_line,
-)
-
-# bollinger_band keeps a 1.1.0-era DeprecationWarning until v2.0; silence it
-# locally so the strict `error::DeprecationWarning` filter (pyproject.toml)
-# stays effective for genuinely new deprecations.
-pytestmark = pytest.mark.filterwarnings(
-    "ignore:Since version 1.1.0, bollinger_band:DeprecationWarning"
 )
 
 N = 100
@@ -46,6 +40,16 @@ def test_bollinger_band_no_nan_after_warmup():
     upper, lower = bollinger_band(X, w=10)
     assert not np.any(np.isnan(upper[10:]))
     assert not np.any(np.isnan(lower[10:]))
+
+
+def test_bollinger_band_emits_no_warning():
+    # The dead 1.1.0-era DeprecationWarning was removed: a normal two-tuple call
+    # must not warn at all.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        upper, lower = bollinger_band(X, w=20)
+    assert upper.shape == (N,)
+    assert lower.shape == (N,)
 
 
 # =========================================================================== #

--- a/fynance/tests/features/test_momentums.py
+++ b/fynance/tests/features/test_momentums.py
@@ -136,3 +136,109 @@ def test_emstd(set_variables):
     assert (ma_2d == fy.emstd(x_2d, a, dtype=np.float32)).all()
     assert (fy.emstd(x_1d, 0.) == 0.).all()
     assert (fy.emstd(x_1d, 1.) == 0.).all()
+
+
+# --------------------------------------------------------------------------- #
+#   Genuine multi-column axis=1 parity (roadmap 1.A)                           #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture()
+def multi_col():
+    # Time on axis 1, three distinct rows, non-square (3, 6).
+    return np.array([
+        [70., 100., 80., 120., 160., 80.],
+        [60., 90., 110., 70., 130., 100.],
+        [50., 80., 60., 90., 120., 70.],
+    ])
+
+
+def _stack_rows(f, X, **kwargs):
+    return np.vstack([f(X[i], **kwargs) for i in range(X.shape[0])])
+
+
+@pytest.mark.parametrize("name", ["sma", "wma", "smstd", "wmstd"])
+def test_moving_axis1_matches_per_row(multi_col, name):
+    # axis=1 must equal stacking the 1-D result of each row.
+    f = getattr(fy, name)
+    out = f(multi_col, w=3, axis=1)
+    assert np.allclose(out, _stack_rows(f, multi_col, w=3))
+
+
+@pytest.mark.parametrize("name", ["sma", "wma", "smstd", "wmstd"])
+def test_moving_axis1_window_greater_than_n_columns(multi_col, name):
+    # The window must be validated against the time axis (axis=1, length 6),
+    # not the leading axis (length 3). A window of 4 > 3 used to be silently
+    # clamped to 3 before the axis transpose.
+    f = getattr(fy, name)
+    out = f(multi_col, w=4, axis=1)
+    assert np.allclose(out, _stack_rows(f, multi_col, w=4))
+    # axis=1 with w=4 differs from the (buggy) clamped w=3 result.
+    assert not np.allclose(out, _stack_rows(f, multi_col, w=3))
+
+
+def test_sma_axis1_differs_from_axis0():
+    # On a non-square multi-column array, axis=1 and axis=0 disagree.
+    X = np.array([
+        [1., 2., 3., 4.],
+        [5., 7., 9., 11.],
+        [2., 4., 8., 16.],
+    ])
+    assert not np.allclose(fy.sma(X, w=2, axis=1), fy.sma(X, w=2, axis=0))
+
+
+@pytest.mark.parametrize(
+    "name", ["sma", "wma", "smstd", "wmstd", "ema", "emstd"],
+)
+def test_axis_error_on_1d(name):
+    # axis=1 on a 1-D array must raise a clean AxisError (np.AxisError was
+    # removed in NumPy 2; the size check also used to raise IndexError first).
+    f = getattr(fy, name)
+    with pytest.raises(np.exceptions.AxisError):
+        f(np.arange(5.), axis=1)
+
+
+def test_z_score_axis1_matches_per_row(multi_col):
+    from fynance.features.stats import z_score
+    for kind in ("s", "w", "e"):
+        out = z_score(multi_col, w=3, kind=kind, axis=1)
+        expected = np.array([
+            z_score(multi_col[i], w=3, kind=kind)
+            for i in range(multi_col.shape[0])
+        ])
+        assert np.allclose(out, expected)
+
+
+def test_roll_z_score_axis1_matches_per_row(multi_col):
+    from fynance.features.stats import roll_z_score
+    for kind in ("s", "w", "e"):
+        out = roll_z_score(multi_col, w=3, kind=kind, axis=1)
+        expected = _stack_rows(roll_z_score, multi_col, w=3, kind=kind)
+        assert np.allclose(out, expected)
+
+
+def test_roll_z_score_e_kind_single_conversion(multi_col):
+    # The e->alpha conversion w = 1 - 2/(1+w) must be applied exactly once,
+    # regardless of axis: axis=1 must equal the per-row 1-D result.
+    from fynance.features.stats import roll_z_score
+    out = roll_z_score(multi_col, w=3, kind="e", axis=1)
+    expected = _stack_rows(roll_z_score, multi_col, w=3, kind="e")
+    assert np.allclose(out, expected)
+
+
+def test_mad_axis1_matches_per_row():
+    from fynance.features.stats import mad
+    # Non-square array whose leading axis differs from the trailing axis so a
+    # broadcast bug (X.T - mean) would raise instead of returning per-row mad.
+    X = np.array([
+        [1., 2.],
+        [3., 4.],
+        [5., 6.],
+    ])
+    out = mad(X, axis=1)
+    expected = np.array([mad(X[i]) for i in range(X.shape[0])])
+    assert np.allclose(out, expected)
+    # axis=0 stays correct (per-column).
+    assert np.allclose(
+        mad(X, axis=0), [mad(X[:, j]) for j in range(X.shape[1])]
+    )

--- a/fynance/tests/features/test_money_management.py
+++ b/fynance/tests/features/test_money_management.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for the iso-vol money-management coefficient. """
+
+# Third-party packages
+import numpy as np
+
+# Local packages
+from fynance.features.momentums import ema
+from fynance.features.money_management import iso_vol
+
+
+def test_iso_vol_uses_standard_returns():
+    # iso_vol must use the standard return s_t / s_{t-1} - 1, not the reciprocal
+    # s_{t-1} / s_t - 1 that the function used before the fix.
+    series = np.array([95, 100, 85, 105, 110, 90]).astype(np.float64)
+    target_vol, leverage, period, half_life = 0.5, 2.0, 12, 3
+
+    out = iso_vol(series, target_vol=target_vol, leverage=leverage,
+                  period=period, half_life=half_life)
+
+    ret2 = np.square(series[1:] / series[:-1] - 1)
+    vol = np.sqrt(period * ema(ret2, w=half_life))
+    vol[vol <= 0.0] = 1e-8
+    expected = np.ones(series.size)
+    expected[2:] = target_vol / vol[:-1]
+    expected[expected > leverage] = leverage
+
+    assert np.allclose(out, expected)
+
+
+def test_iso_vol_causality():
+    # iv[t] must depend only on series[:t+1] (in fact series[:t]): truncating the
+    # series at t+1 leaves iv[t] unchanged -- no future leakage into the signal.
+    rng = np.random.default_rng(0)
+    series = 100 * np.cumprod(1 + rng.standard_normal(60) * 0.02)
+    full = iso_vol(series, target_vol=0.2, leverage=3.0, period=252, half_life=11)
+
+    for t in range(2, series.size):
+        trunc = iso_vol(series[:t + 1], target_vol=0.2, leverage=3.0,
+                        period=252, half_life=11)
+        assert np.isclose(trunc[t], full[t]), (t, trunc[t], full[t])
+
+
+def test_iso_vol_leverage_cap():
+    # A near-flat (ultra-low-vol) series would demand huge leverage; the output
+    # must be capped at `leverage`.
+    flat = np.full(20, 100.0)
+    leverage = 2.5
+    out = iso_vol(flat, target_vol=0.2, leverage=leverage)
+
+    assert np.all(out <= leverage + 1e-12)
+    assert out.max() == leverage
+
+
+def test_iso_vol_volatility_floor():
+    # The 1e-8 floor on `vol` keeps the coefficient finite (no division by zero)
+    # even when the series has zero realized volatility.
+    flat = np.full(10, 50.0)
+    out = iso_vol(flat, target_vol=0.2, leverage=1.5)
+
+    assert np.all(np.isfinite(out))
+    assert not np.any(np.isnan(out))
+
+
+def test_iso_vol_warmup_is_one():
+    # The first two coefficients are seeded to 1 (no return / vol yet).
+    rng = np.random.default_rng(1)
+    series = 100 * np.cumprod(1 + rng.standard_normal(30) * 0.01)
+    out = iso_vol(series)
+
+    assert out[0] == 1.0
+    assert out[1] == 1.0

--- a/fynance/tests/features/test_ohlcv.py
+++ b/fynance/tests/features/test_ohlcv.py
@@ -102,6 +102,29 @@ def test_missing_args_raise():
         vwap(np.array([1.0, 2.0]))
 
 
+@pytest.mark.parametrize("fn", [atr, adx, williams_r])
+@pytest.mark.parametrize("w", [0, -1])
+def test_window_below_one_raises(fn, w):
+    # w=0 used to raise an uncaught ZeroDivisionError (atr/adx) or produce inf;
+    # it must now raise a clear ValueError, and so must any negative window.
+    h, low, c, _ = _synthetic(n=20)
+    with pytest.raises(ValueError, match="w must be >= 1"):
+        fn(h, low, c, w=w)
+
+
+def test_williams_r_out_of_range_on_invalid_ohlc():
+    # %R is bounded in [-100, 0] only for valid OHLC (low <= close <= high).
+    # A close above the rolling high yields %R > 0; below the rolling low yields
+    # %R < -100. The kernel does NOT clamp -- it surfaces the data issue.
+    h = np.array([10.0, 10.0, 10.0])
+    low = np.array([9.0, 9.0, 9.0])
+    # Close above high at t=1 -> %R > 0; close below low at t=2 -> %R < -100.
+    c = np.array([9.5, 20.0, 0.0])
+    out = williams_r(h, low, c, w=2)
+    assert out[1] > 0.0
+    assert out[2] < -100.0
+
+
 # -- No-lookahead ---------------------------------------------------------
 
 

--- a/fynance/tests/features/test_regime.py
+++ b/fynance/tests/features/test_regime.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 
-from fynance.features.regime import detect_regimes
+from fynance.features.regime import _vol_order, detect_regimes, regime_features
 
 
 def _two_regime_series(seed=0):
@@ -33,3 +33,30 @@ def test_deterministic_with_seed():
     a = detect_regimes(X, n_regimes=2, w=15, seed=42)
     b = detect_regimes(X, n_regimes=2, w=15, seed=42)
     assert np.array_equal(a, b)
+
+
+def test_vol_order_empty_cluster_safe():
+    # An empty cluster yields a nan mean; it must sort last (treated as +inf),
+    # never corrupt the order of the populated clusters.
+    vol = np.array([0.1, 0.5, 0.3, 0.2])
+    labels = np.array([0, 2, 0, 2])  # cluster 1 is empty
+    order = _vol_order(vol, labels, n_regimes=3)
+    # Populated means: 0 -> 0.2, 2 -> 0.35; empty 1 -> +inf -> last.
+    assert order.tolist() == [0, 2, 1]
+
+
+def test_vol_order_matches_naive_when_all_populated():
+    rng = np.random.RandomState(7)
+    vol = rng.rand(50)
+    labels = rng.randint(0, 3, 50)
+    order = _vol_order(vol, labels, n_regimes=3)
+    naive = np.argsort([vol[labels == k].mean() for k in range(3)])
+    assert order.tolist() == naive.tolist()
+
+
+def test_regime_features_warmup_row_is_zero():
+    # Row 0 is the documented deterministic warmup: (vol, mean log-return) = (0, 0).
+    X = _two_regime_series()
+    f = regime_features(X, w=15)
+    assert f[0, 0] == 0.0
+    assert f[0, 1] == 0.0

--- a/fynance/tests/features/test_roll_functions_numba.py
+++ b/fynance/tests/features/test_roll_functions_numba.py
@@ -44,3 +44,37 @@ def test_roll_min_default_window_is_expanding():
     X = np.array([3.0, 1.0, 2.0, 0.5, 4.0])
     # w=None -> full length -> expanding min
     assert np.allclose(roll_min(X, dtype=np.float64), np.minimum.accumulate(X))
+
+
+def _multi_col():
+    # Time on axis 1, non-square (3, 6).
+    return np.array([
+        [70., 100., 80., 120., 160., 80.],
+        [60., 90., 110., 70., 130., 100.],
+        [50., 80., 60., 90., 120., 70.],
+    ])
+
+
+def test_roll_min_axis1_matches_per_row():
+    X = _multi_col()
+    out = roll_min(X, w=3, axis=1, dtype=np.float64)
+    expected = np.vstack([_ref(X[i], 3, np.min) for i in range(X.shape[0])])
+    assert np.allclose(out, expected)
+
+
+def test_roll_max_axis1_matches_per_row():
+    X = _multi_col()
+    out = roll_max(X, w=3, axis=1, dtype=np.float64)
+    expected = np.vstack([_ref(X[i], 3, np.max) for i in range(X.shape[0])])
+    assert np.allclose(out, expected)
+
+
+def test_roll_min_axis1_window_greater_than_n_columns():
+    # Window 4 > leading axis length 3 must validate against the time axis.
+    X = _multi_col()
+    out = roll_min(X, w=4, axis=1, dtype=np.float64)
+    expected = np.vstack([_ref(X[i], 4, np.min) for i in range(X.shape[0])])
+    assert np.allclose(out, expected)
+    assert not np.allclose(
+        out, np.vstack([_ref(X[i], 3, np.min) for i in range(X.shape[0])])
+    )

--- a/fynance/tests/features/test_scale.py
+++ b/fynance/tests/features/test_scale.py
@@ -157,3 +157,41 @@ def test_roll_rank_2d_columnwise():
     out = np.asarray(roll_rank(X2, w=3))
     assert out.shape == (5, 2)
     assert np.allclose(out[:, 0], roll_rank(X, w=3))
+
+
+# --------------------------------------------------------------------------- #
+#   Genuine multi-column axis=1 parity (roadmap 1.A)                           #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture()
+def multi_col():
+    # Time on axis 1, distinct rows, non-square (3, 4).
+    return np.array([
+        [1., 2., 3., 4.],
+        [6., 5., 7., 8.],
+        [2., 9., 1., 3.],
+    ])
+
+
+@pytest.mark.parametrize(
+    "kind, base_func",
+    [("std", "standardize"), ("norm", "normalize")],
+)
+def test_scale_axis1_matches_per_row(multi_col, kind, base_func):
+    # Scale(axis=1) must equal stacking the 1-D transform of each row, and
+    # must round-trip through revert. Previously the axis=1 branch discarded
+    # its result (missing return) and silently fell back to axis=0 behaviour.
+    f = getattr(fy, base_func)
+    s = fy.Scale(multi_col, kind=kind, axis=1, a=0, b=1)
+    out = s.scale(multi_col)
+    expected = np.vstack([f(multi_col[i]) for i in range(multi_col.shape[0])])
+    assert np.allclose(out, expected)
+    assert np.allclose(s.revert(out), multi_col)
+
+
+@pytest.mark.parametrize("kind", ["std", "norm"])
+def test_scale_axis1_differs_from_axis0(multi_col, kind):
+    s1 = fy.Scale(multi_col, kind=kind, axis=1, a=0, b=1)
+    s0 = fy.Scale(multi_col, kind=kind, axis=0, a=0, b=1)
+    assert not np.allclose(s1.scale(multi_col), s0.scale(multi_col))

--- a/fynance/tests/metrics/test_metrics.py
+++ b/fynance/tests/metrics/test_metrics.py
@@ -105,6 +105,14 @@ def test_diversified_ratio():
     w = np.array([0.4, 0.3, 0.3])
     result = fy.diversified_ratio(X, W=w)
     assert result > 0
+    # Must be a Python float scalar (not a (1, 1) ndarray), matching the
+    # documented ``-> float`` return type.
+    assert isinstance(result, float)
+    assert not isinstance(result, np.ndarray)
+
+    # Equal weights (default W) should also return a plain float scalar.
+    result_eq = fy.diversified_ratio(X)
+    assert isinstance(result_eq, float)
 
 
 def test_drawdown_zero_initial_warns():

--- a/fynance/tests/metrics/test_summary.py
+++ b/fynance/tests/metrics/test_summary.py
@@ -8,7 +8,12 @@ import numpy as np
 
 # Local packages
 from fynance.core import Metric
-from fynance.metrics import METRICS, sharpe, summary
+from fynance.metrics import (
+    METRICS,
+    annual_volatility,
+    sharpe,
+    summary,
+)
 
 
 def test_summary_keys():
@@ -35,3 +40,16 @@ def test_registry_contains_metrics():
 def test_metric_functions_conform_to_protocol():
     # plain callables structurally satisfy the Metric protocol
     assert isinstance(sharpe, Metric)
+
+
+def test_summary_volatility_consistent_with_sharpe():
+    # The reported annual_volatility must use the same log convention as the
+    # reported sharpe (log=False), so that sharpe == annual_return / vol holds
+    # on the displayed numbers (rf=0). Under the old default (log=True for vol,
+    # log=False for sharpe) the displayed vol did not imply the displayed Sharpe.
+    eq = np.array([100., 101.5, 99., 104., 108., 103., 110.])
+    s = summary(eq)
+    vol_log_false = float(annual_volatility(eq, period=252, log=False))
+    assert np.isclose(s["annual_volatility"], vol_log_false)
+    # sharpe (rf=0) implied by the displayed vol and return.
+    assert np.isclose(s["sharpe"], s["annual_return"] / s["annual_volatility"])

--- a/fynance/tests/metrics/test_zero_vol_ratios.py
+++ b/fynance/tests/metrics/test_zero_vol_ratios.py
@@ -7,7 +7,7 @@
 import numpy as np
 
 # Local
-from fynance.metrics import sharpe, sortino
+from fynance.metrics import calmar, roll_calmar, sharpe, sortino
 from fynance.metrics.ratios import _safe_ratio
 from fynance.metrics.summary import summary
 
@@ -43,3 +43,33 @@ def test_summary_on_flat_curve():
     out = summary(np.full(30, 100.0))
     assert out["sharpe"] == 0.0
     assert np.isfinite(out["max_drawdown"])
+
+
+def test_calmar_zero_mdd_is_inf_not_zero():
+    # A profitable, drawdown-free curve has zero maximum drawdown. Calmar must
+    # follow the same zero-denominator convention as sharpe/sortino (+inf for a
+    # riskless gain), not return 0.0 (the worst possible Calmar).
+    up = np.array([100., 101., 102., 103., 104., 105.])
+    assert np.isposinf(calmar(up, period=12))
+    # a flat curve (zero return over zero drawdown) stays 0.0
+    assert calmar(np.full(10, 100.0), period=12) == 0.0
+
+
+def test_calmar_zero_mdd_2d_columns():
+    up = np.array([100., 101., 102., 103., 104., 105.])
+    drawdown = np.array([100., 90., 95., 80., 85., 70.])
+    X = np.column_stack([up, drawdown])
+    res = calmar(X, period=12)
+    assert res.shape == (2,)
+    assert np.isposinf(res[0])      # drawdown-free profitable column
+    assert np.isfinite(res[1])      # column with a real drawdown
+
+
+def test_roll_calmar_zero_mdd_is_inf_not_zero():
+    # Same convention for the rolling variant: a window that has gained without
+    # any drawdown yet must score +inf, not 0.0.
+    X = np.array([70., 100., 80., 120., 160., 80.])
+    rc = roll_calmar(X, period=12)
+    # index 1 = strictly increasing so far (70 -> 100), zero MDD, positive ret.
+    assert np.isposinf(rc[1])
+    assert rc[0] == 0.0             # first point: zero return over zero MDD

--- a/fynance/tests/models/test_econometric_models.py
+++ b/fynance/tests/models/test_econometric_models.py
@@ -24,25 +24,37 @@ def set_variables():
     return y, params, p, q, P, Q
 
 
-def test_get_parameters(set_variables):
-    y, params, p, q, P, Q = set_variables
+def test_get_parameters():
+    # Use distinct orders (p=1, q=1, Q=2, P=1) and distinct parameter values so
+    # that a Q<->P packing swap, or an argument passed out of signature order,
+    # changes one of the asserted slices and fails. The signature is
+    # ``get_parameters(params, p, q, Q, P, cons)`` and, with a constant, the
+    # flat layout is [c, phi(p), theta(q), omega, alpha(Q), beta(P)].
+    p, q, Q, P = 1, 1, 2, 1
+    # c=0.5, phi=0.3, theta=-0.2, omega=0.1, alpha=[0.4, 0.05], beta=0.8
+    params = np.array([0.5, 0.3, -0.2, 0.1, 0.4, 0.05, 0.8])
+
     phi, theta, alpha, beta, c, omega = fy.get_parameters(
-        params, p, q, P, Q, cons=True
+        params, p, q, Q, P, cons=True
     )
     assert c == params[0]
-    assert phi == params[1]
-    assert theta == params[2]
+    assert np.array_equal(phi, params[1:2])
+    assert np.array_equal(theta, params[2:3])
     assert omega == params[3]
-    assert alpha == params[4]
-    assert beta == params[5]
+    assert np.array_equal(alpha, params[4:6])  # Q=2 -> two ARCH coefficients
+    assert np.array_equal(beta, params[6:7])   # P=1 -> one GARCH coefficient
+
+    # Without a constant the constant slot disappears and everything shifts left.
+    params_nc = np.array([0.3, -0.2, 0.1, 0.4, 0.05, 0.8])
     phi, theta, alpha, beta, c, omega = fy.get_parameters(
-        params, p, q, P, Q, cons=False
+        params_nc, p, q, Q, P, cons=False
     )
-    assert phi == params[0]
-    assert theta == params[1]
-    assert omega == params[2]
-    assert alpha == params[3]
-    assert beta == params[4]
+    assert c == 0.
+    assert np.array_equal(phi, params_nc[0:1])
+    assert np.array_equal(theta, params_nc[1:2])
+    assert omega == params_nc[2]
+    assert np.array_equal(alpha, params_nc[3:5])
+    assert np.array_equal(beta, params_nc[5:6])
 
 
 def test_ARMA_GARCH(set_variables):
@@ -105,3 +117,46 @@ def test_ARMAX_GARCH_shapes_and_positive_vol(set_variables):
     assert u.shape == (y.size,) and h.shape == (y.size,)
     assert np.all(np.isfinite(u)) and np.all(np.isfinite(h))
     assert np.all(h > 0)
+
+
+def test_ARMA_accepts_list_like_MA():
+    # ARMA must coerce a plain Python list for y like MA does, instead of
+    # crashing on ``'list' object has no attribute 'size'``.
+    y_list = [60., 100., 80., 120., 160., 80.]
+    u_list = np.asarray(fy.ARMA(y_list, phi=[0.5], theta=[-0.3], c=0.2, p=1, q=1))
+    u_arr = np.asarray(
+        fy.ARMA(np.array(y_list), phi=np.array([0.5]),
+                theta=np.array([-0.3]), c=0.2, p=1, q=1)
+    )
+    assert np.allclose(u_list, u_arr)
+
+
+def test_ARMA_GARCH_accepts_list():
+    y_list = [60., 100., 80., 120., 160., 80.]
+    u_l, h_l = fy.ARMA_GARCH(
+        y_list, phi=[0.5], theta=[-0.3], alpha=[0.1], beta=[0.1],
+        c=0.2, omega=0.6, p=1, q=1, Q=1, P=1,
+    )
+    u_a, h_a = fy.ARMA_GARCH(
+        np.array(y_list), phi=np.array([0.5]), theta=np.array([-0.3]),
+        alpha=np.array([0.1]), beta=np.array([0.1]),
+        c=0.2, omega=0.6, p=1, q=1, Q=1, P=1,
+    )
+    assert np.allclose(np.asarray(u_l), np.asarray(u_a))
+    assert np.allclose(np.asarray(h_l), np.asarray(h_a))
+
+
+def test_ARMAX_GARCH_accepts_list():
+    y_list = [60., 100., 80., 120., 160., 80.]
+    x = np.zeros((len(y_list), 1))
+    u_l, h_l = fy.ARMAX_GARCH(
+        y_list, x, phi=[0.5], psi=[0.1], theta=[-0.3], alpha=[0.1],
+        beta=[0.1], c=0.2, omega=0.6, p=1, q=1, Q=1, P=1,
+    )
+    u_a, h_a = fy.ARMAX_GARCH(
+        np.array(y_list), x, phi=np.array([0.5]), psi=np.array([0.1]),
+        theta=np.array([-0.3]), alpha=np.array([0.1]), beta=np.array([0.1]),
+        c=0.2, omega=0.6, p=1, q=1, Q=1, P=1,
+    )
+    assert np.allclose(np.asarray(u_l), np.asarray(u_a))
+    assert np.allclose(np.asarray(h_l), np.asarray(h_a))

--- a/fynance/tests/models/test_loss.py
+++ b/fynance/tests/models/test_loss.py
@@ -63,6 +63,17 @@ class TestSharpeLoss:
         assert not torch.isnan(loss)
         assert not torch.isinf(loss)
 
+    def test_rf_change_takes_effect(self):
+        # _rf_per_period is recomputed in forward (a property), so mutating rf
+        # after construction must change the loss instead of being a no-op.
+        loss_fn = SharpeLoss()
+        before = loss_fn(RETURNS).item()
+        loss_fn.rf = 0.10
+        after = loss_fn(RETURNS).item()
+        assert after != before
+        # Matches building a fresh loss with the same rf.
+        assert after == pytest.approx(SharpeLoss(rf=0.10)(RETURNS).item())
+
 
 class TestSortinoLoss:
     def test_forward_scalar(self):
@@ -86,16 +97,45 @@ class TestSortinoLoss:
         assert not torch.isnan(loss)
         assert not torch.isinf(loss)
 
+    def test_all_positive_finite_bounded_and_scale_invariant(self):
+        # On an all-gains batch the downside is ~0. A *fixed absolute* eps inside
+        # the sqrt is dimensionally wrong: the loss then scales with the return
+        # magnitude (10x returns -> 10x loss) instead of being scale-invariant
+        # like a true Sortino ratio, and explodes. A returns-scaled floor keeps
+        # the loss finite, bounded, and scale-invariant.
+        r = torch.abs(RETURNS) + 0.001   # strictly positive → downside = 0
+        loss = SortinoLoss(eps=1e-8)(r)
+        loss_10x = SortinoLoss(eps=1e-8)(10.0 * r)
+        assert torch.isfinite(loss)
+        assert abs(loss.item()) <= 1e3 + 1.0          # bounded
+        # scale invariance (old absolute-eps code is off by ~10x here)
+        assert loss_10x.item() == pytest.approx(loss.item(), rel=1e-2)
+
+    def test_positive_when_negative_mean(self):
+        # Sign convention (like SharpeLoss): a negative-mean return series has a
+        # negative Sortino ratio, so the negated loss must be positive.
+        loss = SortinoLoss()(RETURNS_NEG)
+        assert loss.item() > 0
+
+    def test_rf_change_takes_effect(self):
+        # _rf_per_period is a property (not cached in __init__), so mutating rf
+        # after construction must change the computed loss.
+        loss_fn = SortinoLoss()
+        before = loss_fn(RETURNS).item()
+        loss_fn.rf = 5.0   # huge rf -> excess turns negative -> loss flips sign
+        after = loss_fn(RETURNS).item()
+        assert before != after
+
     def test_downside_only_penalized(self):
         # Two series identical except one has large upside: Sortino should
-        # be lower (better) for the one with large upside because upside
-        # doesn't count against the denominator.
+        # be strictly lower (better) for the one with large upside because
+        # upside doesn't count against the denominator.
         r_base = torch.tensor([-0.01, 0.005, -0.008, 0.003, -0.006])
         r_upside = torch.tensor([-0.01, 0.500, -0.008, 0.003, -0.006])
         loss_base = SortinoLoss()(r_base)
         loss_upside = SortinoLoss()(r_upside)
         # Large upside improves mean without worsening downside → lower loss
-        assert loss_upside.item() <= loss_base.item()
+        assert loss_upside.item() < loss_base.item()
 
 
 class TestDirectionalAccuracyLoss:
@@ -151,6 +191,23 @@ class TestCalmarLoss:
         with pytest.raises(TypeError):
             CalmarLoss()(np.zeros(10))
 
+    def test_no_drawdown_loss_is_bounded(self):
+        from fynance.models.loss import CalmarLoss
+        # Monotonically increasing equity -> zero drawdown. A fixed absolute
+        # eps (1e-8) on an O(returns) drawdown made the ratio explode (e.g.
+        # -3.78e7). A returns-scaled floor keeps it finite and bounded.
+        r = torch.full((100,), 0.01)   # constant gains -> no drawdown
+        loss = CalmarLoss(eps=1e-8)(r)
+        assert torch.isfinite(loss)
+        assert abs(loss.item()) < 1e4
+
+    def test_all_zero_returns_is_finite(self):
+        from fynance.models.loss import CalmarLoss
+        # Degenerate all-zero series: numerator and drawdown are both 0; the
+        # bare-eps backstop in the floor must keep the loss finite (not NaN).
+        loss = CalmarLoss(eps=1e-8)(torch.zeros(50))
+        assert torch.isfinite(loss)
+
 
 class TestOmegaLoss:
     def test_known_value(self):
@@ -168,6 +225,22 @@ class TestOmegaLoss:
         loss = OmegaLoss(threshold=0.01)(r)
         loss.backward()
         assert r.grad is not None
+
+    def test_all_gains_loss_is_bounded(self):
+        from fynance.models.loss import OmegaLoss
+        # All returns above the threshold -> zero losses. A fixed absolute eps
+        # made the ratio explode (e.g. -1e6); a returns-scaled floor bounds it.
+        r = torch.full((100,), 0.01)   # all gains, no losses below threshold
+        loss = OmegaLoss(eps=1e-8)(r)
+        assert torch.isfinite(loss)
+        assert abs(loss.item()) < 1e4
+
+    def test_all_zero_diff_is_finite(self):
+        from fynance.models.loss import OmegaLoss
+        # Returns exactly at threshold: gains == losses == 0; the bare-eps
+        # backstop must keep the loss finite (not NaN).
+        loss = OmegaLoss(threshold=0.0, eps=1e-8)(torch.zeros(50))
+        assert torch.isfinite(loss)
 
 
 class TestHybridLoss:

--- a/fynance/tests/models/test_neural_network.py
+++ b/fynance/tests/models/test_neural_network.py
@@ -208,6 +208,71 @@ class TestMLP:
         model.set_optimizer(nn.MSELoss, torch.optim.Adam, params=[model], lr=1e-3)
         assert model.optimizer is not None
 
+    def test_dtype_request_is_applied(self):
+        """ A float32 request on float64 data yields float32 tensors. """
+        X64 = np.zeros((10, N_IN), dtype=np.float64)
+        y64 = np.zeros((10, N_OUT), dtype=np.float64)
+        model = MultiLayerPerceptron(N_IN, N_OUT, layers=[8])
+        model.set_data(X64, y64, x_type=torch.float32, y_type=torch.float32)
+        assert model.X.dtype == torch.float32
+        assert model.y.dtype == torch.float32
+
+    def test_float64_numpy_trains_without_astype(self):
+        """ Plain float64 numpy input must fit/predict without manual cast. """
+        rng = np.random.default_rng(0)
+        X64 = rng.standard_normal((20, N_IN))  # float64 by default
+        y64 = rng.standard_normal((20, N_OUT))
+        assert X64.dtype == np.float64
+        model = MultiLayerPerceptron(X64, y64, layers=[8])
+        model.set_optimizer(nn.MSELoss, torch.optim.SGD, lr=1e-3)
+        # Coerced to the default (float32) so it matches the float32 params.
+        assert model.X.dtype == torch.get_default_dtype()
+        loss = model.train_on(model.X, model.y)  # must not raise on dtype
+        assert torch.isfinite(loss)
+        pred = model.predict(model.X)
+        assert pred.shape == (20, N_OUT)
+
+    def test_set_data_does_not_alias_numpy(self):
+        """ set_data must not let later edits to the tensor mutate the source. """
+        X = np.zeros((10, N_IN), dtype=np.float32)
+        model = MultiLayerPerceptron(N_IN, N_OUT, layers=[8])
+        t = model._set_data(X)
+        t[0, 0] = 123.0
+        assert X[0, 0] == 0.0
+
+    def test_predict_deterministic_with_dropout(self):
+        """ With dropout>0, predict is deterministic and restores train mode. """
+        torch.manual_seed(0)
+        model = MultiLayerPerceptron(X_t, y_t, layers=[16], drop=0.5)
+        model.set_optimizer(nn.MSELoss, torch.optim.Adam, lr=1e-3)
+        assert model.training  # starts in train mode
+        p1 = model.predict(X_t)
+        p2 = model.predict(X_t)
+        assert torch.allclose(p1, p2)
+        # eval mode must be restored to training after predict
+        assert model.training
+
+    def test_train_on_sets_train_mode(self):
+        """ train_on must put the model back into training mode. """
+        model = MultiLayerPerceptron(X_t, y_t, layers=[16], drop=0.5)
+        model.set_optimizer(nn.MSELoss, torch.optim.Adam, lr=1e-3)
+        model.eval()
+        model.train_on(X_t, y_t)
+        assert model.training
+
+    def test_overfit_tiny_batch_loss_decreases(self):
+        """ Sanity: MLP can overfit a tiny batch (loss decreases). """
+        torch.manual_seed(0)
+        rng = np.random.default_rng(0)
+        X = torch.from_numpy(rng.standard_normal((8, N_IN)).astype(np.float32))
+        y = torch.from_numpy(rng.standard_normal((8, N_OUT)).astype(np.float32))
+        model = MultiLayerPerceptron(X, y, layers=[32, 32], activation=nn.ReLU)
+        model.set_optimizer(nn.MSELoss, torch.optim.Adam, lr=1e-2)
+        first = model.train_on(X, y).item()
+        for _ in range(200):
+            last = model.train_on(X, y).item()
+        assert last < first
+
 
 # ---------------------------------------------------------------------------
 # GatedRecurrentUnit
@@ -255,6 +320,28 @@ class TestGRU:
     def test_hidden_state_size_default(self):
         model = GatedRecurrentUnit(X_t, y_t)
         assert model.H == N_IN
+
+    def test_bias_false_removes_biases(self):
+        """ bias=False must drop the bias on every linear layer. """
+        model = GatedRecurrentUnit(N_IN, N_OUT, hidden_state_size=8, bias=False)
+        assert model.W_h.bias is None
+        assert model.W_u.bias is None
+        assert model.W_r.bias is None
+        assert model.W_y.bias is None
+        # default keeps biases
+        model_b = GatedRecurrentUnit(N_IN, N_OUT, hidden_state_size=8)
+        assert model_b.W_h.bias is not None
+        assert model_b.W_y.bias is not None
+
+    def test_default_activation_is_not_simplex(self):
+        """ Default output must not be a probability simplex (no Softmax). """
+        torch.manual_seed(0)
+        model = GatedRecurrentUnit(N_IN, N_OUT, hidden_state_size=8)
+        H = torch.zeros(T, model.H)
+        Y, _ = model(X_t, H)
+        row_sums = Y.sum(dim=-1)
+        # a Softmax default would force every row sum to exactly 1
+        assert not torch.allclose(row_sums, torch.ones(T))
 
 
 # ---------------------------------------------------------------------------
@@ -313,6 +400,36 @@ class TestLSTM:
     def test_hidden_state_size_default(self):
         model = LongShortTermMemory(X_t, y_t)
         assert model.H == N_IN
+
+    def test_bias_false_removes_biases(self):
+        """ bias=False must drop the bias on every linear layer. """
+        model = LongShortTermMemory(
+            N_IN, N_OUT, hidden_state_size=8, bias=False
+        )
+        for w in (model.W_f, model.W_i, model.W_c, model.W_o,
+                  model.W_h, model.W_y):
+            assert w.bias is None
+
+    def test_default_activation_is_not_simplex(self):
+        """ Default output must not be a probability simplex (no Softmax). """
+        torch.manual_seed(0)
+        model = LongShortTermMemory(N_IN, N_OUT, hidden_state_size=8)
+        H = torch.zeros(T, model.H)
+        C = torch.zeros(T, model.H)
+        Y, _, _ = model(X_t, H, C)
+        assert not torch.allclose(Y.sum(dim=-1), torch.ones(T))
+
+    def test_predict_deterministic_with_dropout(self):
+        """ predict with dropout>0 is deterministic and restores train mode. """
+        torch.manual_seed(0)
+        model = LongShortTermMemory(X_t, y_t, hidden_state_size=8, drop=0.5)
+        model.set_optimizer(nn.MSELoss, torch.optim.Adam, lr=1e-3)
+        H = torch.zeros(T, model.H)
+        C = torch.zeros(T, model.H)
+        Y1, _, _ = model.predict(X_t, H, C)
+        Y2, _, _ = model.predict(X_t, H, C)
+        assert torch.allclose(Y1, Y2)
+        assert model.training
 
 
 # ---------------------------------------------------------------------------
@@ -419,6 +536,36 @@ class TestAttention:
     def test_mha_invalid_heads(self):
         with pytest.raises(ValueError):
             MultiHeadAttention(d_model=33, num_heads=4)
+
+    def test_sdpa_mask_zeros_weight(self):
+        """ Masked positions (mask == 0) get ~0 attention weight. """
+        torch.manual_seed(0)
+        attn = ScaledDotProductAttention()
+        B, T_seq, d = 2, 4, 8
+        Q = torch.randn(B, T_seq, d)
+        K = torch.randn(B, T_seq, d)
+        V = torch.randn(B, T_seq, d)
+        mask = torch.ones(B, T_seq, T_seq)
+        mask[:, :, -1] = 0  # forbid attending to the last key position
+        _, weights = attn(Q, K, V, mask=mask)
+        # weight on masked positions must be (near) zero
+        assert torch.allclose(weights[:, :, -1], torch.zeros(B, T_seq), atol=1e-6)
+        # unmasked rows still sum to one
+        np.testing.assert_allclose(
+            weights.sum(dim=-1).numpy(), np.ones((B, T_seq)), atol=1e-5
+        )
+
+    def test_mha_mask_zeros_weight(self):
+        """ MultiHeadAttention honours the mask: masked keys get ~0 weight. """
+        torch.manual_seed(0)
+        mha = MultiHeadAttention(d_model=16, num_heads=2)
+        x = torch.randn(2, 5, 16)
+        mask = torch.ones(2, 1, 5, 5)
+        mask[:, :, :, -1] = 0  # forbid attending to the last position
+        _, attn = mha(x, mask=mask)
+        assert torch.allclose(
+            attn[:, :, :, -1], torch.zeros(2, mha.num_heads, 5), atol=1e-6
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/fynance/tests/models/test_objective.py
+++ b/fynance/tests/models/test_objective.py
@@ -53,6 +53,24 @@ def test_reproducible_with_seed():
     assert np.allclose(a, b)
 
 
+def test_warm_started_refit_is_reproducible():
+    # The net warm-starts across successive fit() calls (walk-forward refit).
+    # Two equal-seed refit sequences over the same data must yield identical
+    # predictions -- no hidden non-determinism in the online adaptation.
+    X1, r1 = _edge_data(n=300, seed=1)
+    X2, r2 = _edge_data(n=300, seed=2)
+
+    def refit_sequence():
+        m = ObjectiveModel(layers=(8,), epochs=15, lr=5e-3, seed=11)
+        m.fit(X1, r1)        # first walk-forward window
+        m.fit(X2, r2)        # warm-started refit on the next window
+        return np.asarray(m.predict(X2))
+
+    a = refit_sequence()
+    b = refit_sequence()
+    assert np.allclose(a, b)
+
+
 def test_accepts_custom_net_and_loss():
     X, returns = _edge_data(n=300)
     net = torch.nn.Sequential(torch.nn.Linear(2, 4), torch.nn.ReLU(),

--- a/fynance/tests/models/test_rnn.py
+++ b/fynance/tests/models/test_rnn.py
@@ -61,3 +61,44 @@ class TestRecurrentNeuralNetwork:
         H = torch.zeros(T, 32)
         Y, H_out = model(X_t, H)
         assert H_out.shape == (T, 32)
+
+    def test_bias_false_removes_biases(self):
+        """ bias=False must drop the bias on the recurrent and output layers. """
+        model = RecurrentNeuralNetwork(N_IN, N_OUT, hidden_state_size=8, bias=False)
+        assert model.W_h.bias is None
+        assert model.W_y.bias is None
+        model_b = RecurrentNeuralNetwork(N_IN, N_OUT, hidden_state_size=8)
+        assert model_b.W_h.bias is not None
+        assert model_b.W_y.bias is not None
+
+    def test_default_output_is_not_simplex(self):
+        """ Default forward_activation is Identity, not Softmax. """
+        torch.manual_seed(0)
+        model = RecurrentNeuralNetwork(N_IN, N_OUT, hidden_state_size=8)
+        H = torch.zeros(T, model.H)
+        Y, _ = model(X_t, H)
+        # a Softmax default would force every row to sum to exactly 1
+        assert not torch.allclose(Y.sum(dim=-1), torch.ones(T))
+
+    def test_rows_processed_independently(self):
+        """ Honest stateless contract: each row depends only on its own row.
+
+        These cells do NOT thread state across the leading dimension, so
+        perturbing one row of (X, H) must leave the other rows' outputs
+        unchanged. This pins the documented stateless behaviour.
+        """
+        torch.manual_seed(0)
+        model = RecurrentNeuralNetwork(N_IN, N_OUT, hidden_state_size=5)
+        model.eval()
+        X = torch.randn(7, N_IN)
+        H = torch.randn(7, model.H)
+        with torch.no_grad():
+            Y_base, H_base = model(X, H)
+            X_pert = X.clone()
+            X_pert[3] += 100.0  # perturb a single row only
+            Y_pert, H_pert = model(X_pert, H)
+        idx = [i for i in range(7) if i != 3]
+        assert torch.allclose(Y_base[idx], Y_pert[idx], atol=1e-5)
+        assert torch.allclose(H_base[idx], H_pert[idx], atol=1e-5)
+        # the perturbed row itself does change
+        assert not torch.allclose(Y_base[3], Y_pert[3])

--- a/fynance/tests/models/test_rolling.py
+++ b/fynance/tests/models/test_rolling.py
@@ -6,7 +6,11 @@ import torch
 import torch.nn as nn
 
 from fynance.models.mlp import MultiLayerPerceptron
-from fynance.models.rolling import CVResult, _RollingBasis
+from fynance.models.rolling import (
+    CVResult,
+    RollMultiLayerPerceptron,
+    _RollingBasis,
+)
 
 # ---------------------------------------------------------------------------
 # Shared fixtures
@@ -127,3 +131,159 @@ class TestPurge:
         rb = make_rb()
         result = rb.cross_validate(model_factory, X_t, y_t, purge=3)
         assert result.oof_predictions.shape == (T, N_OUT)
+
+
+# ---------------------------------------------------------------------------
+# Causality: window-start guards (no negative-index / future-wrapping windows)
+# ---------------------------------------------------------------------------
+
+class TestWindowGuards:
+
+    def test_roll_period_exceeding_train_period_raises(self):
+        # r > n would push the in-sample eval window (last r bars of the
+        # training window) outside the training window and, with a negative
+        # t0, turn slices into negative indices wrapping to future bars.
+        rb = _RollingBasis(X_t, y_t)
+        with pytest.raises(ValueError, match="roll_period"):
+            rb(train_period=10, test_period=5, roll_period=20)
+
+    def test_negative_start_does_not_produce_negative_windows(self):
+        # A negative start used to let t0 go negative -> slice(t-r, t) and
+        # arange(t-n, t) became negative indices wrapping to the tail (future
+        # leak). t0 must be clamped to >= 0.
+        rb = _RollingBasis(X_t, y_t)
+        rb(train_period=20, test_period=5, start=-8, roll_period=10)
+        assert rb.t0 >= 0
+        it = iter(rb)
+        for eval_set, test_set in it:
+            assert eval_set.start >= 0
+            assert test_set.start >= 0
+            # the rebuilt training index must never be negative
+            assert rb.t_idx.min() >= 0
+
+    def test_all_windows_non_negative_and_train_before_test(self):
+        # Sweep the iterator: every train/eval/test window starts at a
+        # non-negative index and the training window precedes the test window.
+        rb = _RollingBasis(X_t, y_t)
+        rb(train_period=TRAIN, test_period=TEST, roll_period=ROLL)
+        it = iter(rb)
+        for eval_set, test_set in it:
+            train_start = rb.t - rb.n
+            assert train_start >= 0
+            assert eval_set.start >= 0
+            assert test_set.start >= 0
+            # training window [t-n, t) is entirely before the test window.
+            assert rb.t <= test_set.start
+            # eval window is the in-sample tail: inside the training window.
+            assert eval_set.start >= train_start
+            assert eval_set.stop <= rb.t
+
+
+# ---------------------------------------------------------------------------
+# Reported training loss scale (must not depend on batch size)
+# ---------------------------------------------------------------------------
+
+class TestTrainLossScale:
+
+    def _make(self, batch_size):
+        # Seed both RNGs (weight init + the t_idx shuffle in _training) so the
+        # reported loss is deterministic.
+        torch.manual_seed(0)
+        np.random.seed(0)
+        model = RollMultiLayerPerceptron(X_t, y_t, layers=[8])
+        model.set_optimizer(nn.MSELoss, torch.optim.Adam, lr=1e-3)
+        model.set_roll_period(
+            train_period=TRAIN, test_period=TEST, roll_period=ROLL,
+            batch_size=batch_size, epochs=1,
+        )
+        return model
+
+    def _one_train_step(self, model):
+        np.random.seed(0)
+        it = iter(model)
+        next(it)
+        model._training()
+        return model.loss_train[model.i]
+
+    def test_train_loss_on_single_batch_scale(self):
+        # _training reports the mean over batches of per-batch mean losses.
+        # That must be on the same (MSE) scale as a single full-batch loss,
+        # not divided by the train length n (the old `/ n` bug, which made the
+        # reported loss ~ n_batches times too small).
+        model = self._make(batch_size=8)   # 5 batches over n=40
+        reported = self._one_train_step(model)
+        # Reference MSE on the same training window: O(1) for unit-variance
+        # data. The old `/ n` scaling would push it to ~ O(1/40) instead.
+        ref = float(((model.predict(model.X[model.t_idx]).numpy()
+                      - model.y[model.t_idx].numpy()) ** 2).mean())
+        assert reported == pytest.approx(ref, rel=0.6, abs=0.6)
+        assert reported > ref / 3   # not collapsed by the 1/n factor
+
+    def test_train_loss_scale_independent_of_batch_size(self):
+        # Reported train loss for batch_size=8 (5 batches) and batch_size=40
+        # (1 batch) must be on the same scale. The old `/ n` bug divided the
+        # 5-batch sum by n=40 (not by 5), so the small-batch loss came out
+        # several times smaller -- a batch-size-dependent, meaningless scale.
+        ls = self._one_train_step(self._make(batch_size=8))
+        lf = self._one_train_step(self._make(batch_size=TRAIN))
+        assert 0.4 < ls / lf < 2.5
+
+
+# ---------------------------------------------------------------------------
+# _display_kpi reads the current iteration, not the last array slot
+# ---------------------------------------------------------------------------
+
+class TestDisplayKpi:
+
+    def test_kpi_reports_current_iteration_loss(self, capsys):
+        # _display_kpi must read loss_eval[self.i] / loss_test[self.i] -- the
+        # current step -- not [-1] (the last array slot, which stays 0 until the
+        # final iteration and would print the wrong, stale value mid-run).
+        rb = make_rb()
+        rb.loss_eval = np.zeros(5)
+        rb.loss_test = np.zeros(5)
+        rb.i = 1
+        rb.loss_eval[rb.i] = 0.42   # current step value
+        rb.loss_test[rb.i] = 0.73
+        # last slot stays 0 -> if the code used [-1] the printout would show 0.0
+        rb._display_kpi(t=rb.n + rb.s)
+        out = capsys.readouterr().out
+        assert '0.42' in out
+        assert '0.73' in out
+
+
+# ---------------------------------------------------------------------------
+# run(): minimal walk-forward sanity (display off)
+# ---------------------------------------------------------------------------
+
+class TestRunWalkForward:
+
+    def test_run_no_display_train_precedes_test(self):
+        # A tiny seeded walk-forward run with both display paths off must
+        # complete and log per-step losses; and every training window must
+        # precede its test window (causality).
+        torch.manual_seed(0)
+        model = RollMultiLayerPerceptron(X_t, y_t, layers=[8])
+        model.set_optimizer(nn.MSELoss, torch.optim.Adam, lr=1e-3)
+        model.set_roll_period(
+            train_period=TRAIN, test_period=TEST, roll_period=ROLL, epochs=1,
+        )
+        # Record the (train_start, test_start) pairs as the loop advances.
+        bounds = []
+        model.set_roll_period(
+            train_period=TRAIN, test_period=TEST, roll_period=ROLL, epochs=1,
+        )
+        for eval_set, test_set in iter(model):
+            bounds.append((model.t - model.n, test_set.start))
+        for train_start, test_start in bounds:
+            assert train_start >= 0
+            assert train_start + TRAIN <= test_start
+
+        model.set_roll_period(
+            train_period=TRAIN, test_period=TEST, roll_period=ROLL, epochs=1,
+        )
+        out = model.run(backtest_plot=False, backtest_kpi=False)
+        assert out is model
+        stats = model.get_stats()
+        assert stats.size > 0
+        assert np.all(np.isfinite(stats["train_loss"]))

--- a/fynance/tests/models/test_signalmodel.py
+++ b/fynance/tests/models/test_signalmodel.py
@@ -45,3 +45,24 @@ def test_fit_returns_self():
     model = MultiLayerPerceptron(X, y, layers=[4])
     model.set_optimizer(nn.MSELoss, torch.optim.SGD, lr=1e-3)
     assert model.fit(X, y) is model
+
+
+def test_fit_predict_on_float64_numpy():
+    """ Plain float64 numpy (no .astype) must fit/predict without crashing. """
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(40, 3))  # float64 by default
+    y = X.sum(axis=1, keepdims=True)  # float64
+    assert X.dtype == np.float64 and y.dtype == np.float64
+    model = MultiLayerPerceptron(X, y, layers=[8])
+    model.set_optimizer(nn.MSELoss, torch.optim.SGD, lr=1e-3)
+    out = model.fit(X, y, epochs=2).predict(X)
+    assert np.asarray(out).shape[0] == X.shape[0]
+
+
+def test_set_seed_only_seeds_requested_generator():
+    """ Passing only seed_torch must leave the numpy seed untouched. """
+    X, y = _xy()
+    model = MultiLayerPerceptron(X, y, layers=[4])
+    model.set_seed(seed_torch=123)
+    assert model.seed_torch == 123
+    assert model.seed_numpy is None  # numpy generator not (re)seeded

--- a/fynance/tests/portfolio/test_allocation.py
+++ b/fynance/tests/portfolio/test_allocation.py
@@ -73,6 +73,34 @@ def test_ivp_equal_variance():
     np.testing.assert_allclose(w, np.full(4, 0.25), atol=1e-4)
 
 
+def test_ivp_proportional_to_inverse_variance():
+    """ Unequal-variance assets: weights ∝ 1/σ² (the documented formula). """
+    rng = np.random.default_rng(1)
+    vols = np.array([0.01, 0.04, 0.16])  # 1x / 4x / 16x
+    X = rng.normal(0.0, 1.0, size=(4000, 3)) * vols
+    var = np.diag(np.cov(X, rowvar=False))
+    expected = (1.0 / var) / np.sum(1.0 / var)
+
+    w = IVP(X).flatten()
+    np.testing.assert_allclose(w, expected, rtol=1e-10)
+
+    # normalize=True must preserve the inverse-variance ordering (no asset
+    # zeroed by a subtract-min step) and keep a valid distribution.
+    w_norm = IVP(X, normalize=True).flatten()
+    assert np.all(w_norm > 0)
+    assert abs(w_norm.sum() - 1.0) < 1e-9
+    # With default box bounds the distribution is unchanged.
+    np.testing.assert_allclose(w_norm, expected, rtol=1e-10)
+
+
+def test_ivp_single_asset():
+    """ N == 1 must not crash on the 0-d covariance and return [[1.]]. """
+    X = RNG.normal(0.0, 0.01, size=(50, 1))
+    w = IVP(X)
+    assert w.shape == (1, 1)
+    np.testing.assert_allclose(w, [[1.0]])
+
+
 # ---------------------------------------------------------------------------
 # MVP
 # ---------------------------------------------------------------------------
@@ -89,6 +117,27 @@ def test_mvp_normalized_positive(returns):
     assert abs(w.sum() - 1.0) < 1e-6
 
 
+def test_mvp_single_asset():
+    """ N == 1 must not crash on the 0-d covariance and return [[1.]]. """
+    X = RNG.normal(0.0, 0.01, size=(50, 1))
+    w = MVP(X)
+    assert w.shape == (1, 1)
+    np.testing.assert_allclose(w, [[1.0]])
+
+
+def test_mvp_singular_covariance_pinv():
+    """ Linearly dependent columns trigger the pseudo-inverse fallback. """
+    rng = np.random.default_rng(11)
+    a = rng.normal(0.0, 0.01, size=(200, 1))
+    b = rng.normal(0.0, 0.01, size=(200, 1))
+    # Third column is an exact linear combination → singular covariance.
+    X = np.column_stack([a, b, 2.0 * a - 3.0 * b])
+    w = MVP(X).flatten()
+    assert w.shape == (3,)
+    assert abs(w.sum() - 1.0) < 1e-6
+    assert np.all(np.isfinite(w))
+
+
 # ---------------------------------------------------------------------------
 # MVP_uc
 # ---------------------------------------------------------------------------
@@ -103,6 +152,35 @@ def test_mvp_uc_bounds(returns):
     w = MVP_uc(returns).flatten()
     assert np.all(w >= -1e-6)
     assert np.all(w <= 1.0 + 1e-6)
+
+
+def test_mvp_uc_matches_closed_form_unequal_variance():
+    """ On a long-only feasible set MVP_uc must match the closed-form MVP.
+
+    Regression for the ftol/scaling bug: on small return-scale variances the
+    objective w'Σw fell below SLSQP's default ftol and the optimizer returned
+    the 1/N start instead of the minimum-variance weights.
+    """
+    rng = np.random.default_rng(0)
+    vols = np.array([0.01, 0.04, 0.16])  # 1x / 4x / 16x, uncorrelated
+    X = rng.normal(0.0, 1.0, size=(5000, 3)) * vols
+
+    w_uc = MVP_uc(X).flatten()
+    w_cf = MVP(X).flatten()
+    # The closed-form solution here is long-only (positive), so it is feasible
+    # for the box-constrained problem and the two must coincide.
+    assert np.all(w_cf >= 0)
+    np.testing.assert_allclose(w_uc, w_cf, atol=1e-4)
+    # And it is clearly not the 1/N start (the old buggy output).
+    assert not np.allclose(w_uc, np.full(3, 1 / 3), atol=1e-2)
+
+
+def test_mvp_uc_single_asset():
+    """ N == 1 must not crash on the 0-d covariance and return [[1.]]. """
+    X = RNG.normal(0.0, 0.01, size=(50, 1))
+    w = MVP_uc(X)
+    assert w.shape == (1, 1)
+    np.testing.assert_allclose(w, [[1.0]])
 
 
 # ---------------------------------------------------------------------------
@@ -129,6 +207,40 @@ def test_erc_equal_risk_uncorrelated():
     np.testing.assert_allclose(w, np.full(4, 0.25), atol=0.05)
 
 
+def test_erc_equalizes_risk_contributions_unequal_variance():
+    """ ERC must equalize risk contributions, not return the 1/N start.
+
+    Regression for the ftol/scaling bug: the quartic risk-contribution
+    surrogate on return-scale covariances was ~1e-16, below SLSQP's default
+    ftol, so the optimizer stopped at iteration 1 and returned 1/N. On
+    uncorrelated assets with vols 1x/4x/16x that gave risk contributions of
+    roughly [0.006, 0.058, 0.936] instead of equalized thirds.
+    """
+    rng = np.random.default_rng(0)
+    vols = np.array([0.01, 0.04, 0.16])  # 1x / 4x / 16x
+    X = rng.normal(0.0, 1.0, size=(5000, 3)) * vols
+    sigma = np.cov(X, rowvar=False)
+
+    w = ERC(X).flatten()
+    # Risk contributions RC_i = w_i (Σ w)_i, normalized to sum to one.
+    rc = w * (sigma @ w)
+    rc = rc / rc.sum()
+    # Equal risk contributions: each asset carries 1/N of total risk.
+    np.testing.assert_allclose(rc, np.full(3, 1 / 3), atol=1e-3)
+    # The solution must not be the 1/N starting guess.
+    assert not np.allclose(w, np.full(3, 1 / 3), atol=1e-2)
+    # Lower-variance assets must carry more weight (ERC tilts toward them).
+    assert w[0] > w[1] > w[2]
+
+
+def test_erc_single_asset():
+    """ N == 1 must not crash on the 0-d covariance and return [[1.]]. """
+    X = RNG.normal(0.0, 0.01, size=(50, 1))
+    w = ERC(X)
+    assert w.shape == (1, 1)
+    np.testing.assert_allclose(w, [[1.0]])
+
+
 # ---------------------------------------------------------------------------
 # MDP
 # ---------------------------------------------------------------------------
@@ -142,6 +254,32 @@ def test_mdp_shape_and_sum(returns):
 def test_mdp_positive(returns):
     w = MDP(returns).flatten()
     assert np.all(w >= -1e-6)
+
+
+def test_mdp_beats_equal_weight_diversification():
+    """ MDP weights must achieve a higher diversification ratio than 1/N. """
+    from fynance.metrics import diversified_ratio
+
+    rng = np.random.default_rng(3)
+    # Two correlated blocks with different volatilities: 1/N is sub-optimal.
+    f1 = rng.normal(0.0, 0.01, size=(600, 1))
+    f2 = rng.normal(0.0, 0.01, size=(600, 1))
+    idio = rng.normal(0.0, 0.003, size=(600, 4))
+    vols = np.array([1.0, 1.0, 4.0, 4.0])
+    X = np.column_stack([f1, f1, f2, f2]) * vols + idio
+
+    w = MDP(X).flatten()
+    dr_mdp = float(np.asarray(diversified_ratio(X, W=w)).item())
+    dr_eq = float(np.asarray(diversified_ratio(X)).item())
+    assert dr_mdp > dr_eq
+
+
+def test_mdp_single_asset():
+    """ N == 1 must not crash and return [[1.]]. """
+    X = RNG.normal(0.0, 0.01, size=(50, 1))
+    w = MDP(X)
+    assert w.shape == (1, 1)
+    np.testing.assert_allclose(w, [[1.0]])
 
 
 # ---------------------------------------------------------------------------
@@ -164,6 +302,42 @@ def test_hrp_correlated(correlated_returns):
     w = HRP(correlated_returns)
     assert w.shape == (N, 1)
     assert abs(w.sum() - 1.0) < 1e-6
+
+
+def test_hrp_splits_risk_across_blocks():
+    """ On two correlated blocks HRP must spread risk between the blocks.
+
+    Block A (assets 0-1) is low-volatility, block B (assets 2-3) is high
+    volatility. HRP's inverse-variance bisection should give block A more
+    total weight than block B, yet keep both blocks meaningfully funded
+    (unlike a pure minimum-variance solution that piles into the low-vol
+    block).
+    """
+    rng = np.random.default_rng(5)
+    fa = rng.normal(0.0, 0.01, size=(800, 1))
+    fb = rng.normal(0.0, 0.01, size=(800, 1))
+    idio = rng.normal(0.0, 0.002, size=(800, 4))
+    vols = np.array([1.0, 1.0, 3.0, 3.0])
+    X = np.column_stack([fa, fa, fb, fb]) * vols + idio
+
+    w = HRP(X).flatten()
+    block_a = w[0] + w[1]
+    block_b = w[2] + w[3]
+    # Low-vol block gets more weight than the high-vol block.
+    assert block_a > block_b
+    # But the high-vol block is still funded, not crushed to zero.
+    assert block_b > 0.05
+    # Within each block, the two near-identical assets are split evenly.
+    np.testing.assert_allclose(w[0], w[1], rtol=0.2)
+    np.testing.assert_allclose(w[2], w[3], rtol=0.2)
+
+
+def test_hrp_single_asset():
+    """ N == 1 must not crash on the 0-d covariance and return [[1.]]. """
+    X = RNG.normal(0.0, 0.01, size=(50, 1))
+    w = HRP(X)
+    assert w.shape == (1, 1)
+    np.testing.assert_allclose(w, [[1.0]])
 
 
 # ---------------------------------------------------------------------------
@@ -209,6 +383,17 @@ def test_normalize_clamps_weights():
     w_norm = _normalize(w.copy(), low_bound=0.1, up_bound=0.4)
     assert np.all(w_norm >= 0.1 - 1e-9)
     assert np.all(w_norm <= 0.4 + 1e-9)
+
+
+def test_normalize_does_not_mutate_input():
+    """ _normalize must copy its input, never mutate the caller's array. """
+    w = np.array([0.5, 0.3, 0.15, 0.05])
+    original = w.copy()
+    out = _normalize(w, low_bound=0.1, up_bound=0.4)
+    # Caller's array untouched.
+    np.testing.assert_array_equal(w, original)
+    # And a genuinely new array was returned.
+    assert out is not w
 
 
 def test_normalize_max_iter_warning(capsys):

--- a/fynance/tests/research/test_compare.py
+++ b/fynance/tests/research/test_compare.py
@@ -4,6 +4,7 @@
 """ Tests for :mod:`fynance.research.compare`. """
 
 # Built-in
+import math
 from pathlib import Path
 
 # Third-party
@@ -12,7 +13,13 @@ import pytest
 
 # Local
 import fynance
-from fynance.research import compare_report, gbm, leaderboard, run_experiment
+from fynance.research import (
+    Experiment,
+    compare_report,
+    gbm,
+    leaderboard,
+    run_experiment,
+)
 from fynance.strategy import Strategy
 
 
@@ -35,6 +42,35 @@ def test_leaderboard_ranked_by_sharpe(experiments):
     assert {r["name"] for r in rows} == {"a", "b", "c"}
     sharpes = [r["sharpe"] for r in rows]
     assert sharpes == sorted(sharpes, reverse=True)
+
+
+def test_leaderboard_nan_sinks_to_bottom():
+    # A present-but-NaN metric must sort as "worst", not float to the top.
+    exps = [
+        Experiment(name="good", metrics={"sharpe": 2.0}),
+        Experiment(name="bad", metrics={"sharpe": float("nan")}),
+        Experiment(name="mid", metrics={"sharpe": 1.0}),
+    ]
+
+    rows = leaderboard(exps, sort_by="sharpe", descending=True)
+
+    assert [r["name"] for r in rows[:2]] == ["good", "mid"]
+    assert rows[-1]["name"] == "bad"  # NaN sank to the bottom
+    assert math.isnan(rows[-1]["sharpe"])
+
+
+def test_leaderboard_nan_sinks_ascending():
+    # Ascending (lower is better): NaN must still sink to the bottom.
+    exps = [
+        Experiment(name="bad", metrics={"sharpe": float("nan")}),
+        Experiment(name="best", metrics={"sharpe": -1.0}),
+        Experiment(name="worst", metrics={"sharpe": 5.0}),
+    ]
+
+    rows = leaderboard(exps, sort_by="sharpe", descending=False)
+
+    assert rows[0]["name"] == "best"
+    assert rows[-1]["name"] == "bad"
 
 
 def test_compare_report_writes_md_and_png(tmp_path, experiments):

--- a/fynance/tests/research/test_experiment.py
+++ b/fynance/tests/research/test_experiment.py
@@ -74,3 +74,28 @@ def test_version_and_timestamp_autoset():
 
     assert e.fynance_version == fynance.__version__
     assert e.created_at  # non-empty ISO timestamp
+
+
+def test_from_dict_tolerates_unknown_keys(populated):
+    # Forward compatibility: an artifact from a newer fynance may carry extra
+    # fields. from_dict must ignore them rather than raise TypeError.
+    data = populated.to_dict()
+    data["a_future_field"] = {"not": "known here"}
+    data["another_extra"] = 42
+
+    restored = Experiment.from_dict(data)
+
+    assert restored.name == "demo"
+    assert restored.metrics["sharpe"] == 1.5
+    assert not hasattr(restored, "a_future_field")
+
+
+def test_load_raises_clear_error_on_corrupt_json(tmp_path):
+    # A truncated / corrupt artifact must raise a clear ValueError naming the
+    # path, not leak a bare JSONDecodeError.
+    path = tmp_path / "bad" / "experiment.json"
+    path.parent.mkdir(parents=True)
+    path.write_text('{"name": "demo", "metrics": {', encoding="utf-8")  # truncated
+
+    with pytest.raises(ValueError, match="corrupt or truncated"):
+        Experiment.load(path)

--- a/fynance/tests/research/test_guards.py
+++ b/fynance/tests/research/test_guards.py
@@ -53,6 +53,44 @@ def test_dsr_decreases_with_more_trials():
     assert 0.0 <= many <= 1.0
 
 
+def test_psr_matches_hand_computed_reference():
+    # Worked reference (Bailey & Lopez de Prado PSR), hand-computed:
+    #   sr = 0.10 (per-observation), n_obs = 100, benchmark = 0, normal returns
+    #   denom = sqrt(1 - 0*sr + (3-1)/4 * sr^2) = sqrt(1 + 0.5 * 0.01) = 1.0024969
+    #   z     = (0.10 - 0) * sqrt(100 - 1) / denom = 0.99250926
+    #   PSR   = Phi(z) = 0.83952542
+    assert probabilistic_sharpe_ratio(0.1, 100) == pytest.approx(
+        0.8395254171844497, abs=1e-12
+    )
+
+
+def test_dsr_matches_hand_computed_reference():
+    # Worked reference (Bailey & Lopez de Prado DSR), hand-computed:
+    #   n_trials = 10, sr_variance = 0.04 (std 0.2)
+    #   E[max] gauss factor = (1 - g) * Phi^-1(1 - 1/10)
+    #                         + g * Phi^-1(1 - 1/(10 e)) = 1.57459830
+    #     (g = Euler-Mascheroni = 0.5772156649)
+    #   sr_star = sqrt(0.04) * 1.57459830 = 0.31491966
+    #   then PSR(sr=0.30 per-obs, n_obs=500, benchmark=sr_star):
+    #     denom = sqrt(1 + 0.5 * 0.30^2) = 1.0220568
+    #     z     = (0.30 - 0.31491966) * sqrt(499) / denom = -0.32602512
+    #     DSR   = Phi(z) = 0.37220268
+    assert deflated_sharpe_ratio(0.3, 500, 10, sr_variance=0.04) == pytest.approx(
+        0.3722026752956389, abs=1e-12
+    )
+
+
+def test_psr_dsr_not_saturated_for_realistic_inputs():
+    # A realistic annualized Sharpe (~1.0 daily) de-annualized to per-obs
+    # (1 / sqrt(252) = 0.063) must yield a sensible, non-saturated PSR/DSR.
+    sr_obs = 1.0 / np.sqrt(252)
+    psr = probabilistic_sharpe_ratio(sr_obs, 500)
+    dsr = deflated_sharpe_ratio(sr_obs, 500, 10, sr_variance=0.04 / 252)
+
+    assert 0.6 < psr < 0.999  # informative, not pinned at 1.0
+    assert 0.3 < dsr < 0.95   # the multiple-testing correction still bites
+
+
 # -- permutation test ------------------------------------------------------
 
 def test_permutation_structure_and_determinism():
@@ -62,6 +100,49 @@ def test_permutation_structure_and_determinism():
     assert set(out1) == {"observed", "p_value", "null_mean", "null_std"}
     assert 0.0 < out1["p_value"] <= 1.0
     assert out1 == out2  # fully reproducible
+
+
+def stochastic_momentum() -> Strategy:
+    """ Momentum whose features carry noise drawn from the global numpy RNG. """
+    def features(p):
+        base = np.diff(p, prepend=p[0])
+        return base + 0.01 * np.std(base) * np.random.standard_normal(base.shape)
+
+    return Strategy(features=features)
+
+
+def test_permutation_threads_distinct_seeds_per_run():
+    # Regression: the master seed used to be reused verbatim for the observed
+    # run and every permutation, so a stochastic strategy replayed *identical*
+    # model RNG draws on every path. The fix derives a distinct seed per run.
+    # Reconstruct the old "reuse one seed" null and assert the real null is not
+    # the same sequence, while staying fully reproducible.
+    from fynance.research.runner import run_experiment
+
+    strat = stochastic_momentum()
+    prices = gbm(300, seed=1).to_numpy()
+    log_ret = np.diff(np.log(prices))
+    s0 = float(prices[0])
+    seed, n_perm = 7, 30
+
+    out = permutation_test(strat, prices, n_permutations=n_perm, seed=seed)
+
+    # Old behavior: every run seeded with the same master seed.
+    rng = np.random.default_rng(seed)
+    legacy = np.empty(n_perm)
+    for i in range(n_perm):
+        shuffled = rng.permutation(log_ret)
+        path = s0 * np.exp(np.concatenate([[0.0], np.cumsum(shuffled)]))
+        legacy[i] = run_experiment(strat, path, name="perm", seed=seed
+                                   ).metrics["sharpe"]
+
+    # The fixed null differs from the legacy (one-seed) null for a stochastic
+    # strategy: the model noise now varies across permutations too.
+    assert not np.allclose([out["null_mean"]], [legacy.mean()])
+    assert out["null_std"] > 0.0
+    # Still reproducible for a fixed seed.
+    out2 = permutation_test(strat, prices, n_permutations=n_perm, seed=seed)
+    assert out == out2
 
 
 def test_permutation_detects_autocorrelation_edge():

--- a/fynance/tests/research/test_ledger.py
+++ b/fynance/tests/research/test_ledger.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 # Third-party
 import numpy as np
+import pytest
 
 # Local
 import fynance
@@ -75,3 +76,62 @@ def test_n_trials_counts_only_experiments(tmp_path):
     (tmp_path / "stray" / "report.md").write_text("noise")
 
     assert led.n_trials == 1
+
+
+def test_append_rejects_duplicate_name(tmp_path):
+    # Append-only: a name collision must raise rather than silently overwrite
+    # (which would undercount n_trials and deflate the DSR correction).
+    led = Ledger(tmp_path)
+    led.append(Experiment(name="dup", metrics={"sharpe": 1.0}))
+
+    with pytest.raises(FileExistsError):
+        led.append(Experiment(name="dup", metrics={"sharpe": 9.0}))
+
+    # The original is untouched and the trial count stays correct.
+    assert led.n_trials == 1
+    assert led.load()[0].metrics["sharpe"] == 1.0
+
+
+def test_deflated_sharpe_deannualizes_not_saturated(tmp_path):
+    # Realistic annualized Sharpes (~1) over n_obs ~ 500 must NOT saturate the
+    # DSR to ~1 once de-annualized; before the fix the annualized Sharpe was
+    # fed straight in, pinning the DSR at ~1.
+    led = Ledger(tmp_path)
+    rng = np.random.default_rng(0)
+    for i in range(12):
+        n = 500
+        # Per-day Sharpe ~ 0.06 -> annualized ~ 1.0, with spread across trials.
+        per_day = 0.06 + 0.02 * rng.standard_normal()
+        sharpe_annual = per_day * np.sqrt(252)
+        returns = (per_day + rng.standard_normal(n)).tolist()
+        led.append(Experiment(
+            name=f"t{i}",
+            spec={"period": 252},
+            metrics={"sharpe": float(sharpe_annual)},
+            series={"returns": returns},
+        ))
+
+    best = max(led.load(), key=lambda e: e.metrics["sharpe"])
+    dsr = led.deflated_sharpe(best)
+
+    assert 0.0 <= dsr <= 1.0
+    assert dsr < 0.999  # NOT saturated — the multiple-testing correction bites
+
+
+def test_deflated_sharpe_uses_recorded_period(tmp_path):
+    # The de-annualization must use the period recorded in spec. A monthly run
+    # (period=12) and a daily run (period=252) carrying the SAME annualized
+    # Sharpe de-annualize to different per-obs Sharpes -> different DSR.
+    returns = np.random.default_rng(1).standard_normal(400).tolist()
+
+    def _led(period):
+        led = Ledger(tmp_path / f"p{period}")
+        e = Experiment(name="x", spec={"period": period},
+                       metrics={"sharpe": 1.5}, series={"returns": returns})
+        led.append(e)
+        return led, e
+
+    led_d, e_d = _led(252)
+    led_m, e_m = _led(12)
+
+    assert led_d.deflated_sharpe(e_d) != led_m.deflated_sharpe(e_m)

--- a/fynance/tests/research/test_run_experiment.py
+++ b/fynance/tests/research/test_run_experiment.py
@@ -71,6 +71,27 @@ def test_costs_override_changes_result():
     assert free.metrics != pricey.metrics
 
 
+def test_costs_override_does_not_mutate_strategy():
+    # The override must be confined to the single run: a later run on the same
+    # strategy must not inherit it (an aliasing hazard in permutation loops).
+    own = ProportionalCost(0.0005)
+    strat = Strategy(features=lambda p: np.diff(p, prepend=p[0]), cost=own)
+    data = gbm(400, seed=3)
+
+    overridden = run_experiment(strat, data, name="ovr", costs=ProportionalCost(0.02))
+
+    assert strat.cost is own  # restored, not left pointing at the override
+
+    # And a subsequent run with no override uses the strategy's own cost.
+    again = run_experiment(strat, data, name="again")
+    baseline = run_experiment(
+        Strategy(features=lambda p: np.diff(p, prepend=p[0]), cost=ProportionalCost(0.0005)),
+        data, name="base",
+    )
+    assert again.metrics == baseline.metrics
+    assert again.metrics != overridden.metrics
+
+
 def test_no_lookahead_walk_forward():
     # Perturbing the tail must not change the out-of-sample returns on the
     # earlier (unperturbed) prefix — a black-box causality probe.

--- a/fynance/tests/research/test_synthetic.py
+++ b/fynance/tests/research/test_synthetic.py
@@ -52,3 +52,26 @@ def test_zero_length_edge_cases():
     # n == 1 -> a single starting price, no returns.
     assert gbm(1, s0=100.0, seed=0).to_numpy().tolist() == [100.0]
     assert regime_switching(1, s0=100.0, seed=0).to_numpy().tolist() == [100.0]
+
+
+def test_regime_switching_initial_state_is_drawn():
+    # With p_switch=0 the only regime randomness is the *initial* state. It used
+    # to be hard-coded to regime 0 (biasing short paths); now it is drawn, so
+    # across seeds both regimes must appear. Distinct sigmas make the active
+    # regime visible in the first log-return's magnitude.
+    regimes = ((0.0, 0.001), (0.0, 0.5))
+    high_vol = []
+    for s in range(40):
+        p = regime_switching(2, regimes=regimes, p_switch=0.0, seed=s).to_numpy()
+        first_ret = np.diff(np.log(p))[0]
+        high_vol.append(abs(first_ret) > 0.05)  # True => started in regime 1
+
+    assert any(high_vol)          # regime 1 was sometimes the initial state
+    assert any(not h for h in high_vol)  # regime 0 too -> genuinely drawn
+
+
+def test_regime_switching_initial_state_reproducible():
+    a = regime_switching(50, p_switch=0.1, seed=9).to_numpy()
+    b = regime_switching(50, p_switch=0.1, seed=9).to_numpy()
+
+    assert np.allclose(a, b)

--- a/fynance/tests/signal/test_signal.py
+++ b/fynance/tests/signal/test_signal.py
@@ -48,6 +48,31 @@ def test_rank_requires_2d():
         rank(np.array([1.0, 2.0, 3.0]), top=1, bottom=1)
 
 
+def test_rank_rejects_overlapping_legs():
+    # top + bottom > n_assets would let the long leg overwrite the short leg,
+    # silently producing a non-dollar-neutral book (sum 0.667 in the report).
+    import pytest
+    with pytest.raises(ValueError):
+        rank(np.array([[1.0, 2.0, 3.0, 4.0]]), top=3, bottom=3)
+
+
+def test_rank_rejects_negative_legs():
+    import pytest
+    for top, bottom in ((-1, 1), (1, -1)):
+        with pytest.raises(ValueError):
+            rank(np.array([[1.0, 2.0, 3.0, 4.0]]), top=top, bottom=bottom)
+
+
+def test_rank_dollar_neutral_when_legs_fit():
+    # Any valid split (top + bottom <= n_assets) must be exactly dollar-neutral.
+    pred = np.array([[1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+                     [6.0, 5.0, 4.0, 3.0, 2.0, 1.0]])
+    for top, bottom in ((1, 1), (2, 2), (3, 3), (2, 1), (1, 4)):
+        w = rank(pred, top=top, bottom=bottom)
+        assert np.allclose(w.sum(axis=1), 0.0)        # row-wise dollar-neutral
+        assert np.allclose(w[w > 0].sum(), top * w.shape[0] * (1.0 / top))
+
+
 def test_vol_target_position_is_causal():
     rng = np.random.default_rng(0)
     prices = 100.0 * np.cumprod(1.0 + rng.normal(0, 0.01, 100))

--- a/fynance/tests/strategy/test_strategy.py
+++ b/fynance/tests/strategy/test_strategy.py
@@ -81,6 +81,63 @@ def test_swappable_signal_slot():
     assert not np.allclose(r1.positions, r2.positions)
 
 
+def test_run_with_precomputed_features_X():
+    # X replaces features(prices): the model never sees the price-only
+    # featurizer, so a constant exogenous feature must drive the position.
+    prices = _prices(120)
+
+    class PassThrough:
+        def fit(self, X, y):
+            return self
+
+        def predict(self, X):
+            return np.asarray(X, dtype=np.float64).reshape(-1)
+
+    # Exogenous feature: +1 everywhere -> sign() -> long everywhere.
+    X = np.ones(prices.shape[0])
+    strat = Strategy(model=PassThrough(), signal=sign)
+    res = strat.run(prices, X=X)
+    assert isinstance(res, BacktestResult)
+    # All positions long (1.0) since X is constant +1.
+    assert np.allclose(res.positions, 1.0)
+
+    # And X actually overrides the featurizer: flipping X flips the book.
+    res_neg = strat.run(prices, X=-np.ones(prices.shape[0]))
+    assert np.allclose(res_neg.positions, -1.0)
+
+
+def test_run_walk_forward_with_precomputed_features_X():
+    prices = _prices(300)
+    y = np.sign(np.diff(prices, prepend=prices[0]))
+
+    class MeanModel:
+        def fit(self, X, y):
+            self._m = float(np.mean(np.asarray(y)))
+            return self
+
+        def predict(self, X):
+            return np.full(np.asarray(X).shape[0], self._m)
+
+    # 2-D exogenous feature matrix aligned with the price index.
+    X = np.column_stack([y, np.ones_like(y)])
+    strat = Strategy(model=MeanModel(), signal=sign)
+    res = strat.run_walk_forward(prices, y, train=100, test=20, step=20, X=X)
+    assert isinstance(res, BacktestResult)
+    assert np.isfinite(res.summary()["sharpe"])
+
+    # No-lookahead with X: perturbing the FUTURE leaves earlier OOS positions
+    # untouched (X is sliced per window, never globally).
+    cut = len(prices) - 40
+    p2 = prices.copy()
+    p2[cut:] *= 1.2
+    y2 = np.sign(np.diff(p2, prepend=p2[0]))
+    X2 = np.column_stack([y2, np.ones_like(y2)])
+    pert = strat.run_walk_forward(p2, y2, train=100, test=20, step=20, X=X2)
+    prefix = cut - 100 - 40
+    assert prefix > 0
+    assert np.allclose(res.positions[:prefix], pert.positions[:prefix])
+
+
 def test_walk_forward_no_lookahead():
     # A model that *genuinely depends on y* (so the probe is not vacuous).
     class MeanSignModel:

--- a/fynance/tests/test_exceptions.py
+++ b/fynance/tests/test_exceptions.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for :class:`fynance._exceptions.ArraySizeError`. """
+
+# Third-party packages
+import pytest
+
+# Local packages
+from fynance._exceptions import ArraySizeError
+
+
+def test_message_size_only():
+    err = ArraySizeError(3)
+    assert str(err) == "array of size 3 is not allowed"
+
+
+def test_message_with_axis():
+    err = ArraySizeError(3, axis=1)
+    assert str(err) == "array of size 3 in axis 1 is not allowed"
+
+
+def test_message_with_min_size():
+    err = ArraySizeError(3, min_size=5)
+    assert str(err) == "array of size 3 is not allowed, minimum size is 5"
+
+
+def test_message_with_axis_and_min_size():
+    err = ArraySizeError(3, axis=0, min_size=5)
+    assert str(err) == (
+        "array of size 3 in axis 0 is not allowed, minimum size is 5"
+    )
+
+
+def test_message_with_prefix():
+    err = ArraySizeError(3, msg_prefix="feature matrix")
+    assert str(err) == "feature matrix: array of size 3 is not allowed"
+
+
+def test_message_with_all_fields():
+    err = ArraySizeError(3, axis=1, min_size=5, msg_prefix="X")
+    assert str(err) == (
+        "X: array of size 3 in axis 1 is not allowed, minimum size is 5"
+    )
+
+
+def test_dual_inheritance_valueerror_and_indexerror():
+    # ArraySizeError is both a ValueError and an IndexError, so callers can
+    # catch it under either contract.
+    err = ArraySizeError(0)
+    assert isinstance(err, ValueError)
+    assert isinstance(err, IndexError)
+
+    with pytest.raises(ValueError):
+        raise ArraySizeError(0)
+
+    with pytest.raises(IndexError):
+        raise ArraySizeError(0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fynance"
-version = "2.9.0"
+version = "2.10.0"
 description = "Pure-Python (Numba-accelerated) machine learning, econometrics and statistical tools for financial analysis and backtesting"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Release **v2.10.0** — full 2026-06 code-audit remediation (9 PRs, #188–#196). Merge after `chore/release-2.10.0` (#198) lands in develop.

Corrects logic bugs, lookahead risks, weak/missing tests and doc drift the 5 gates didn't catch. Highlights: features `axis=1` path, `ERC`/`MVP_uc` convergence, research DSR de-annualization, `_RollingBasis` future-leak guard, NN eval-mode/dtype/contract, loss numerical stability, CONTRIBUTING/Sphinx refresh. 658 → 819 tests.