### PR TITLE
fix: polish low-priority robustness items (portfolio/research/features)

### DIFF
--- a/fynance/features/money_management.py
+++ b/fynance/features/money_management.py
@@ -52,6 +52,8 @@ def iso_vol(series, target_vol=0.20, leverage=1., period=252, half_life=11):
            1.07186485])
 
     """
+    # Coerce input to a 1d float array so list/tuple inputs work too.
+    series = np.asarray(series, dtype=np.float64).reshape(-1)
     # Set iso-vol vector
     iv = np.ones([series.size])
     # Compute squared daily return vector (standard return s_t / s_{t-1} - 1)

--- a/fynance/portfolio/allocation.py
+++ b/fynance/portfolio/allocation.py
@@ -32,6 +32,7 @@ Main entry points
 from __future__ import annotations
 
 # Built-in packages
+import warnings
 from typing import Callable
 
 # Third-party
@@ -114,6 +115,11 @@ def ERC(
         return np.ones([1, 1])
 
     up_bound = max(up_bound, 1 / N)
+    # Clamp low_bound so the box stays compatible with the sum-to-one
+    # constraint: with low_bound > 1/N every feasible weight already exceeds
+    # its share, the constraint is infeasible and SLSQP would silently return
+    # weights summing to more than one (as HRP/IVP already guard against).
+    low_bound = min(low_bound, 1 / N)
     # The risk-contribution surrogate is quartic in the covariance, so on
     # return-scale inputs (values ~1e-4) it collapses to ~1e-16, far below
     # SLSQP's default ftol and the optimizer stops at the 1/N start. Rescale
@@ -533,6 +539,11 @@ def MVP_uc(
         return np.ones([1, 1])
 
     up_bound = max(up_bound, 1 / N)
+    # Clamp low_bound so the box stays compatible with the sum-to-one
+    # constraint: with low_bound > 1/N the feasible set is empty and SLSQP
+    # would silently return weights summing to more than one (as HRP/IVP
+    # already guard against).
+    low_bound = min(low_bound, 1 / N)
     # On return-scale inputs the portfolio variance w'Sigma w is ~1e-4 or
     # smaller, which can sit below SLSQP's default ftol so the optimizer stops
     # at the 1/N start. Rescale the covariance to unit trace so the objective
@@ -832,6 +843,9 @@ def _normalize(w: NDArray[np.float64], low_bound: float = 0., up_bound: float = 
         j += 1
 
     if j >= max_iter:
-        print('Iterative normalize algorithm exceeded max iterations')
+        warnings.warn(
+            'Iterative normalize algorithm exceeded max iterations',
+            stacklevel=2,
+        )
 
     return w

--- a/fynance/research/compare.py
+++ b/fynance/research/compare.py
@@ -100,7 +100,14 @@ def _markdown_table(rows: list[dict[str, float | str]]) -> str:
     if not rows:
         return "_no experiments_\n"
 
-    cols = ["name"] + [k for k in rows[0] if k != "name"]
+    # Union the metric keys across every row (preserving first-seen order) so a
+    # metric present only in lower-ranked rows is not silently dropped.
+    metric_cols: list[str] = []
+    for row in rows:
+        for k in row:
+            if k != "name" and k not in metric_cols:
+                metric_cols.append(k)
+    cols = ["name"] + metric_cols
     head = "| " + " | ".join(cols) + " |"
     sep = "| " + " | ".join("---" for _ in cols) + " |"
     body = []

--- a/fynance/research/synthetic.py
+++ b/fynance/research/synthetic.py
@@ -66,6 +66,9 @@ def gbm(
     5
 
     """
+    if n < 1:
+        raise ValueError(f"n must be a positive integer, got {n}")
+
     rng = np.random.default_rng(seed)
     log_ret = mu + sigma * rng.standard_normal(max(n - 1, 0))
     path = np.concatenate([[0.0], np.cumsum(log_ret)])
