### PR TITLE
fix: _RollingBasis._display_kpi IndexError on default run() path + zero-denominator guard

### DIFF
--- a/fynance/models/rolling.py
+++ b/fynance/models/rolling.py
@@ -468,12 +468,18 @@ class _RollingBasis:
 
     def _display_kpi(self, t):
         pct = t - self.n - self.s
-        pct = pct / (self.T - self.n - self.T % self.s)
+        # Guard the denominator: ``T - n - T % s`` can be 0 (e.g. T=45, n=40,
+        # s=10) which would raise ``ZeroDivisionError``. Floor it at 1.
+        pct = pct / max(self.T - self.n - self.T % self.s, 1)
         txt = '{:5.2%} is done | '.format(pct)
         # Use the current iteration index ``self.i`` — ``[-1]`` is the last
-        # array slot, which stays 0 until the final iteration.
-        txt += 'Eval loss is {:5.2} | '.format(self.loss_eval[self.i])
-        txt += 'Test loss is {:5.2} | '.format(self.loss_test[self.i])
+        # array slot, which stays 0 until the final iteration. ``__next__``
+        # bumps ``self.i`` before the ``StopIteration`` check, so after the
+        # loop ``self.i == loss_eval.size``; clamp to the last filled slot to
+        # avoid an out-of-bounds read on the final out-of-loop print.
+        i = min(self.i, self.loss_eval.size - 1)
+        txt += 'Eval loss is {:5.2} | '.format(self.loss_eval[i])
+        txt += 'Test loss is {:5.2} | '.format(self.loss_test[i])
         print(txt, end='\r')
 
     def _display_plot_loss(self, bnn, i):

--- a/fynance/tests/models/test_rolling.py
+++ b/fynance/tests/models/test_rolling.py
@@ -251,6 +251,31 @@ class TestDisplayKpi:
         assert '0.42' in out
         assert '0.73' in out
 
+    def test_kpi_index_clamped_after_loop(self):
+        # __next__ bumps self.i before the StopIteration check, so after the
+        # loop self.i == loss_eval.size. The final out-of-loop _print must not
+        # index out of bounds: the index has to be clamped to the last slot.
+        rb = make_rb()
+        rb.loss_eval = np.zeros(4)
+        rb.loss_test = np.zeros(4)
+        rb.loss_eval[-1] = 0.5
+        rb.loss_test[-1] = 0.6
+        rb.i = rb.loss_eval.size   # one past the last valid slot
+        rb._display_kpi(t=rb.n + rb.s)   # must not raise IndexError
+
+    def test_kpi_zero_denominator_does_not_divide_by_zero(self):
+        # For T=45, n=40, s=10 the denominator (T - n - T % s) is 0; the
+        # progress percentage must be guarded against ZeroDivisionError.
+        X = torch.from_numpy(RNG.standard_normal((45, N_IN)).astype(np.float32))
+        y = torch.from_numpy(RNG.standard_normal((45, N_OUT)).astype(np.float32))
+        rb = _RollingBasis(X, y)
+        rb(train_period=40, test_period=10, roll_period=10)
+        assert rb.T - rb.n - rb.T % rb.s == 0   # degenerate denominator
+        rb.loss_eval = np.zeros(1)
+        rb.loss_test = np.zeros(1)
+        rb.i = 0
+        rb._display_kpi(t=rb.n + rb.s)   # must not raise ZeroDivisionError
+
 
 # ---------------------------------------------------------------------------
 # run(): minimal walk-forward sanity (display off)
@@ -287,3 +312,19 @@ class TestRunWalkForward:
         stats = model.get_stats()
         assert stats.size > 0
         assert np.all(np.isfinite(stats["train_loss"]))
+
+    def test_run_default_kpi_path_completes(self):
+        # The DEFAULT path run(backtest_kpi=True) used to raise IndexError on
+        # the final out-of-loop print: __next__ bumps self.i past the last
+        # filled loss slot before StopIteration. A tiny seeded run with the KPI
+        # display on (plot off) must complete without error.
+        torch.manual_seed(0)
+        model = RollMultiLayerPerceptron(X_t, y_t, layers=[8])
+        model.set_optimizer(nn.MSELoss, torch.optim.Adam, lr=1e-3)
+        model.set_roll_period(
+            train_period=TRAIN, test_period=TEST, roll_period=ROLL, epochs=1,
+        )
+        out = model.run(backtest_plot=False, backtest_kpi=True)
+        assert out is model
+        stats = model.get_stats()
+        assert stats.size > 0


### PR DESCRIPTION
## Summary

Fixes two bugs in `fynance/models/rolling.py` `_RollingBasis._display_kpi` (roadmap finding 1.1).

### HIGH — `run(backtest_kpi=True)` (the DEFAULT) raised `IndexError` (regression from #196)
`__next__` does `self.i += 1` *before* the `StopIteration` check, so after the
walk-forward loop `self.i == loss_eval.size` while the `loss_eval`/`loss_test`
arrays have size `n_iter`. The final out-of-loop `_print` then read
`self.loss_eval[self.i]` out of bounds. The pre-#196 `[-1]` did not crash.
**Fix:** clamp the read index — `i = min(self.i, self.loss_eval.size - 1)`.

### LOW — `ZeroDivisionError` in the progress percentage
The denominator `T - n - T % s` can be 0 (e.g. `T=45, n=40, s=10`).
**Fix:** floor it at 1 — `max(self.T - self.n - self.T % self.s, 1)`.

## Tests (fail-before / pass-after, verified against a pre-fix copy)
- `test_kpi_index_clamped_after_loop` — `self.i` one past the last slot must not raise.
- `test_kpi_zero_denominator_does_not_divide_by_zero` — `T=45, n=40, s=10` config.
- `test_run_default_kpi_path_completes` — tiny seeded `run(backtest_plot=False, backtest_kpi=True)` completes.

All three fail on `develop` (IndexError / ZeroDivisionError / IndexError) and pass with the fix.

## Gates
- `ruff check fynance/` — pass
- `mypy fynance/` — pass (no issues, 171 files)
- `pytest fynance/models/rolling.py fynance/tests/models/test_rolling.py -o addopts='--doctest-modules' -q` — 24 passed

Scope: `fynance/models/rolling.py` + `fynance/tests/models/test_rolling.py` only. No `__init__` exports touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYiBP4z6rdZA1BHnEUqG4p