### PR TITLE
fix: harden data/core edge cases against silent failures

### DIFF
--- a/fynance/core/price_series.py
+++ b/fynance/core/price_series.py
@@ -155,13 +155,19 @@ class PriceSeries:
         index = data[index_col].to_numpy() if index_col is not None else None
 
         if value_col is None:
-            candidates = [c for c in data.columns if c != index_col]
+            # Match the documented default: the single non-index *numeric*
+            # column. Filtering by name alone would pick a lone string column
+            # and fail later with an opaque cast-to-float64 error.
+            candidates = [
+                c for c, dt in zip(data.columns, data.dtypes)
+                if c != index_col and dt.is_numeric()
+            ]
 
             if len(candidates) != 1:
 
                 raise ValueError(
                     "value_col is ambiguous; pass it explicitly "
-                    f"(candidates={candidates})"
+                    f"(numeric candidates={candidates})"
                 )
 
             value_col = candidates[0]
@@ -319,6 +325,11 @@ class PriceSeries:
 
             return self._new(r, index=self.index[1:])
 
+        if p.size == 0:
+            # Empty input: no leading NaN to write (full[0] would be OOB).
+
+            return self._new(np.empty(0, dtype=np.float64))
+
         full = np.empty(p.size, dtype=np.float64)
         full[0] = np.nan
         full[1:] = r
@@ -398,6 +409,11 @@ class PriceSeries:
                 f"positions length {pos.size} != returns length "
                 f"{self.values.size}"
             )
+
+        if pos.size == 0:
+            # Empty input: no leading NaN to write (shifted[0] would be OOB).
+
+            return self._new(np.empty(0, dtype=np.float64))
 
         shifted = np.empty_like(pos)
         shifted[0] = np.nan

