### PR TITLE
fix: recurrent models honor the SignalModel fit/predict contract

### DIFF
--- a/fynance/models/_recurrent_base.py
+++ b/fynance/models/_recurrent_base.py
@@ -150,6 +150,17 @@ class _OutputLayerMixin:
     cell state (e.g. :class:`~fynance.models.lstm.LongShortTermMemory`)
     must override both methods.
 
+    For drop-in :class:`~fynance.core.protocols.SignalModel` use the
+    mixin also provides :meth:`fit` and a single-argument
+    :meth:`predict`. Because each row is processed independently
+    (stateless gated cell), the hidden state has no carry-over meaning
+    across a fit / predict call and the natural default is to
+    zero-initialize it: :meth:`fit` zero-initializes ``H`` and threads
+    it across epochs, and :meth:`predict` called as ``predict(X)``
+    zero-initializes ``H`` and returns only the prediction. The
+    explicit-state forms ``train_on(X, y, H)`` and ``predict(X, H)``
+    remain available for callers that thread the state themselves.
+
     This mixin is designed for multiple inheritance alongside
     :class:`_RecurrentBase` or one of its subclasses. The MRO must
     place :class:`_OutputLayerMixin` **before** the recurrent base so
@@ -174,6 +185,51 @@ class _OutputLayerMixin:
     def __init__(self, forward_activation=nn.Identity):
         self.W_y = nn.Linear(self.H, self.M, bias=getattr(self, 'bias', True))
         self.f_y = nn.Softmax(dim=-1) if forward_activation is nn.Softmax else forward_activation()
