### PR TITLE
fix: signed infinity for zero-denominator ratios (sharpe/sortino/roll_sharpe)

### DIFF
--- a/fynance/metrics/ratios.py
+++ b/fynance/metrics/ratios.py
@@ -24,9 +24,10 @@ def _safe_ratio(excess: NDArray, denom: NDArray) -> Any:
     """ ``excess / denom`` robust to a zero denominator (scalar **or** array).
 
     A zero-volatility series has an undefined ratio: it is ``+inf`` when the
-    excess return is non-zero (a riskless gain), and ``0`` when the excess is also
-    zero (a flat, do-nothing curve). Returns a numpy scalar for 0-D input and an
-    array otherwise — matching the surrounding ratio functions' shape contract.
+    excess return is positive (a riskless gain), ``-inf`` when the excess is
+    negative (a riskless loss), and ``0`` when the excess is also zero (a flat,
+    do-nothing curve). Returns a numpy scalar for 0-D input and an array
+    otherwise — matching the surrounding ratio functions' shape contract.
     """
     excess = np.asarray(excess, dtype=np.float64)
     denom = np.asarray(denom, dtype=np.float64)
@@ -36,11 +37,16 @@ def _safe_ratio(excess: NDArray, denom: NDArray) -> Any:
 
             return np.float64(excess / denom)
 
-        return np.float64(np.inf if excess != 0. else 0.)
+        if excess == 0.:
+
+            return np.float64(0.)
+
+        return np.float64(np.sign(excess) * np.inf)
 
     res = np.full(denom.shape, np.inf, dtype=np.float64)
     nz = denom != 0.
     res[nz] = excess[nz] / denom[nz]
+    res[(~nz) & (excess < 0.)] = -np.inf
     res[(~nz) & (excess == 0.)] = 0.
 
     return res