--- a/fynance/data/align.py
+++ b/fynance/data/align.py
@@ -55,7 +55,26 @@ def align(
     dict of str to PriceSeries
         Series sharing a common index.
 
+    Raises
+    ------
+    ValueError
+        If ``how`` is unknown, or if any input series has duplicate index
+        entries. Duplicate timestamps would otherwise be silently collapsed
+        (the index-to-value mapping keeps only the last value), shrinking the
+        series to its unique count without warning.
+
     """
+    for name, ps in series.items():
+        idx_list = ps.index.tolist()
+
+        if len(idx_list) != len(set(idx_list)):
+
+            raise ValueError(
+                f"series {name!r} has duplicate index entries; align cannot "
+                "map a timestamp to more than one value (deduplicate or "
+                "aggregate the series first)"
+            )
+
     index_sets = [set(ps.index.tolist()) for ps in series.values()]
 
     if how == "outer":
@@ -96,6 +115,11 @@ def resample(
     an explanatory :class:`ValueError` rather than surfacing an opaque polars
     error.
 
+    polars only accepts ``datetime64`` resolutions ``[D]``, ``[ms]``, ``[us]``
+    and ``[ns]``. Any other resolution (the common ``[s]``, plus ``[h]``,
+    ``[m]``, ``[W]``, ``[M]``, ``[Y]``) is losslessly upcast to ``[us]`` before
+    resampling, so it works instead of triggering an opaque polars error.
+
     Parameters
     ----------
     ps : PriceSeries
@@ -127,6 +151,19 @@ def resample(
             f"{index.dtype!r}; convert the index to numpy datetime64 first "
             "(integer and object/datetime.datetime indexes are not supported)"
         )
+
+    # polars only accepts datetime64 [D]/[ms]/[us]/[ns]; upcast any other
+    # resolution (e.g. the common [s], or [h]/[m]/[W]/[M]/[Y]) to [us] so the
+    # call succeeds instead of raising an opaque polars resolution error.
+    _supported = (
+        np.dtype("datetime64[D]"),
+        np.dtype("datetime64[ms]"),
+        np.dtype("datetime64[us]"),
+        np.dtype("datetime64[ns]"),
+    )
+
+    if index.dtype not in _supported:
+        index = index.astype("datetime64[us]")
 
     df = pl.DataFrame({"_t": index, "_v": ps.values}).sort("_t")
     gb = df.group_by_dynamic("_t", every=freq)

--- a/fynance/data/split.py
+++ b/fynance/data/split.py
@@ -49,8 +49,25 @@ def train_test_split(
     (train_idx, test_idx) : tuple of numpy.ndarray
         ``test_idx`` is strictly after ``train_idx`` (no leakage).
 
+    Raises
+    ------
+    ValueError
+        If ``test_size`` is negative (a negative integer would yield
+        out-of-bounds train indices and a negative fraction would silently
+        produce an empty test set), if the resulting test count exceeds ``n``,
+        or if the train set would be empty.
+
     """
+    if test_size < 0:
+
+        raise ValueError(f"test_size must be >= 0, got {test_size}")
+
     n_test = int(round(n * test_size)) if 0 < test_size < 1 else int(test_size)
+
+    if n_test > n:
+
+        raise ValueError(f"test_size ({n_test}) exceeds n ({n})")
+
     split = n - n_test
 
     if split - gap <= 0:
@@ -95,7 +112,8 @@ def walk_forward(
     ValueError
         If ``train <= 0`` or ``purge >= train``: either would yield empty train
         windows (``[t-train : t-purge]`` becomes empty), which silently breaks a
-        downstream ``fit`` with an opaque error instead of failing here.
+        downstream ``fit`` with an opaque error instead of failing here. Also if
+        ``step <= 0``, which would never advance ``t`` and loop forever.
 
     """
     if train <= 0:
@@ -111,6 +129,13 @@ def walk_forward(
 
     if step is None:
         step = test
+
+    if step <= 0:
+
+        raise ValueError(
+            f"step must be > 0, got {step} (otherwise t never advances "
+            "and the window generator loops forever)"
+        )
 
     t = train
 

--- a/fynance/tests/core/test_price_series.py
+++ b/fynance/tests/core/test_price_series.py
@@ -75,6 +75,14 @@ def test_to_returns_dropna_false_keeps_length():
     assert np.isnan(r.values[0])
 
 
+def test_to_returns_dropna_false_empty_series():
+    # Empty input must not IndexError on the leading-NaN write (full[0]).
+    ps = PriceSeries([])
+    r = ps.to_returns("pct", dropna=False)
+    assert len(r) == 0
+    assert r.values.dtype == np.float64
+
+
 def test_to_returns_unknown_kind_raises():
     ps = PriceSeries([100.0, 110.0, 99.0])
     with pytest.raises(ValueError, match="unknown kind"):
@@ -162,6 +170,13 @@ def test_pnl_is_causal():
     assert np.isclose(pnl.values[3], -1.0 * 0.04)
 
 
+def test_pnl_empty_series():
+    # Empty input must not IndexError on the shift (shifted[0]).
+    out = PriceSeries([]).pnl([])
+    assert len(out) == 0
+    assert out.values.dtype == np.float64
+
+
 def test_pnl_no_lookahead():
     # changing a future position must not change earlier pnl
     returns = PriceSeries([0.01, 0.02, -0.03, 0.04])
@@ -208,3 +223,31 @@ def test_from_polars_series_and_frame():
     df = pl.DataFrame({"px": [10.0, 11.0, 12.0]})
     ps2 = PriceSeries.from_polars(df, value_col="px")
     assert np.array_equal(ps2.values, [10.0, 11.0, 12.0])
+
+
+def test_from_polars_default_value_col_picks_numeric():
+    # With a temporal index column and one numeric + one string column, the
+    # default value column must be the numeric one (documented behavior), not
+    # the string column (which would fail with an opaque cast error).
+    pl = pytest.importorskip("polars")
+    df = pl.DataFrame(
+        {
+            "date": ["2020-01-01", "2020-01-02"],
+            "label": ["a", "b"],
+            "px": [10.0, 11.0],
+        }
+    ).with_columns(pl.col("date").str.to_date())
+    ps = PriceSeries.from_polars(df)
+    assert ps.name == "px"
+    assert np.array_equal(ps.values, [10.0, 11.0])
+
+
+def test_from_polars_lone_string_column_raises_clean_error():
+    # A single non-index column that is a string is not a numeric candidate;
+    # value_col resolution must reject it cleanly, not cast-fail later.
+    pl = pytest.importorskip("polars")
+    df = pl.DataFrame(
+        {"date": ["2020-01-01", "2020-01-02"], "label": ["a", "b"]}
+    ).with_columns(pl.col("date").str.to_date())
+    with pytest.raises(ValueError, match="value_col is ambiguous"):
+        PriceSeries.from_polars(df)

--- a/fynance/tests/data/test_align.py
+++ b/fynance/tests/data/test_align.py
@@ -50,6 +50,15 @@ def test_ffill_leading_nan_stays_nan():
     assert out["b"].values[2] == 30.0
 
 
+def test_align_rejects_duplicate_index():
+    # Duplicate timestamps would be silently collapsed (index-to-value mapping
+    # keeps only the last), shrinking the series to its unique count.
+    a = PriceSeries([1.0, 2.0, 3.0], index=[1, 2, 2], name="a")
+    b = PriceSeries([10.0, 20.0, 30.0], index=[1, 2, 3], name="b")
+    with pytest.raises(ValueError, match="duplicate"):
+        align({"a": a, "b": b}, how="outer")
+
+
 # --- resample ----------------------------------------------------------------
 
 def _weekly_ps():
@@ -103,3 +112,36 @@ def test_resample_object_datetime_index_raises_clean_error():
     ps = PriceSeries([1.0, 2.0], index=idx)
     with pytest.raises(ValueError, match="datetime64"):
         resample(ps, "1w", agg="last")
+
+
+def _weekly_ps_seconds():
+    # Same as _weekly_ps but with the common datetime64[s] resolution, which
+    # polars does not accept directly (only [D]/[ms]/[us]/[ns]).
+    idx = np.array(
+        ["2020-01-01", "2020-01-02", "2020-01-08", "2020-01-09"],
+        dtype="datetime64[s]",
+    )
+    return PriceSeries([1.0, 2.0, 3.0, 4.0], index=idx, name="x")
+
+
+def test_resample_last_datetime64_seconds():
+    # datetime64[s] used to slip past the dtype.kind guard then raise the
+    # opaque polars resolution error; it now resamples correctly.
+    out = resample(_weekly_ps_seconds(), "1w", agg="last")
+    assert isinstance(out, PriceSeries)
+    assert np.allclose(out.values, [2.0, 4.0])
+    assert out.index.dtype.kind == "M"
+
+
+def test_resample_mean_datetime64_seconds():
+    out = resample(_weekly_ps_seconds(), "1w", agg="mean")
+    assert np.allclose(out.values, [1.5, 3.5])
+
+
+def test_resample_ohlc_datetime64_seconds():
+    out = resample(_weekly_ps_seconds(), "1w", agg="ohlc")
+    assert set(out) == {"open", "high", "low", "close"}
+    assert np.allclose(out["open"].values, [1.0, 3.0])
+    assert np.allclose(out["high"].values, [2.0, 4.0])
+    assert np.allclose(out["low"].values, [1.0, 3.0])
+    assert np.allclose(out["close"].values, [2.0, 4.0])

--- a/fynance/tests/data/test_split.py
+++ b/fynance/tests/data/test_split.py
@@ -71,3 +71,29 @@ def test_train_test_split_zero_is_empty_test():
     train, test = train_test_split(100, test_size=0.0)
     assert len(test) == 0
     assert len(train) == 100
+
+
+def test_train_test_split_rejects_negative_test_size():
+    # A negative integer would yield out-of-bounds train indices
+    # (e.g. test_size=-3, n=10 -> split=13 -> arange(0, 13)); a negative
+    # fraction would silently produce an empty test set.
+    with pytest.raises(ValueError, match="test_size"):
+        train_test_split(10, test_size=-3)
+    with pytest.raises(ValueError, match="test_size"):
+        train_test_split(10, test_size=-0.2)
+
+
+def test_train_test_split_rejects_test_size_over_n():
+    # A test count larger than n would leave a negative-length train set.
+    with pytest.raises(ValueError, match="exceeds n"):
+        train_test_split(10, test_size=11)
+
+
+def test_walk_forward_rejects_nonpositive_step():
+    # step <= 0 never advances t -> the while loop runs forever.
+    # Use a tiny n and assert the ValueError is raised eagerly (the generator
+    # validates step on the first __next__), so the loop is never entered.
+    with pytest.raises(ValueError, match="step"):
+        next(walk_forward(5, train=2, test=1, step=0))
+    with pytest.raises(ValueError, match="step"):
+        next(walk_forward(5, train=2, test=1, step=-1))


### PR DESCRIPTION
Fixes the audited edge-case bugs in `fynance/data/split.py`, `fynance/data/align.py`, and `fynance/core/price_series.py` (roadmap 1.3). Each fix ships with a test that fails before and passes after.

## Findings fixed

| Sev | Location | Bug | Fix |
|-----|----------|-----|-----|
| HIGH | `split.walk_forward` | `step <= 0` never advances `t` -> the generator loops forever (the earlier `train>0`/`purge<train` guards did not cover `step`) | Raise `ValueError` for `step <= 0`, before the loop |
| HIGH | `split.train_test_split` | negative `test_size` int -> out-of-bounds train indices (`test_size=-3, n=10 -> arange(0,13)`); negative fraction -> silently empty test | Guard `test_size < 0`; also reject `n_test > n` |
| MEDIUM | `align.resample` | only `dtype.kind == "M"` was validated, but polars accepts only `[D]/[ms]/[us]/[ns]`; the common `[s]` (and `[h]/[m]/[W]/[M]/[Y]`) slipped past then raised the opaque polars error #192 meant to prevent | Losslessly upcast unsupported resolutions to `[us]` before resampling |
| MEDIUM | `align.align` | `dict(zip(index, values))` silently dropped duplicate-index entries (kept last), collapsing the series to its unique count | Detect duplicate timestamps and raise a clear `ValueError` |
| MEDIUM | `price_series.to_returns(dropna=False)` / `pnl()` | `IndexError` on an empty series (`full[0]`/`shifted[0]` on size-0); sibling `apply()` got an empty guard in #192 but these didn't | Short-circuit empty input in both |
| LOW | `price_series.from_polars` | default value column filtered by name only, so a lone string column was selected then failed with an opaque cast error (docstring says "numeric") | Filter candidates by numeric dtype, matching the doc |

## Notes
- The `step <= 0` test uses `next(walk_forward(...))` (the generator validates `step` eagerly on first `__next__`), so it asserts the raise without ever entering the loop -- no hang risk in CI.
- `resample` on `datetime64[s]` now works (upcast to `[us]`) rather than being rejected, preserving correct behavior for the common case.

## Gates
- `ruff check fynance/` -> clean
- `mypy fynance/` -> Success, no issues in 171 source files
- `pytest fynance/data/ fynance/tests/data/ fynance/core/ fynance/tests/core/ --doctest-modules` -> 89 passed
- No `__init__` exports touched; `CHANGELOG.md`/roadmap untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYiBP4z6rdZA1BHnEUqG4p