+
+    def _init_state(self, X: torch.Tensor) -> torch.Tensor:
+        """ Build a zero hidden state matching ``X`` (rows, dtype, device). """
+        try:
+            param = next(self.parameters())  # type: ignore[attr-defined]
+            device, dtype = param.device, param.dtype
+
+        except StopIteration:
+            device, dtype = X.device, X.dtype
+
+        return torch.zeros(X.shape[0], self.H, dtype=dtype, device=device)  # type: ignore[attr-defined]
+
+    def fit(self, X, y, epochs: int = 1, x_type=None, y_type=None):
+        """ Fit the model on ``(X, y)`` for ``epochs`` full-batch steps.
+
+        Conforms to the :class:`~fynance.core.protocols.SignalModel`
+        contract. The hidden state is zero-initialized once and threaded
+        across epochs (detached between steps). An optimizer must have
+        been registered with
+        :meth:`~fynance.models._base.BaseNeuralNet.set_optimizer`.
+
+        Parameters
+        ----------
+        X, y : array-like
+            Input and output data (numpy / torch / polars), shapes
+            ``(T, N)`` and ``(T, M)``.
+        epochs : int
+            Number of full-batch training steps.
+        x_type, y_type : torch.dtype, optional
+            Target dtypes forwarded to
+            :meth:`~fynance.models._base.BaseNeuralNet.set_data`.
+
+        Returns
+        -------
+        _OutputLayerMixin
+            ``self``, to allow chaining.
+
+        """
+        self.set_data(X, y, x_type=x_type, y_type=y_type)  # type: ignore[attr-defined]
+        H = self._init_state(self.X)  # type: ignore[attr-defined]
+
+        for _ in range(epochs):
+            _, H = self.train_on(self.X, self.y, H)  # type: ignore[attr-defined]
+
+        return self
 
     @torch.enable_grad()
     def train_on(self, X: torch.Tensor, y: torch.Tensor, H: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
@@ -205,24 +261,56 @@ class _OutputLayerMixin:
         return loss, H.detach()
 
     @torch.no_grad()
-    def predict(self, X: torch.Tensor, H: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    def predict(self, X, H: torch.Tensor | None = None):
         """ Predicts outputs of neural network model.
+
+        Two calling conventions are supported:
+
+        - ``predict(X)`` — conforms to the
+          :class:`~fynance.core.protocols.SignalModel` contract: ``X``
+          may be array-like (coerced to a tensor), the hidden state is
+          zero-initialized, and **only** the prediction tensor ``Y`` is
+          returned.
+        - ``predict(X, H)`` — explicit-state form: ``X`` and ``H`` are
+          tensors and the updated state is threaded back, returning the
+          ``(Y, H)`` tuple.
+
+        In both cases ``X`` (and ``H``) are moved to the model's device.
 
         Parameters
         ----------
-        X : torch.Tensor
+        X : array-like or torch.Tensor
             Inputs to compute prediction.
-        H : torch.Tensor
-            States of the model.
+        H : torch.Tensor, optional
+            States of the model. If ``None`` (default), a zero state is
+            used and only the prediction is returned.
 
         Returns
         -------
         torch.Tensor
-           Outputs prediction.
-        torch.Tensor
-           Updated states of the model.
+           Outputs prediction (when ``H`` is ``None``).
+        tuple of torch.Tensor
+           ``(Y, H)`` outputs prediction and updated state (when ``H``
+           is provided).
 
         """
+        return_state = H is not None
+
+        if not isinstance(X, torch.Tensor):
+            X = self._set_data(X)  # type: ignore[attr-defined]
+
+        try:
+            device = next(self.parameters()).device  # type: ignore[attr-defined]
+            X = X.to(device)
+            if return_state:
+                H = H.to(device)  # type: ignore[union-attr]
+
+        except StopIteration:
+            pass
+
+        if H is None:
+            H = self._init_state(X)
+
         was_training = self.training  # type: ignore[attr-defined]
         self.eval()  # type: ignore[attr-defined]
         try:
@@ -231,4 +319,8 @@ class _OutputLayerMixin:
         finally:
             self.train(was_training)  # type: ignore[attr-defined]
 
-        return Y.detach(), H.detach()
+        if return_state:
+
+            return Y.detach(), H.detach()
+
+        return Y.detach()

--- a/fynance/models/lstm.py
+++ b/fynance/models/lstm.py
@@ -319,6 +319,52 @@ class LongShortTermMemory(_OutputLayerMixin, LSTMCell):
 
         return Y, H, C
 
+    def fit(self, X, y, epochs: int = 1, x_type=None, y_type=None):
+        """ Fit the model on ``(X, y)`` for ``epochs`` full-batch steps.
+
+        Conforms to the :class:`~fynance.core.protocols.SignalModel`
+        contract. The hidden state ``H`` and cell state ``C`` are both
+        zero-initialized once and threaded across epochs (detached
+        between steps). An optimizer must have been registered with
+        :meth:`~fynance.models._base.BaseNeuralNet.set_optimizer`.
+
+        Parameters
+        ----------
+        X, y : array-like
+            Input and output data (numpy / torch / polars), shapes
+            ``(T, N)`` and ``(T, M)``.
+        epochs : int
+            Number of full-batch training steps.
+        x_type, y_type : torch.dtype, optional
+            Target dtypes forwarded to
+            :meth:`~fynance.models._base.BaseNeuralNet.set_data`.
+
+        Returns
+        -------
+        LongShortTermMemory
+            ``self``, to allow chaining.
+
+        """
+        self.set_data(X, y, x_type=x_type, y_type=y_type)
+        H = self._init_state(self.X)
+        C = self._init_cell_state(self.X)
+
+        for _ in range(epochs):
+            _, H, C = self.train_on(self.X, self.y, H, C)
+
+        return self
+
+    def _init_cell_state(self, X: torch.Tensor) -> torch.Tensor:
+        """ Build a zero cell state matching ``X`` (rows, dtype, device). """
+        try:
+            param = next(self.parameters())
+            device, dtype = param.device, param.dtype
+
+        except StopIteration:
+            device, dtype = X.device, X.dtype
+
+        return torch.zeros(X.shape[0], self.C, dtype=dtype, device=device)
+
     @torch.enable_grad()
     def train_on(self, X: torch.Tensor, y: torch.Tensor, H: torch.Tensor, C: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:  # type: ignore[override]
         """ Trains the neural network model.
@@ -352,28 +398,64 @@ class LongShortTermMemory(_OutputLayerMixin, LSTMCell):
         return loss, H.detach(), C.detach()
 
     @torch.no_grad()
-    def predict(self, X: torch.Tensor, H: torch.Tensor, C: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:  # type: ignore[override]
+    def predict(self, X, H: torch.Tensor | None = None, C: torch.Tensor | None = None):  # type: ignore[override]
         """ Predicts outputs of neural network model.
+
+        Two calling conventions are supported:
+
+        - ``predict(X)`` — conforms to the
+          :class:`~fynance.core.protocols.SignalModel` contract: ``X``
+          may be array-like (coerced to a tensor), the hidden state and
+          cell state are zero-initialized, and **only** the prediction
+          tensor ``Y`` is returned.
+        - ``predict(X, H, C)`` — explicit-state form: the updated states
+          are threaded back, returning the ``(Y, H, C)`` tuple. ``C`` is
+          zero-initialized when omitted.
+
+        In both cases ``X`` (and any supplied state) is moved to the
+        model's device.
 
         Parameters
         ----------
-        X : torch.Tensor
+        X : array-like or torch.Tensor
             Inputs to compute prediction.
-        H : torch.Tensor
-            States of the model.
-        C : torch.Tensor
-            Cell memory of the model.
+        H : torch.Tensor, optional
+            States of the model. If ``None`` (default), a zero state is
+            used and only the prediction is returned.
+        C : torch.Tensor, optional
+            Cell memory of the model. Zero-initialized when ``None``.
 
         Returns
         -------
         torch.Tensor
-            Outputs prediction.
-        torch.Tensor
-            Updated states of the model.
-        torch.Tensor
-            Cell memory of the model.
+            Outputs prediction (when ``H`` is ``None``).
+        tuple of torch.Tensor
+            ``(Y, H, C)`` outputs prediction and updated states (when
+            ``H`` is provided).
 
         """
+        return_state = H is not None
+
+        if not isinstance(X, torch.Tensor):
+            X = self._set_data(X)
+
+        try:
+            device = next(self.parameters()).device
+            X = X.to(device)
+            if H is not None:
+                H = H.to(device)
+            if C is not None:
+                C = C.to(device)
+
+        except StopIteration:
+            pass
+
+        if H is None:
+            H = self._init_state(X)
+
+        if C is None:
+            C = self._init_cell_state(X)
+
         was_training = self.training
         self.eval()
         try:
@@ -382,4 +464,8 @@ class LongShortTermMemory(_OutputLayerMixin, LSTMCell):
         finally:
             self.train(was_training)
 
-        return Y.detach(), H.detach(), C.detach()
+        if return_state:
+
+            return Y.detach(), H.detach(), C.detach()
+
+        return Y.detach()

--- a/fynance/tests/models/test_rnn.py
+++ b/fynance/tests/models/test_rnn.py
@@ -102,3 +102,47 @@ class TestRecurrentNeuralNetwork:
         assert torch.allclose(H_base[idx], H_pert[idx], atol=1e-5)
         # the perturbed row itself does change
         assert not torch.allclose(Y_base[3], Y_pert[3])
+
+    def test_fit_predict_signalmodel_contract(self):
+        """ fit(X, y) / predict(X) work end-to-end with zero-init state. """
+        model = _make_rnn()
+        out = model.fit(X_np, y_np, epochs=2)
+        assert out is model  # fit returns self for chaining
+        Y = model.predict(X_np)
+        # single-arg predict returns only the prediction tensor
+        assert isinstance(Y, torch.Tensor)
+        assert Y.shape == (T, N_OUT)
+        assert not Y.requires_grad
+
+    def test_fit_matches_explicit_zero_state(self):
+        """ fit(X, y) is equivalent to threading an explicit zero state. """
+        torch.manual_seed(0)
+        model_a = _make_rnn()
+        torch.manual_seed(0)
+        model_b = _make_rnn()
+        # path A: SignalModel fit
+        model_a.fit(X_t, y_t, epochs=3)
+        # path B: explicit zero-state threading
+        H = torch.zeros(T, model_b.H)
+        for _ in range(3):
+            _, H = model_b.train_on(X_t, y_t, H)
+        with torch.no_grad():
+            Y_a = model_a.predict(X_t)
+            Y_b, _ = model_b.predict(X_t, torch.zeros(T, model_b.H))
+        assert torch.allclose(Y_a, Y_b, atol=1e-6)
+
+    def test_predict_explicit_state_still_returns_tuple(self):
+        """ predict(X, H) keeps the explicit-state (Y, H) contract. """
+        model = _make_rnn()
+        H = torch.zeros(T, model.H)
+        Y, H_out = model.predict(X_t, H)
+        assert Y.shape == (T, N_OUT)
+        assert H_out.shape == (T, model.H)
+
+    def test_predict_moves_input_to_model_device(self):
+        """ predict coerces / moves X to the model's parameter device. """
+        model = _make_rnn()
+        device = next(model.parameters()).device
+        # numpy input (not yet a tensor, not on device) must still work
+        Y = model.predict(X_np)
+        assert Y.device == device

--- a/fynance/tests/models/test_signalmodel.py
+++ b/fynance/tests/models/test_signalmodel.py
@@ -5,12 +5,16 @@
 
 # Third-party packages
 import numpy as np
+import pytest
 import torch
 import torch.nn as nn
 
 # Local packages
 from fynance.core import SignalModel
 from fynance.models import MultiLayerPerceptron
+from fynance.models.gru import GatedRecurrentUnit
+from fynance.models.lstm import LongShortTermMemory
+from fynance.models.rnn import RecurrentNeuralNetwork
 
 
 def _xy(n=40, feat=3):
@@ -18,6 +22,38 @@ def _xy(n=40, feat=3):
     X = rng.normal(size=(n, feat)).astype(np.float32)
     y = (X.sum(axis=1, keepdims=True)).astype(np.float32)
     return X, y
+
+
+# Recurrent models advertise the SignalModel protocol; they must honor
+# fit(X, y) / predict(X) with a zero-initialized hidden (and cell) state.
+RECURRENT_MODELS = [RecurrentNeuralNetwork, GatedRecurrentUnit, LongShortTermMemory]
+
+
+@pytest.mark.parametrize("Model", RECURRENT_MODELS)
+def test_recurrent_conforms_and_fit_predict(Model):
+    X, y = _xy()
+    model = Model(X, y, hidden_state_size=6)
+    model.set_optimizer(nn.MSELoss, torch.optim.SGD, lr=1e-3)
+    assert isinstance(model, SignalModel)
+    # fit(X, y) must not raise and must return self; predict(X) returns Y only
+    out = model.fit(X, y, epochs=2)
+    assert out is model
+    Y = out.predict(X)
+    assert isinstance(Y, torch.Tensor)
+    arr = np.asarray(Y)
+    assert arr.shape == (X.shape[0], y.shape[1])
+
+
+@pytest.mark.parametrize("Model", RECURRENT_MODELS)
+def test_recurrent_fit_predict_float64_numpy(Model):
+    """ Plain float64 numpy must fit/predict on a recurrent model. """
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(30, 3))  # float64
+    y = X.sum(axis=1, keepdims=True)  # float64
+    model = Model(X, y, hidden_state_size=5)
+    model.set_optimizer(nn.MSELoss, torch.optim.SGD, lr=1e-3)
+    out = model.fit(X, y, epochs=2).predict(X)
+    assert np.asarray(out).shape[0] == X.shape[0]
 
 
 def test_mlp_conforms_and_fit_predict():


### PR DESCRIPTION
## Summary

Fixes roadmap finding 1.6: `RecurrentNeuralNetwork` / `GatedRecurrentUnit` /
`LongShortTermMemory` are `runtime_checkable` `SignalModel` instances, but
calling `.fit(X, y)` raised a raw `TypeError`. `BaseNeuralNet.fit` forwards
only `(X, y)` to `train_on`, while the recurrent `train_on` requires `H`
(and `C` for LSTM) positionally — so they advertised a contract they could
not honor.

## Approach: path (a) — make `fit`/`predict` work with a zero-init state

These are *stateless* gated cells (each row is processed independently; `H`/`C`
are concatenated per row with no carry-over meaning across a call), so the
zero-initialized state is the natural, correct default. We override `fit` and
`predict` on the recurrent models to zero-initialize the hidden state (and cell
state for LSTM) and thread it through, so `fit(X, y)` and `predict(X)` conform
to the `SignalModel` contract.

The explicit-state APIs are preserved unchanged:
- `train_on(X, y, H)` / `train_on(X, y, H, C)` — untouched.
- `predict(X, H)` → `(Y, H)` and `predict(X, H, C)` → `(Y, H, C)` still work for
  callers threading state themselves; `predict(X)` (single arg) returns only `Y`.

### MEDIUM — `fit`/`predict` SignalModel contract
- `_OutputLayerMixin.fit` (used by RNN/GRU) and `LongShortTermMemory.fit`
  zero-init the state, thread it across epochs (detached between steps),
  return `self`.
- `predict` gains an optional `H` (and `C`): when `H is None`, zero-init and
  return only `Y`; otherwise keep the existing tuple contract.

### LOW — device move in recurrent `predict` (mirrors PR #195)
- `predict` now coerces array-like `X` to a tensor and moves `X` (and any
  supplied `H`/`C`) to the model's parameter device, guarded against a
  param-less model via `StopIteration`.

## Tests (fail-before / pass-after, seeded, tiny)
- `test_signalmodel.py`: parametrized over all three models — `fit(X, y)` works
  end-to-end and conforms to `SignalModel`; `predict(X)` returns `Y` only;
  plain float64 numpy fits/predicts.
- `test_rnn.py`: end-to-end `fit`/`predict`; `fit()` equals explicit zero-state
  threading; `predict(X, H)` still returns the `(Y, H)` tuple; device placement.

Verified failing on a throwaway worktree at the pre-fix `HEAD` (9 new failures),
passing after the fix.

## Gates
- `ruff check fynance/` — clean
- `mypy` on the four recurrent modules — clean
- Scoped test command (`--doctest-modules`) — 27 passed
- Full `fynance/tests/models/` — 218 passed (no regressions)

Out of scope (`_base.py` / `mlp.py` / `rolling.py`) untouched; no `__init__`
exports, `CHANGELOG.md`, or roadmap edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYiBP4z6rdZA1BHnEUqG4p
