### PR TITLE
fix: keep loss gradients alive in low-risk regimes

### DIFF
--- a/fynance/models/loss/calmar.py
+++ b/fynance/models/loss/calmar.py
@@ -30,9 +30,20 @@ class CalmarLoss(BaseLoss):
     Drawdowns are :math:`O(\text{returns})`, so a fixed absolute ``eps``
     (e.g. ``1e-8``) is dimensionally wrong: on a low- or zero-drawdown
     batch the ratio would explode and dominate gradients. The drawdown is
-    therefore floored with a **returns-scaled** epsilon,
-    ``eps * |equity|.mean()``, keeping the loss finite and bounded while
-    preserving its sign convention (minimizing it maximizes the ratio).
+    therefore floored with a **returns-scaled** value
+    ``|equity|.mean() / MAX_RATIO`` (plus a bare ``eps`` backstop for the
+    degenerate all-zero batch), capping the ratio at roughly ``MAX_RATIO``
+    in the low-drawdown regime regardless of the return scale.
+
+    The ratio is then passed through a **smooth saturating map**,
+    ``MAX_RATIO * tanh(ratio / MAX_RATIO)``, instead of a hard clamp. A
+    hard clamp pins the loss to a constant on a near-zero-drawdown batch
+    and so zeroes the gradient in exactly the strong-uptrend regime
+    training still wants to push on; ``tanh`` is near-linear for
+    normal-regime ratios (leaving their numerics unchanged) yet keeps a
+    residual, non-zero gradient when the ratio is large. This keeps the
+    loss finite and bounded while preserving its sign convention
+    (minimizing it maximizes the ratio).
 
     """
 
@@ -47,11 +58,13 @@ class CalmarLoss(BaseLoss):
         annual_return = y_pred.mean() * self.period
         # Returns-scaled floor: a fixed absolute eps is dimensionally wrong for
         # an O(returns) drawdown and lets the ratio explode on a low-drawdown
-        # batch. Scaling by the equity magnitude keeps the floor on the right
-        # scale; the bare eps backstop guards the degenerate all-zero-return
-        # case and the final clamp bounds the magnitude when the drawdown is
-        # near zero (so the loss stays finite with well-scaled gradients).
-        floor = self.eps * equity.abs().mean() + self.eps
+        # batch. Scaling by ``|equity|.mean() / MAX_RATIO`` caps the ratio at
+        # ~MAX_RATIO in the near-zero-drawdown regime; the bare eps backstop
+        # guards the degenerate all-zero-return case.
+        floor = equity.abs().mean() / _MAX_RATIO + self.eps
         ratio = annual_return / torch.clamp(max_drawdown, min=floor)
 
-        return -torch.clamp(ratio, min=-_MAX_RATIO, max=_MAX_RATIO)
+        # Smooth saturating map instead of a hard clamp: tanh is near-linear for
+        # normal-regime ratios (numerics unchanged) but keeps a non-zero
+        # gradient when the ratio is large, unlike a clamp that zeroes it.
+        return -_MAX_RATIO * torch.tanh(ratio / _MAX_RATIO)

--- a/fynance/models/loss/omega.py
+++ b/fynance/models/loss/omega.py
@@ -28,8 +28,18 @@ class OmegaLoss(BaseLoss):
     Both gains and losses are :math:`O(|r - L|)`, so a fixed absolute
     ``eps`` is dimensionally wrong: on an all-gains batch (zero losses) the
     ratio would explode (e.g. ``-1e6``) and dominate gradients. The
-    denominator is therefore floored with a **returns-scaled** epsilon,
-    ``eps * |r - L|.mean()``, keeping the loss finite and bounded while
+    denominator is therefore floored with a **returns-scaled** value
+    ``|r - L|.mean() / MAX_RATIO`` (plus a bare ``eps`` backstop for the
+    degenerate all-zero-diff batch), capping the ratio at roughly
+    ``MAX_RATIO`` in the low-loss regime regardless of the return scale.
+
+    The ratio is then passed through a **smooth saturating map**,
+    ``MAX_RATIO * tanh(ratio / MAX_RATIO)``, instead of a hard clamp. A
+    hard clamp pins the loss to a constant on an all-gains batch and so
+    zeroes the gradient in exactly the regime training still wants to push
+    on; ``tanh`` is near-linear for normal-regime ratios (leaving their
+    numerics unchanged) yet keeps a residual, non-zero gradient when the
+    ratio is large. This keeps the loss finite and bounded while
     preserving the sign convention (minimizing it maximizes the ratio).
 
     Parameters
@@ -55,9 +65,13 @@ class OmegaLoss(BaseLoss):
         losses = torch.relu(-diff).mean()
         # Returns-scaled floor: a fixed absolute eps is dimensionally wrong for
         # O(|r - L|) losses and lets the ratio explode on an all-gains batch.
-        # The bare eps backstop guards the degenerate all-zero-diff case and
-        # the final clamp bounds the magnitude when losses are near zero.
-        floor = self.eps * diff.abs().mean() + self.eps
+        # Scaling by ``|r - L|.mean() / MAX_RATIO`` caps the ratio at ~MAX_RATIO
+        # in the low-loss regime; the bare eps backstop guards the degenerate
+        # all-zero-diff case.
+        floor = diff.abs().mean() / _MAX_RATIO + self.eps
         ratio = gains / torch.clamp(losses, min=floor)
 
-        return -torch.clamp(ratio, min=-_MAX_RATIO, max=_MAX_RATIO)
+        # Smooth saturating map instead of a hard clamp: tanh is near-linear for
+        # normal-regime ratios (numerics unchanged) but keeps a non-zero
+        # gradient when the ratio is large, unlike a clamp that zeroes it.
+        return -_MAX_RATIO * torch.tanh(ratio / _MAX_RATIO)

--- a/fynance/models/loss/sortino.py
+++ b/fynance/models/loss/sortino.py
@@ -42,9 +42,20 @@ class SortinoLoss(BaseLoss):
     The downside deviation is :math:`O(\text{returns})`, so a fixed
     absolute ``eps`` inside the square root is dimensionally wrong: on an
     all-gains batch (zero downside) the loss would explode (e.g. ``-100``).
-    The downside is therefore floored with a **returns-scaled** epsilon
-    proportional to the excess-return magnitude, keeping the loss finite
-    and bounded while preserving the sign convention.
+    The downside is therefore floored with a **returns-scaled** value
+    ``|excess|.mean() / MAX_RATIO`` (plus a bare ``eps`` backstop for the
+    degenerate all-zero batch). This caps the ratio at roughly
+    ``MAX_RATIO`` in the low-downside regime regardless of the return
+    scale, keeping the loss finite and bounded while preserving the sign
+    convention.
+
+    The ratio is then passed through a **smooth saturating map**,
+    ``MAX_RATIO * tanh(ratio / MAX_RATIO)``, instead of a hard clamp. A
+    hard clamp pins the loss to a constant on a low-downside batch and so
+    kills the gradient in exactly the strong-uptrend regime training still
+    wants to push on; ``tanh`` is near-linear for normal-regime ratios
+    (leaving their numerics unchanged) yet keeps a residual, non-zero
+    gradient when the ratio is large.
 
     Parameters
     ----------
@@ -53,8 +64,9 @@ class SortinoLoss(BaseLoss):
     period : int, optional
         Number of periods per year. Default is 252.
     eps : float, optional
-        Relative numerical stabilizer scaling the downside-deviation floor
-        (see Notes). Default is 1e-8.
+        Bare numerical stabilizer added to the returns-scaled downside floor
+        as a backstop for the degenerate all-zero batch (see Notes).
+        Default is 1e-8.
 
     Examples
     --------
@@ -100,10 +112,13 @@ class SortinoLoss(BaseLoss):
         downside = torch.sqrt(torch.mean(F.relu(-excess) ** 2))
         # Floor the downside relative to the return scale: a fixed absolute eps
         # inside the sqrt is dimensionally wrong for an O(returns) downside and
-        # lets the ratio explode on an all-gains batch. ``eps`` backstops the
-        # degenerate all-zero case; the final clamp bounds the magnitude in the
-        # near-zero-downside regime (where pushing for more gains is fine, so
-        # saturating the gradient there is harmless for this training proxy).
-        floor = self.eps * excess.abs().mean() + self.eps
+        # lets the ratio explode on an all-gains batch. Scaling the floor by
+        # ``|excess|.mean() / MAX_RATIO`` caps the ratio at ~MAX_RATIO in the
+        # low-downside regime (scale-invariantly); ``eps`` backstops the
+        # degenerate all-zero case.
+        floor = excess.abs().mean() / _MAX_RATIO + self.eps
         ratio = excess.mean() / torch.clamp(downside, min=floor)
-        return -torch.clamp(ratio, min=-_MAX_RATIO, max=_MAX_RATIO)
+        # Smooth saturating map instead of a hard clamp: tanh is near-linear for
+        # normal-regime ratios (numerics unchanged) but keeps a non-zero
+        # gradient when the ratio is large, unlike a clamp that zeroes it.
+        return -_MAX_RATIO * torch.tanh(ratio / _MAX_RATIO)

--- a/fynance/tests/models/test_loss.py
+++ b/fynance/tests/models/test_loss.py
@@ -111,6 +111,30 @@ class TestSortinoLoss:
         # scale invariance (old absolute-eps code is off by ~10x here)
         assert loss_10x.item() == pytest.approx(loss.item(), rel=1e-2)
 
+    def test_low_risk_gradient_survives(self):
+        # On a strong-uptrend (near-zero-downside) batch the ratio blows past
+        # MAX_RATIO. A hard clamp pinned the loss to a constant there and so
+        # ZEROED the gradient in exactly the regime we still want to optimize.
+        # The smooth tanh saturation must keep the loss finite AND leave a
+        # non-zero gradient w.r.t. the input.
+        gen = torch.Generator().manual_seed(0)
+        r = (torch.rand(60, generator=gen) * 0.01 + 0.005).requires_grad_(True)
+        loss = SortinoLoss()(r)
+        assert torch.isfinite(loss)
+        loss.backward()
+        assert r.grad is not None
+        assert torch.any(r.grad != 0)
+        assert not torch.isnan(r.grad).any()
+
+    def test_higher_sortino_gives_lower_loss(self):
+        # Sign convention must survive the smooth saturation: a higher-Sortino
+        # batch (more upside, same downside) must give a strictly lower loss
+        # even when both batches are well into the saturating regime.
+        gen = torch.Generator().manual_seed(1)
+        base = torch.rand(60, generator=gen) * 0.01 + 0.005
+        better = base + 0.01   # uniformly higher mean, downside still ~0
+        assert SortinoLoss()(better).item() < SortinoLoss()(base).item()
+
     def test_positive_when_negative_mean(self):
         # Sign convention (like SharpeLoss): a negative-mean return series has a
         # negative Sortino ratio, so the negated loss must be positive.
@@ -208,6 +232,30 @@ class TestCalmarLoss:
         loss = CalmarLoss(eps=1e-8)(torch.zeros(50))
         assert torch.isfinite(loss)
 
+    def test_low_drawdown_gradient_survives(self):
+        from fynance.models.loss import CalmarLoss
+        # Near-zero-drawdown (almost monotone equity) batch: the ratio blows
+        # past MAX_RATIO. A hard clamp pinned the loss to a constant and ZEROED
+        # the gradient there; the smooth tanh saturation must keep the loss
+        # finite AND leave a non-zero gradient w.r.t. the input.
+        gen = torch.Generator().manual_seed(0)
+        r = (torch.rand(100, generator=gen) * 0.01 + 0.005).requires_grad_(True)
+        loss = CalmarLoss()(r)
+        assert torch.isfinite(loss)
+        loss.backward()
+        assert r.grad is not None
+        assert torch.any(r.grad != 0)
+        assert not torch.isnan(r.grad).any()
+
+    def test_higher_calmar_gives_lower_loss(self):
+        from fynance.models.loss import CalmarLoss
+        # Sign convention must survive the smooth saturation: a higher-Calmar
+        # batch (higher return, same near-zero drawdown) gives a lower loss.
+        gen = torch.Generator().manual_seed(1)
+        base = torch.rand(100, generator=gen) * 0.01 + 0.005
+        better = base + 0.01   # higher mean return, drawdown still ~0
+        assert CalmarLoss()(better).item() < CalmarLoss()(base).item()
+
 
 class TestOmegaLoss:
     def test_known_value(self):
@@ -241,6 +289,31 @@ class TestOmegaLoss:
         # backstop must keep the loss finite (not NaN).
         loss = OmegaLoss(threshold=0.0, eps=1e-8)(torch.zeros(50))
         assert torch.isfinite(loss)
+
+    def test_all_gains_gradient_survives(self):
+        from fynance.models.loss import OmegaLoss
+        # All-gains (zero-loss) batch: the ratio blows past MAX_RATIO. A hard
+        # clamp pinned the loss to a constant and ZEROED the gradient there;
+        # the smooth tanh saturation must keep the loss finite AND leave a
+        # non-zero gradient w.r.t. the input.
+        gen = torch.Generator().manual_seed(0)
+        r = (torch.rand(100, generator=gen) * 0.01 + 0.005).requires_grad_(True)
+        loss = OmegaLoss()(r)
+        assert torch.isfinite(loss)
+        loss.backward()
+        assert r.grad is not None
+        assert torch.any(r.grad != 0)
+        assert not torch.isnan(r.grad).any()
+
+    def test_higher_omega_gives_lower_loss(self):
+        from fynance.models.loss import OmegaLoss
+        # Sign convention must survive the smooth saturation: an all-gains batch
+        # (Omega -> high) must give a strictly lower loss than a mixed batch
+        # with real losses (finite, smaller Omega).
+        gen = torch.Generator().manual_seed(2)
+        all_gains = torch.rand(100, generator=gen) * 0.01 + 0.005
+        mixed = torch.rand(100, generator=gen) * 0.02 - 0.01
+        assert OmegaLoss()(all_gains).item() < OmegaLoss()(mixed).item()
 
 
 class TestHybridLoss:


### PR DESCRIPTION
## Problem (roadmap 1.5 — quality of the PR #196 fix)

PR #196 made `CalmarLoss` / `OmegaLoss` / `SortinoLoss` **finite** on low-denominator batches by adding a returns-scaled eps floor PLUS a hard `MAX_RATIO = 1e3` clamp. But the eps floor (`~eps * |x|.mean()` ≈ 5e-9 for typical returns) is far too small to keep the ratio below `MAX_RATIO`, so in low-risk regimes (strong-uptrend / near-zero-drawdown / all-gains) the ratio blows past `MAX_RATIO` and the **hard clamp engages — which ZEROES the gradient** (a constant has no gradient).

Reproduced on `develop`: a seeded strong-uptrend batch gives `loss = -1000.0` (exactly `-MAX_RATIO`) with a gradient that is **identically zero** for all three losses. The loss stays finite (PR #196's stated goal) but the gradient is dead in exactly the regime you still want to optimize.

## Fix (both halves, surgically, per loss)

1. **Raise the floor** to a returns-scaled `|x|.mean() / MAX_RATIO` (keeping a bare `eps` backstop for the degenerate all-zero batch). This caps the low-risk ratio near `MAX_RATIO`, scale-invariantly — instead of letting it run to ~1e8.
2. **Replace the hard clamp** `clamp(ratio, ±MAX_RATIO)` with a **smooth saturating map** `MAX_RATIO * tanh(ratio / MAX_RATIO)`. `tanh` is near-linear for normal-regime ratios (numerics unchanged to `<1e-4` relative) yet always keeps a non-zero gradient.

Net: loss stays **finite and bounded**, the **sign convention holds** (minimizing still maximizes Calmar/Omega/Sortino), and the **normal regime is unchanged** (Sortino bit-identical; Calmar/Omega differ by `<5e-5` rel). The Calmar docstring no longer claims "well-scaled gradients" where they were in fact saturated.

## Tests (fail-before / pass-after)

Per loss, on a seeded low-risk batch (verified failing on `develop`):
- loss is **finite** AND `loss.backward()` produces a **non-zero** gradient w.r.t. the input (was ~0).
- sign-convention guard: a higher-Sharpe/Calmar/Sortino/Omega batch gives a strictly lower loss.

## Gates

- `pytest fynance/models/loss/ fynance/tests/models/test_loss.py --doctest-modules` → 43 passed
- full `fynance/tests/models/` → 214 passed
- `ruff check fynance/` → clean
- `mypy fynance/` → clean

No `__init__` exports touched. No `CHANGELOG.md` / roadmap edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYiBP4z6rdZA1BHnEUqG4p