@@ -548,23 +554,13 @@ def roll_sharpe(
     """
     ret = _roll_annual_return(X, period, w, ddof)
     vol = _roll_annual_volatility(X, period, log, w, axis, ddof)
-    sharpe = np.zeros(X.shape)
-    slice_bool = (vol != 0)
 
-    if isinstance(rf, float) or isinstance(rf, int):
-        _rf = rf
-
-    elif isinstance(rf, np.ndarray) and rf.shape[0] != X.shape[0]:
+    if isinstance(rf, np.ndarray) and rf.shape[0] != X.shape[0]:
         msg_prefix = 'rf must be '
 
         raise ArraySizeError(X.shape[0], msg_prefix=msg_prefix)
 
-    else:
-        _rf = rf[slice_bool]
-
-    sharpe[slice_bool] = (ret[slice_bool] - _rf) / vol[slice_bool]
-
-    return sharpe
+    return _safe_ratio(ret - rf, vol)
 
 
 @WrapperArray('dtype', 'axis', 'window', 'ddof', min_size=2)

--- a/fynance/tests/metrics/test_metrics.py
+++ b/fynance/tests/metrics/test_metrics.py
@@ -501,10 +501,11 @@ def test_sortino(set_variables):
         f(x_2d, axis=0, ddof=7)
     execinfo.match(r'7.*6')
 
-    # All positive returns → downside vol == 0 → inf (tested on 2D; 1D scalar
-    # path shares the same pre-existing limitation as sharpe)
-    x_up_2d = np.array([100., 110., 120., 130., 140., 150.]).reshape(6, 1)
-    assert f(x_up_2d, period=12) == np.array([np.inf])
+    # All positive returns → downside vol == 0 → inf, on both the 2-D array
+    # path and the 1-D scalar (0-D) path.
+    x_up = np.array([100., 110., 120., 130., 140., 150.])
+    assert f(x_up.reshape(6, 1), period=12) == np.array([np.inf])
+    assert np.isposinf(f(x_up, period=12))
 
     # Numeric check: sortino >= sharpe (downside vol <= total vol)
     s_sharpe = fy.sharpe(x_1d.astype(np.float64), period=12)

--- a/fynance/tests/metrics/test_zero_vol_ratios.py
+++ b/fynance/tests/metrics/test_zero_vol_ratios.py
@@ -7,7 +7,7 @@
 import numpy as np
 
 # Local
-from fynance.metrics import calmar, roll_calmar, sharpe, sortino
+from fynance.metrics import calmar, roll_calmar, roll_sharpe, sharpe, sortino
 from fynance.metrics.ratios import _safe_ratio
 from fynance.metrics.summary import summary
 
@@ -19,11 +19,50 @@ def test_flat_curve_is_zero_not_crash():
 
 
 def test_safe_ratio_zero_denominator():
-    # Riskless gain -> +inf; flat (0/0) -> 0; mixed array handled element-wise.
+    # Riskless gain -> +inf; riskless loss -> -inf; flat (0/0) -> 0; mixed
+    # array handled element-wise.
     assert np.isposinf(_safe_ratio(1.0, 0.0))
+    assert np.isneginf(_safe_ratio(-1.0, 0.0))
     assert _safe_ratio(0.0, 0.0) == 0.0
-    r = _safe_ratio(np.array([1.0, 0.0, 2.0]), np.array([0.0, 0.0, 2.0]))
-    assert np.isposinf(r[0]) and r[1] == 0.0 and r[2] == 1.0
+    r = _safe_ratio(np.array([1.0, -1.0, 0.0, 2.0]),
+                    np.array([0.0, 0.0, 0.0, 2.0]))
+    assert np.isposinf(r[0])
+    assert np.isneginf(r[1])
+    assert r[2] == 0.0
+    assert r[3] == 1.0
+
+
+def test_flat_curve_with_rf_is_riskless_loss():
+    # A flat (zero-volatility) curve evaluated against a positive risk-free
+    # rate is a guaranteed underperformance: the ratio limit is -inf, not the
+    # best-possible +inf. This guards the sign bug in _safe_ratio.
+    flat = np.full(20, 100.0)
+    assert np.isneginf(sharpe(flat, rf=0.05))
+    assert np.isneginf(sortino(flat, rf=0.05))
+
+
+def test_2d_zero_vol_negative_excess_is_neg_inf():
+    # 2-D array path: a flat column with a positive rf scores -inf (riskless
+    # loss), while a real column stays finite.
+    flat = np.full(50, 100.0)
+    rng = np.random.default_rng(0)
+    normal = 100.0 * np.cumprod(1 + rng.standard_normal(50) * 0.01)
+    X = np.column_stack([flat, normal])
+
+    res = sharpe(X, rf=0.05, axis=0)
+    assert res.shape == (2,)
+    assert np.isneginf(res[0])
+    assert np.isfinite(res[1])
+
+
+def test_roll_sharpe_zero_vol_is_signed_inf_not_zero():
+    # A zero-rolling-vol window must follow the calmar/roll_calmar +/-inf
+    # convention, not the old 0.0 zeroing. A flat curve has zero return over
+    # zero volatility at every window: a negative risk-free rate makes the
+    # excess positive (+inf), a positive one makes it a riskless loss (-inf).
+    flat = np.full(6, 100.0)
+    assert np.all(np.isposinf(roll_sharpe(flat, rf=-0.05, period=12)))
+    assert np.all(np.isneginf(roll_sharpe(flat, rf=0.05, period=12)))
 
 
 def test_2d_mixed_columns_no_crash():


### PR DESCRIPTION
## Summary

Fixes two audited issues in `fynance/metrics/ratios.py` (roadmap 1.4):

- **MEDIUM — `_safe_ratio` sign bug.** When the denominator (volatility / MDD) is zero, the helper returned `+inf` for *any* non-zero excess, so a **riskless loss** — e.g. `sharpe(flat_series, rf=0.05)`, `sortino(...)` on a flat or declining curve — was reported as the **best-possible** ratio. The correct limit of a negative excess over a vanishing denominator is `-inf`.
  - Scalar branch: return `np.sign(excess) * np.inf` for non-zero excess, keeping an explicit `excess == 0 -> 0.0` path (so `0 * inf` never produces `nan`).
  - Array branch: set `-inf` where `excess < 0` and the denominator is zero; keep `+inf` (`excess > 0`) and `0.0` (`excess == 0`).
- **LOW — `roll_sharpe` inconsistency.** It used its own `sharpe[zero_vol] = 0.0` zeroing instead of the unified `±inf` convention from `calmar`/`roll_calmar` (PR #194). Now routed through `_safe_ratio(ret - rf, vol)`, preserving the `rf`-shape `ArraySizeError` guard.

The flat-curve `rf=0` (zero-excess → `0.0`) behavior and all existing doctests are unchanged.

## Tests (fail-before / pass-after)

- `test_safe_ratio_zero_denominator` — extended with `-inf` for negative excess (scalar + array).
- `test_flat_curve_with_rf_is_riskless_loss` — `sharpe`/`sortino` on a flat curve with `rf>0` → `-inf`.
- `test_2d_zero_vol_negative_excess_is_neg_inf` — 2-D array path.
- `test_roll_sharpe_zero_vol_is_signed_inf_not_zero` — zero-rolling-vol window → `±inf` (not `0.0`).
- `test_sortino` — corrected the stale comment claiming the 1-D scalar path crashes; added an assertion that `sortino(monotone_up_1d)` returns `inf`.
- Existing `test_zero_vol_ratios` (positive-excess → `+inf`) stays green.

## Gates

- `ruff check fynance/` — passed
- `mypy fynance/` — passed (171 files)
- `pytest fynance/metrics/ fynance/tests/metrics/ --doctest-modules` — 69 passed

No `__init__` exports touched. Scope limited to `ratios.py` + its metrics tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYiBP4z6rdZA1BHnEUqG4p