### PR TITLE
fix: repair axis=1 / negative-axis edges in features scaling and stats

### DIFF
--- a/fynance/_wrappers.py
+++ b/fynance/_wrappers.py
@@ -61,7 +61,13 @@ def wrap_axis(func):
                 stacklevel=2,
             )
 
-        if X.ndim <= axis:
+        # Normalize negative axes (e.g. -1 -> ndim - 1) before the checks
+        # below, otherwise a negative axis would slip through and the kernel,
+        # which ignores `axis`, would silently return the axis=0 result.
+        if axis < 0:
+            axis += X.ndim
+
+        if X.ndim <= axis or axis < 0:
 
             raise np.exceptions.AxisError(axis, X.ndim)
 

--- a/fynance/features/scale.py
+++ b/fynance/features/scale.py
@@ -424,6 +424,11 @@ def roll_standardize(X, w=None, a=0, b=1, axis=0, kind_moment="s"):
     s = std(X, w, axis=axis)
 
     if axis == 1:
+        # The rolling moments are returned in the input orientation
+        # (rows, cols); transpose them along with `X` so the time axis lands
+        # on axis 0 and the orientations match before broadcasting.
+        m = m.T if isinstance(m, np.ndarray) and m.ndim == X.ndim else m
+        s = s.T if isinstance(s, np.ndarray) and s.ndim == X.ndim else s
 
         return _standardize(X.T, m, s, a, b).T
 
@@ -508,6 +513,11 @@ def roll_normalize(X, w=None, a=0, b=1, axis=0):
     s = roll_max(X, w, axis=axis)
 
     if axis == 1:
+        # The rolling min/max are returned in the input orientation
+        # (rows, cols); transpose them along with `X` so the time axis lands
+        # on axis 0 and the orientations match before broadcasting.
+        m = m.T if isinstance(m, np.ndarray) and m.ndim == X.ndim else m
+        s = s.T if isinstance(s, np.ndarray) and s.ndim == X.ndim else s
 
         return _normalize(X.T, m, s, a, b).T
 

--- a/fynance/features/stats.py
+++ b/fynance/features/stats.py
@@ -18,7 +18,6 @@ __all__ = ['accuracy', 'directional_accuracy', 'percent_positive',
            'tail_ratio', 'z_score', 'roll_z_score', 'mad', 'roll_mad']
 
 
-@WrapperArray('axis')
 def accuracy(y_true: NDArray, y_pred: NDArray, sign: bool = True, axis: int = 0) -> float:
     r""" Compute the accuracy of prediction.
 
@@ -59,6 +58,10 @@ def accuracy(y_true: NDArray, y_pred: NDArray, sign: bool = True, axis: int = 0)
     mdd, calmar, sharpe, drawdown
 
     """
+    # No `wrap_axis` here: it can only transpose the first positional argument,
+    # leaving `y_pred` mis-oriented for axis=1. Both arrays already share the
+    # same orientation, so reduce directly along `axis` (NumPy handles the
+    # axis bounds, including negative axes).
     if sign:
         y_true = np.sign(y_true)
         y_pred = np.sign(y_pred)
@@ -66,7 +69,6 @@ def accuracy(y_true: NDArray, y_pred: NDArray, sign: bool = True, axis: int = 0)
     return np.sum(y_true == y_pred, axis=axis) / y_true.shape[axis]
 
 
-@WrapperArray('axis')
 def directional_accuracy(
     y_true: NDArray, y_pred: NDArray, axis: int = 0,
 ) -> float:
