### PR TITLE
chore: release v2.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [2.10.1] - 2026-06-22
+
+### Breaking Changes
+
+### Added
+
+### Changed
+
 - **`RNN`/`GRU`/`LSTM` honor the `SignalModel` contract.** `fit(X, y)` and
   `predict(X)` now work with a zero-initialized hidden (and cell) state — the
   natural default for these stateless gated cells. The explicit-state forms

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fynance"
-version = "2.10.0"
+version = "2.10.1"
 description = "Pure-Python (Numba-accelerated) machine learning, econometrics and statistical tools for financial analysis and backtesting"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Release **v2.10.1** — audit round-2 remediation (7 PRs, #201–#207).

### Changed
- RNN/GRU/LSTM honor SignalModel (zero-init state); custom losses use smooth tanh saturation (gradient preserved).

### Fixed
- `roll_standardize`/`roll_normalize` axis=1; `run(backtest_kpi=True)` IndexError (regression); `_safe_ratio` −inf sign + `roll_sharpe`; `walk_forward` step≤0 / negative `test_size`; `resample` resolutions; dup-index; empty `to_returns`/`pnl`; negative-axis + 2-D `accuracy`; ERC/MVP_uc `low_bound`; synthetic `n<1`; leaderboard columns; `iso_vol` list input.

## Test plan
5 gates green on develop: 880 passed/1 skipped, ruff, mypy (171), interrogate 94.7%, Sphinx -W.