@@ -117,6 +120,9 @@ def regime_switching(
     True
 
     """
+    if n < 1:
+        raise ValueError(f"n must be a positive integer, got {n}")
+
     rng = np.random.default_rng(seed)
     mus = np.array([r[0] for r in regimes], dtype=np.float64)
     sigmas = np.array([r[1] for r in regimes], dtype=np.float64)

--- a/fynance/tests/features/test_money_management.py
+++ b/fynance/tests/features/test_money_management.py
@@ -72,3 +72,18 @@ def test_iso_vol_warmup_is_one():
 
     assert out[0] == 1.0
     assert out[1] == 1.0
+
+
+def test_iso_vol_accepts_list_input():
+    # A plain list/tuple used to raise a bare AttributeError ('list' object has
+    # no attribute 'size'); the input is now coerced like in sibling modules.
+    data = [95.0, 100.0, 85.0, 105.0, 110.0, 90.0]
+    out_list = iso_vol(data, target_vol=0.5, leverage=2, period=12, half_life=3)
+    out_arr = iso_vol(np.asarray(data), target_vol=0.5, leverage=2,
+                      period=12, half_life=3)
+
+    assert isinstance(out_list, np.ndarray)
+    assert np.allclose(out_list, out_arr)
+    # Tuples work too.
+    assert np.allclose(iso_vol(tuple(data), target_vol=0.5, leverage=2,
+                               period=12, half_life=3), out_arr)

--- a/fynance/tests/portfolio/test_allocation.py
+++ b/fynance/tests/portfolio/test_allocation.py
@@ -126,12 +126,22 @@ def test_mvp_single_asset():
 
 
 def test_mvp_singular_covariance_pinv():
-    """ Linearly dependent columns trigger the pseudo-inverse fallback. """
+    """ An exactly singular covariance triggers the pseudo-inverse fallback.
+
+    A constant (zero-variance) column makes its covariance row/column exactly
+    zero, so the matrix is singular and ``np.linalg.inv`` raises
+    ``LinAlgError`` — genuinely exercising the ``pinv`` branch (a merely
+    near-singular matrix does not raise, so ``inv`` would silently succeed).
+    """
     rng = np.random.default_rng(11)
     a = rng.normal(0.0, 0.01, size=(200, 1))
     b = rng.normal(0.0, 0.01, size=(200, 1))
-    # Third column is an exact linear combination → singular covariance.
-    X = np.column_stack([a, b, 2.0 * a - 3.0 * b])
+    # Third column is constant → zero variance → exactly singular covariance.
+    X = np.column_stack([a, b, np.full((200, 1), 100.0)])
+    # Guard: this construction must actually make inv raise (else the test
+    # would pass without ever reaching the pinv fallback it claims to cover).
+    with pytest.raises(np.linalg.LinAlgError):
+        np.linalg.inv(np.atleast_2d(np.cov(X, rowvar=False)))
     w = MVP(X).flatten()
     assert w.shape == (3,)
     assert abs(w.sum() - 1.0) < 1e-6
@@ -181,6 +191,18 @@ def test_mvp_uc_single_asset():
     w = MVP_uc(X)
     assert w.shape == (1, 1)
     np.testing.assert_allclose(w, [[1.0]])
+
+
+def test_mvp_uc_high_low_bound_still_sums_to_one(returns):
+    """ low_bound > 1/N must be clamped, not break the sum-to-one constraint.
+
+    With N=5 the feasible share per asset is 1/N=0.2; a low_bound of 0.3 makes
+    the box incompatible with sum-to-one. Before the clamp, SLSQP silently
+    returned weights summing to 1.5. low_bound is now clamped to 1/N (as
+    HRP/IVP already do) so the weights still sum to one.
+    """
+    w = MVP_uc(returns, low_bound=0.3).flatten()
+    assert abs(w.sum() - 1.0) < 1e-5, f"weights sum to {w.sum():.6f}"
 
 
 # ---------------------------------------------------------------------------
@@ -239,6 +261,18 @@ def test_erc_single_asset():
     w = ERC(X)
     assert w.shape == (1, 1)
     np.testing.assert_allclose(w, [[1.0]])
+
+
+def test_erc_high_low_bound_still_sums_to_one(returns):
+    """ low_bound > 1/N must be clamped, not break the sum-to-one constraint.
+
+    With N=5 the feasible share per asset is 1/N=0.2; a low_bound of 0.3 makes
+    the box incompatible with sum-to-one. Before the clamp, SLSQP silently
+    returned weights summing to 1.5. low_bound is now clamped to 1/N (as
+    HRP/IVP already do) so the weights still sum to one.
+    """
+    w = ERC(returns, low_bound=0.3).flatten()
+    assert abs(w.sum() - 1.0) < 1e-4, f"weights sum to {w.sum():.6f}"
 
 
 # ---------------------------------------------------------------------------
@@ -396,11 +430,10 @@ def test_normalize_does_not_mutate_input():
     assert out is not w
 
 
-def test_normalize_max_iter_warning(capsys):
+def test_normalize_max_iter_warning():
     w = np.array([0.99, 0.005, 0.003, 0.002])
-    _normalize(w.copy(), low_bound=0.0, up_bound=0.3, max_iter=2)
-    captured = capsys.readouterr()
-    assert "exceeded max iterations" in captured.out
+    with pytest.warns(UserWarning, match="exceeded max iterations"):
+        _normalize(w.copy(), low_bound=0.0, up_bound=0.3, max_iter=2)
 
 
 def test_rolling_allocation_regression():

--- a/fynance/tests/research/test_compare.py
+++ b/fynance/tests/research/test_compare.py
@@ -73,6 +73,24 @@ def test_leaderboard_nan_sinks_ascending():
     assert rows[-1]["name"] == "bad"
 
 
+def test_compare_report_table_unions_heterogeneous_metrics(tmp_path):
+    # A metric present only in a lower-ranked row must not be dropped: the table
+    # columns used to be derived from rows[0] alone, silently hiding it.
+    exps = [
+        Experiment(name="top", metrics={"sharpe": 2.0}),
+        Experiment(name="low", metrics={"sharpe": 1.0, "sortino": 3.5}),
+    ]
+
+    out = compare_report(exps, tmp_path, name="het", sort_by="sharpe")
+    text = out["markdown"].read_text()
+
+    header = next(line for line in text.splitlines() if line.startswith("| name"))
+    assert "sharpe" in header
+    assert "sortino" in header  # the lower-ranked-only metric survives
+    # And its value is rendered for the row that has it.
+    assert "3.5000" in text
+
+
 def test_compare_report_writes_md_and_png(tmp_path, experiments):
     out = compare_report(experiments, tmp_path, name="cmp")
 

--- a/fynance/tests/research/test_synthetic.py
+++ b/fynance/tests/research/test_synthetic.py
@@ -54,6 +54,15 @@ def test_zero_length_edge_cases():
     assert regime_switching(1, s0=100.0, seed=0).to_numpy().tolist() == [100.0]
 
 
+@pytest.mark.parametrize("gen", [gbm, regime_switching])
+@pytest.mark.parametrize("n", [0, -1, -5])
+def test_non_positive_length_raises(gen, n):
+    # n < 1 used to silently return a length-1 path ([s0]) instead of erroring;
+    # it must now raise rather than fabricate an observation out of no data.
+    with pytest.raises(ValueError, match="positive integer"):
+        gen(n, seed=0)
+
+
 def test_regime_switching_initial_state_is_drawn():
     # With p_switch=0 the only regime randomness is the *initial* state. It used
     # to be hard-coded to regime 0 (biasing short paths); now it is drawn, so


### PR DESCRIPTION
Fixes the LOW-priority audited items from roadmap 1.7. All surgical, no public API signature/semantic changes; `portfolio.allocation` stays stable.

## Findings fixed

| # | Location | Fix |
|---|----------|-----|
| 1 | `portfolio/allocation.py` `ERC`, `MVP_uc` | Clamp `low_bound = min(low_bound, 1/N)` (as HRP/IVP already do). A `low_bound > 1/N` made the sum-to-one constraint infeasible and SLSQP silently returned weights summing to >1 (e.g. 1.5). |
| 2 | `portfolio/allocation.py` `_normalize` | Switch `print()` on max-iter overflow to `warnings.warn`. Also retarget `test_mvp_singular_covariance_pinv` to an **exactly** singular covariance (constant/zero-variance column) so `np.linalg.inv` actually raises and the `pinv` fallback is exercised (the old near-singular matrix never raised). |
| 3 | `research/synthetic.py` `gbm`, `regime_switching` | Guard `n < 1` with `ValueError` instead of fabricating a length-1 path from no data. |
| 4 | `research/compare.py` `_markdown_table` | Union metric keys across all rows (first-seen order) so a metric present only in lower-ranked rows is no longer silently dropped. |
| 5 | `features/money_management.py` `iso_vol` | Coerce input via `np.asarray(..., dtype=np.float64).reshape(-1)` (like sibling modules) so list/tuple inputs work instead of raising a bare `AttributeError`. |

## Tests

Each fix has a test verified to FAIL before and PASS after (validated against the original source via throwaway checkout — no `git stash`).

## Gates

- `ruff check fynance/` — pass
- `mypy fynance/` — pass (no issues, 171 files)
- Scoped suite with `--doctest-modules` — 132 passed, 1 skipped (pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYiBP4z6rdZA1BHnEUqG4p