@@ -109,6 +111,10 @@ def directional_accuracy(
     accuracy
 
     """
+    # No `wrap_axis` here: it can only transpose the first positional argument,
+    # leaving `y_pred` mis-oriented for axis=1. Both arrays already share the
+    # same orientation, so reduce directly along `axis` (NumPy handles the
+    # axis bounds, including negative axes).
     return np.mean(np.sign(y_true) == np.sign(y_pred), axis=axis)
 
 

--- a/fynance/tests/features/test_momentums.py
+++ b/fynance/tests/features/test_momentums.py
@@ -242,3 +242,92 @@ def test_mad_axis1_matches_per_row():
     assert np.allclose(
         mad(X, axis=0), [mad(X[:, j]) for j in range(X.shape[1])]
     )
+
+
+# --------------------------------------------------------------------------- #
+#   wrap_axis: negative axes (roadmap 1.2)                                     #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("name", ["sma", "wma", "smstd", "wmstd"])
+def test_negative_axis_matches_positive(name):
+    # axis=-1 used to slip through the wrap_axis checks and the kernel, which
+    # ignores `axis`, silently returned the axis=0 result. It must now resolve
+    # to the last axis (axis=1 for a 2-D array).
+    f = getattr(fy, name)
+    X = np.array([
+        [1., 2., 3., 4.],
+        [5., 7., 9., 11.],
+        [2., 4., 8., 16.],
+    ])
+    assert np.allclose(f(X, w=2, axis=-1), f(X, w=2, axis=1))
+    assert not np.allclose(f(X, w=2, axis=-1), f(X, w=2, axis=0))
+
+
+@pytest.mark.parametrize("name", ["sma", "wma", "smstd", "wmstd"])
+def test_negative_axis_1d_matches_axis0(name):
+    # On a 1-D array axis=-1 must resolve to axis 0 (the only axis).
+    f = getattr(fy, name)
+    x = np.array([1., 3., 2., 5., 4., 6.])
+    assert np.allclose(f(x, w=2, axis=-1), f(x, w=2, axis=0))
+
+
+# --------------------------------------------------------------------------- #
+#   stats.accuracy / directional_accuracy: 2-D axis=1 (roadmap 1.2)           #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture()
+def accuracy_pair():
+    # Two distinct rows, time on axis 1.
+    y_true = np.array([
+        [1., -.5, .5, -.2],
+        [.3, -.1, .8, -.4],
+    ])
+    y_pred = np.array([
+        [.5, -.2, -.5, .1],
+        [.2, .1, .7, -.3],
+    ])
+    return y_true, y_pred
+
+
+@pytest.mark.parametrize("sign", [True, False])
+def test_accuracy_axis1_matches_per_row(accuracy_pair, sign):
+    # wrap_axis only transposes the first positional arg, leaving y_pred
+    # mis-oriented for axis=1; accuracy used to raise a broadcast ValueError.
+    from fynance.features.stats import accuracy
+    y_true, y_pred = accuracy_pair
+    out = accuracy(y_true, y_pred, sign=sign, axis=1)
+    expected = np.array([
+        accuracy(y_true[i], y_pred[i], sign=sign)
+        for i in range(y_true.shape[0])
+    ])
+    assert np.allclose(out, expected)
+
+
+def test_directional_accuracy_axis1_matches_per_row(accuracy_pair):
+    from fynance.features.stats import directional_accuracy
+    y_true, y_pred = accuracy_pair
+    out = directional_accuracy(y_true, y_pred, axis=1)
+    expected = np.array([
+        directional_accuracy(y_true[i], y_pred[i])
+        for i in range(y_true.shape[0])
+    ])
+    assert np.allclose(out, expected)
+
+
+def test_accuracy_axis0_unchanged(accuracy_pair):
+    # The default axis=0 path (per-column) must keep working.
+    from fynance.features.stats import accuracy, directional_accuracy
+    y_true, y_pred = accuracy_pair
+    assert np.allclose(
+        accuracy(y_true, y_pred, axis=0),
+        [accuracy(y_true[:, j], y_pred[:, j]) for j in range(y_true.shape[1])],
+    )
+    assert np.allclose(
+        directional_accuracy(y_true, y_pred, axis=0),
+        [
+            directional_accuracy(y_true[:, j], y_pred[:, j])
+            for j in range(y_true.shape[1])
+        ],
+    )

--- a/fynance/tests/features/test_scale.py
+++ b/fynance/tests/features/test_scale.py
@@ -195,3 +195,56 @@ def test_scale_axis1_differs_from_axis0(multi_col, kind):
     s1 = fy.Scale(multi_col, kind=kind, axis=1, a=0, b=1)
     s0 = fy.Scale(multi_col, kind=kind, axis=0, a=0, b=1)
     assert not np.allclose(s1.scale(multi_col), s0.scale(multi_col))
+
+
+# --------------------------------------------------------------------------- #
+#   Standalone rolling functions: genuine multi-column axis=1 parity          #
+#   (roadmap 1.2 — PR #193 fixed the Scale path but not these functions)      #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture()
+def roll_multi_col():
+    # Time on axis 1, distinct rows, non-square (3, 6); no constant rolling
+    # window so the rolling std/range never collapses to zero.
+    return np.array([
+        [1., 3., 2., 5., 4., 6.],
+        [6., 4., 7., 2., 8., 3.],
+        [2., 9., 1., 4., 7., 5.],
+    ])
+
+
+@pytest.mark.parametrize("kind_moment", ["s", "w", "e"])
+def test_roll_standardize_axis1_matches_per_row(roll_multi_col, kind_moment):
+    # The standalone roll_standardize used to raise on genuine multi-column
+    # data with axis=1: its rolling-moment parameters stayed in input
+    # orientation (rows, cols) while X.T was (cols, rows), so the broadcast
+    # failed. The result must now equal stacking the 1-D transform of each row.
+    from fynance.features.scale import roll_standardize
+    out = roll_standardize(roll_multi_col, w=3, axis=1, kind_moment=kind_moment)
+    expected = np.vstack([
+        roll_standardize(roll_multi_col[i], w=3, kind_moment=kind_moment)
+        for i in range(roll_multi_col.shape[0])
+    ])
+    assert np.allclose(out, expected, equal_nan=True)
+
+
+def test_roll_normalize_axis1_matches_per_row(roll_multi_col):
+    # Same broadcast bug as roll_standardize, on the rolling min/max path.
+    from fynance.features.scale import roll_normalize
+    out = roll_normalize(roll_multi_col, w=3, axis=1)
+    expected = np.vstack([
+        roll_normalize(roll_multi_col[i], w=3)
+        for i in range(roll_multi_col.shape[0])
+    ])
+    assert np.allclose(out, expected, equal_nan=True)
+
+
+@pytest.mark.parametrize("func", ["roll_standardize", "roll_normalize"])
+def test_standalone_roll_axis1_differs_from_axis0(roll_multi_col, func):
+    # Guard against silently falling back to the axis=0 result.
+    from fynance.features import scale
+    f = getattr(scale, func)
+    out1 = f(roll_multi_col, w=3, axis=1)
+    out0 = f(roll_multi_col, w=3, axis=0)
+    assert not np.allclose(out1, out0, equal_nan=True)


### PR DESCRIPTION
## Summary

Fixes three audited axis-handling bugs in the `fynance.features` subpackage (roadmap 1.2). Scope: `fynance/features/scale.py`, `fynance/_wrappers.py`, `fynance/features/stats.py` and their tests under `fynance/tests/features/`.

### HIGH — standalone `roll_standardize` / `roll_normalize` axis=1 (incomplete fix from PR #193)
The standalone functions still raised `ValueError: operands could not be broadcast together with shapes (cols,rows) (rows,cols)` on genuine multi-column data with `axis=1`. They computed the rolling moments (`m`/`s`) via the `WrapperArray`-decorated `sma`/`smstd`/`roll_min`/`roll_max`, which return results in **input** orientation `(rows, cols)`, but passed them alongside `X.T` which is `(cols, rows)`. PR #193 only fixed this inside the `Scale` class (`Scale._apply`), not these standalone entry points. Fix: transpose the 2-D parameters too for `axis==1`, mirroring `Scale._apply` (1-D reduced params left untouched).

### MEDIUM — `_wrappers.wrap_axis` mishandled negative axes
`axis=-1` passed both the `ndim <= axis` and `axis == 1` checks, then fell through to `func(X, axis=-1)`; since the kernels ignore `axis`, the result was silently the **axis=0** result. Fix: normalize `axis += X.ndim` for negative axes before the bound checks, and reject genuinely out-of-range axes with `AxisError`.

### MEDIUM — `stats.accuracy` / `directional_accuracy` crashed on 2-D axis=1
`WrapperArray('axis')` transposes only the **first** positional argument (`y_true`), so `y_true.T == y_pred` was a shape-mismatch broadcast `ValueError`. Fix: drop the `'axis'` wrapper and reduce both arrays directly along `axis` (both already share orientation; NumPy handles the axis bounds, including negative axes and the 1-D `axis=1` `AxisError`).

## Tests
Each fix has a test that fails before / passes after (verified by restoring the pre-fix sources and re-running):
- `test_scale.py`: standalone `roll_standardize` (s/w/e) and `roll_normalize` axis=1 parity vs per-row, plus axis=1 ≠ axis=0 guards.
- `test_momentums.py`: negative-axis parity for `sma`/`wma`/`smstd`/`wmstd` (2-D and 1-D), and 2-D axis=1 `accuracy`/`directional_accuracy` parity + axis=0 regression guards.

## Gates
- `ruff check fynance/` — clean
- `mypy fynance/` — clean (0 errors, 171 files)
- `pytest fynance/features/ fynance/_wrappers.py fynance/tests/features/ -o addopts='--doctest-modules'` — 262 passed; full `fynance/tests/metrics/` also green.

No `__init__` exports touched; `CHANGELOG.md` / roadmap untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYiBP4z6rdZA1BHnEUqG4p