### PR TITLE
Release v2.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [2.10.1] - 2026-06-22
+
+### Breaking Changes
+
+### Added
+
+### Changed
+
 - **`RNN`/`GRU`/`LSTM` honor the `SignalModel` contract.** `fit(X, y)` and
   `predict(X)` now work with a zero-initialized hidden (and cell) state — the
   natural default for these stateless gated cells. The explicit-state forms

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`RNN`/`GRU`/`LSTM` honor the `SignalModel` contract.** `fit(X, y)` and
+  `predict(X)` now work with a zero-initialized hidden (and cell) state — the
+  natural default for these stateless gated cells. The explicit-state forms
+  (`train_on(X, y, H[, C])`, `predict(X, H[, C])`) are unchanged.
+- **Custom losses use a smooth saturating map.** `CalmarLoss`/`OmegaLoss`/
+  `SortinoLoss` replace the hard `MAX_RATIO` clamp (which zeroed the gradient on
+  low-risk batches) with `MAX_RATIO * tanh(ratio / MAX_RATIO)` plus a
+  scale-invariant floor — finite loss, gradient preserved, normal-regime
+  numerics unchanged.
+
 ### Fixed
+
+- **`roll_standardize`/`roll_normalize` with `axis=1`** on genuine multi-column
+  input (the 2.10.0 `axis=1` repair had only covered the `Scale` class).
+- **`RollMultiLayerPerceptron.run(backtest_kpi=True)`** (the default) raised
+  `IndexError` on the final post-loop print; the KPI index is now clamped.
+- **`_safe_ratio` returns `-inf`** (not `+inf`) for a negative excess over a
+  zero denominator — a riskless loss is no longer scored as the best ratio;
+  `roll_sharpe` is unified onto the same `_safe_ratio` convention.
+- **`_wrappers` negative axis** (`axis=-1`) now resolves correctly instead of
+  silently computing `axis=0`; `accuracy`/`directional_accuracy` work on 2-D
+  `axis=1`.
+- **`data.split.walk_forward(step<=0)`** infinite loop and `train_test_split`
+  negative `test_size` (out-of-bounds indices) now raise; `align.resample`
+  handles `datetime64` resolutions beyond `[D]/[ms]/[us]/[ns]`; `align` rejects a
+  duplicate index; `PriceSeries.to_returns(dropna=False)`/`pnl()` handle empty
+  input.
+- **Portfolio `ERC`/`MVP_uc` clamp `low_bound`** (feasible, sum-to-one weights);
+  `research.synthetic.gbm`/`regime_switching` reject `n < 1`;
+  `research.compare` leaderboard unions metric columns across rows;
+  `features.money_management.iso_vol` accepts list input.
 
 ### Deprecated
 

--- a/doc/dev/01-overview.md
+++ b/doc/dev/01-overview.md
@@ -33,13 +33,13 @@ library's core invariant, enforced in tests.
 
 ## Current state (snapshot)
 
-- **Version `2.9.0`** (in `pyproject.toml`, static), released on `master` and
+- **Version `2.10.1`** (in `pyproject.toml`, static), released on `master` and
   published to PyPI; `Development Status :: 5 - Production/Stable`.
 - **Python 3.10–3.13** (CI matrix). Build is **pure-Python** (setuptools, no
   compile step) — numerical kernels are Numba `@njit`. No Cython.
-- **~570 unit/benchmark tests** under `fynance/tests/` (mirrors the package),
+- **~790 unit/benchmark tests** under `fynance/tests/` (mirrors the package),
   **plus doctests** run on every module via `--doctest-modules` — docstring
-  examples are part of the suite and must stay runnable (~660 collected in
+  examples are part of the suite and must stay runnable (~880 collected in
   total).
 - **Four CI gates**: pytest (3.10–3.13), `ruff`, `interrogate` (docstring
   coverage ≥ 80%), Sphinx build `-W`, and `mypy` clean.

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -72,6 +72,29 @@ Template:
 
 <!-- new entries below, newest first -->
 
+### 2026-06-22 — Audit round 2: regression + residual bugs (PRs #201–#207, v2.10.1)  [accepted]
+
+A second audit pass after v2.10.0 caught **one regression** the first remediation
+introduced — `RollMultiLayerPerceptron.run(backtest_kpi=True)` (the default path)
+raised `IndexError` because `__next__` bumps `self.i` past the last filled slot
+before `StopIteration`; fixed by clamping the KPI index — plus residual
+pre-existing bugs the first pass missed. Shipped in 7 atomic PRs (parallel
+worktrees). Test count 880 (with doctests). Two decisions worth recording:
+
+- **`RNN`/`GRU`/`LSTM` are now drop-in `SignalModel`s via a zero-initialized
+  state.** Since these are stateless gated cells (each row independent), `H`/`C`
+  carry no meaning across a call, so `fit(X, y)`/`predict(X)` default the state to
+  zeros; the explicit-state forms remain for callers that thread state. Chosen
+  over making them raise (they advertised `SignalModel` but `.fit` previously
+  `TypeError`'d).
+- **Training losses saturate smoothly, not by a hard clamp.** The v2.10.0
+  `MAX_RATIO` clamp made the loss finite but zeroed the gradient on low-risk
+  batches; replaced with `MAX_RATIO * tanh(ratio / MAX_RATIO)` + a scale-invariant
+  floor so a residual gradient always survives. **Lesson: parallel-worktree
+  agents must not use `git stash` (shared stash stack collides) — verify
+  fail-before via a temp copy.**
+
+
 ### 2026-06-22 — Full code audit + remediation (PRs #188–#196)  [accepted]
 
 A deep correctness/tests/docs audit (the 5 gates were already green) found logic

--- a/doc/dev/05-testing.md
+++ b/doc/dev/05-testing.md
@@ -4,7 +4,7 @@
 
 | Layer | Command | Catches |
 |-------|---------|---------|
-| **Unit** | `pytest` | logic, shapes, regressions (~570 unit/benchmark tests under `fynance/tests/`; ~660 collected with doctests) |
+| **Unit** | `pytest` | logic, shapes, regressions (~790 unit/benchmark tests under `fynance/tests/`; ~880 collected with doctests) |
 | **Doctests** | `pytest --doctest-modules` (on by default in `pyproject.toml`) | every docstring `>>>` example — they are part of the suite |
 | **Benchmarks** | `pytest-benchmark` (e.g. `test_filters_benchmark.py`) | perf regressions on hot paths |
 | **Coverage** | `pytest --cov=fynance --cov-report=term-missing` | untested branches |

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -66,11 +66,11 @@ so an agent doesn't re-investigate settled ground or assume a known stub is a bu
 - **Numerical kernels on Numba `@njit`** — no Cython anywhere; the build is
   pure-Python (no `setup.py`, no compile step). Every kernel has a golden-value
   parity test (1e-9/1e-10) captured from the former Cython.
-- **Quality gates (all 4 enforced in CI)**: ~660 tests collected (~570 unit/
+- **Quality gates (all 4 enforced in CI)**: ~880 tests collected (~790 unit/
   benchmark + doctests on every module via `--doctest-modules`), incl. property
   tests (kernel parity + no-lookahead); `ruff`; `interrogate` (docstring coverage
-  ≥ 80%, currently ~93.6%); Sphinx build `-W`; **`mypy` clean (0 errors)**.
-- **Released**: `v2.9.0` on `master` + PyPI; `Production/Stable`. CI matrix
+  ≥ 80%, currently ~94.7%); Sphinx build `-W`; **`mypy` clean (0 errors)**.
+- **Released**: `v2.10.1` on `master` + PyPI; `Production/Stable`. CI matrix
   3.10–3.13; release builds a pure-Python universal wheel + sdist and creates the
   GitHub Release from the CHANGELOG on tag.
 
@@ -78,10 +78,12 @@ so an agent doesn't re-investigate settled ground or assume a known stub is a bu
 
 Nothing is currently in flight (`develop` is clean). The v2.9.0 **library
 bricks** all shipped (OHLCV indicators, causal GARCH-volatility feature,
-adaptive windows, `RegimeMoE`, `MarketImpactCost`). Remaining open work is the
-**2026-06 audit remediation** (correctness/tests/docs the CI gates don't catch —
-roadmap §1), an optional **Streamlit ledger explorer** (roadmap §2), and minor
-**CI/badge hygiene** (roadmap §3). See `07-roadmap.md`.
+adaptive windows, `RegimeMoE`, `MarketImpactCost`), and the **2026-06 audit**
+was fully remediated across two passes (v2.10.0: PRs #188–#196; v2.10.1: PRs
+#201–#207 — correctness/tests/docs the CI gates don't catch, incl. one KPI
+regression). The CI/badge hygiene chores are resolved (CI runs on `develop` PRs;
+badges green). The only remaining open item is the optional **Streamlit ledger
+explorer** (roadmap §2). See `07-roadmap.md`.
 
 **Out of scope here**: strategy research on **real data** (empirical loss /
 architecture / normalization benchmarks, out-of-sample Sharpe, online regimes,

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -17,9 +17,9 @@ shipped, `03-decisions.md` for *why*. Keep it short and true.
 > brique d'entraînement aligné-objectif (`ObjectiveModel`) et les **bricks de
 > librairie** (conteneur `OHLCV` + indicateurs ATR/ADX/Williams %R/OBV/VWAP, feature
 > GARCH causale, `RegimeMoE`, fenêtres adaptatives, coût market-impact non-linéaire)
-> sont **terminés** — voir `CHANGELOG.md` / `03-decisions.md`. Un **audit complet** (2026-06-22) a été
-> **entièrement remédié** en 9 PR atomiques (#188–#196) — voir `CHANGELOG.md`
-> / `03-decisions.md`. Il ne reste que les items optionnels ci-dessous.
+> sont **terminés** — voir `CHANGELOG.md` / `03-decisions.md`. Un **audit complet** (2026-06-22) a été remédié en 9 PR (#188–#196,
+> v2.10.0). Un **2ᵉ passage** a relevé une régression (KPI `run()`) + des bugs
+> résiduels — backlog en **section 1** ci-dessous ; le reste est optionnel.
 
 > ⚠️ **Hors scope ici** : la recherche de stratégie sur **vraie data** (benchmarks
 > empiriques loss / architecture / normalisation, évaluation Sharpe out-of-sample,
@@ -28,6 +28,45 @@ shipped, `03-decisions.md` for *why*. Keep it short and true.
 > code de librairie réutilisable, data-agnostique.
 
 ---
+
+## 1. Audit round 2 — régression + bugs résiduels (2026-06-22)
+
+2ᵉ passage d'audit après v2.10.0 : une **régression** introduite par la
+remédiation + des bugs **pré-existants** ratés au 1er tour. PR atomiques,
+parallélisables (fichiers disjoints). Cible **v2.10.1**.
+
+### 1.1 — `fix/rolling-kpi-crash` (models/rolling.py)
+- [ ] **HIGH (régression #196)** `run(backtest_kpi=True)` (chemin par DÉFAUT) lève `IndexError` : `_display_kpi` lit `loss_eval[self.i]` mais `__next__` incrémente `self.i` avant `StopIteration` → après la boucle `self.i==n_iter` (taille `n_iter`). Clamp `min(self.i, n_iter-1)` + test `run(backtest_kpi=True)`.
+- [ ] **LOW** `_display_kpi` : dénominateur `T-n-T%s` peut valoir 0 → ZeroDivisionError (garder).
+
+### 1.2 — `fix/features-axis-edges` (features/scale.py, _wrappers.py, features/stats.py)
+- [ ] **HIGH (fix #193 incomplet)** `roll_standardize`/`roll_normalize(axis=1)` lèvent encore sur multi-colonnes (params non transposés ; seul `Scale` a été corrigé). Mirror `Scale._apply` + tests standalone axis=1.
+- [ ] **MED** `_wrappers.wrap_axis` : `axis=-1` calcule silencieusement `axis=0` — normaliser `axis %= ndim`.
+- [ ] **MED** `stats.accuracy`/`directional_accuracy(axis=1)` crashent sur 2-D (seul `y_true` transposé ; transposer les deux).
+
+### 1.3 — `fix/data-core-edges` (data/split.py, data/align.py, core/price_series.py)
+- [ ] **HIGH** `split.walk_forward(step<=0)` boucle infinie ; `train_test_split(test_size<0)` → indices train hors-bornes. Gardes.
+- [ ] **MED (fix #192 partiel)** `align.resample` ne valide que `kind=='M'` mais polars n'accepte que `[D]/[ms]/[us]/[ns]` ; `[s]`/`[h]`/`[Y]` passent puis erreur opaque. Valider/normaliser la résolution.
+- [ ] **MED (fix #192 partiel)** `price_series.to_returns(dropna=False)` et `pnl()` : `IndexError` sur série vide (garde non propagée depuis `apply`).
+- [ ] **MED** `align` : index dupliqué silencieusement écrasé (`dict(zip)`) → longueur change. Détecter/lever.
+- [ ] **LOW** `from_polars` doc « numeric column » mais filtre par nom seulement.
+
+### 1.4 — `fix/metrics-ratio-sign` (metrics/ratios.py)
+- [ ] **MED** `_safe_ratio` renvoie `+inf` pour un excès NÉGATIF sur dénominateur nul (devrait être `-inf`) : `sharpe(flat, rf>0)` = perte sans risque notée meilleure possible. Corriger le signe.
+- [ ] **LOW** `roll_sharpe` garde encore la convention `0.0` (incohérent avec `calmar→inf` unifié en #194) — router via `_safe_ratio`.
+
+### 1.5 — `fix/loss-gradient-saturation` (models/loss/{calmar,omega,sortino}.py)
+- [ ] **MED (qualité fix #196)** le plancher eps (~5e-9) est trop petit → le clamp `MAX_RATIO=1e3` s'active et ANNULE le gradient en régime faible-risque (Sortino : 78/300 batches). Plancher relatif plus large ou map saturante douce, pour garder un gradient ; doc Calmar honnête.
+
+### 1.6 — `fix/recurrent-fit` (models/_recurrent_base.py, rnn.py, gru.py, lstm.py)
+- [ ] **MED** RNN/GRU/LSTM se déclarent `SignalModel` mais `.fit()` lève `TypeError` (train_on exige `H`/`C`). Override `fit`/`predict` (H/C init zéro) OU message clair + retirer la conformité SignalModel.
+- [ ] **LOW** `predict` récurrent ne déplace pas X/H/C sur le device du modèle.
+
+### 1.7 — `fix/low-polish` (portfolio/allocation.py, research/{synthetic,compare}.py, features/money_management.py)
+- [ ] **LOW** `ERC`/`MVP_uc` : `low_bound>1/N` → poids infaisables ; clamper `low_bound=min(low_bound,1/N)`.
+- [ ] **LOW** `_normalize` : `print()` → `warnings.warn` ; test `MVP` pinv via colonne à variance nulle.
+- [ ] **LOW** `synthetic.gbm(0)`/`regime_switching(0)` renvoient longueur-1 (garde `n<1`) ; `compare._markdown_table` : union des clés (pas seulement `rows[0]`).
+- [ ] **LOW** `money_management.iso_vol` : coercition d'entrée manquante (`np.asarray(...).reshape(-1)`).
 
 ## 3. Chore — CI / hygiène
 

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -17,9 +17,9 @@ shipped, `03-decisions.md` for *why*. Keep it short and true.
 > brique d'entraînement aligné-objectif (`ObjectiveModel`) et les **bricks de
 > librairie** (conteneur `OHLCV` + indicateurs ATR/ADX/Williams %R/OBV/VWAP, feature
 > GARCH causale, `RegimeMoE`, fenêtres adaptatives, coût market-impact non-linéaire)
-> sont **terminés** — voir `CHANGELOG.md` / `03-decisions.md`. Un **audit complet** (2026-06-22) a été remédié en 9 PR (#188–#196,
-> v2.10.0). Un **2ᵉ passage** a relevé une régression (KPI `run()`) + des bugs
-> résiduels — backlog en **section 1** ci-dessous ; le reste est optionnel.
+> sont **terminés** — voir `CHANGELOG.md` / `03-decisions.md`. Deux passages d'audit (2026-06-22) ont été **entièrement remédiés** : 9 PR
+> (#188–#196, v2.10.0) puis 7 PR (#201–#207, v2.10.1, dont une régression KPI).
+> Voir `CHANGELOG.md` / `03-decisions.md`. Il ne reste que l'item optionnel ci-dessous.
 
 > ⚠️ **Hors scope ici** : la recherche de stratégie sur **vraie data** (benchmarks
 > empiriques loss / architecture / normalisation, évaluation Sharpe out-of-sample,
@@ -28,56 +28,6 @@ shipped, `03-decisions.md` for *why*. Keep it short and true.
 > code de librairie réutilisable, data-agnostique.
 
 ---
-
-## 1. Audit round 2 — régression + bugs résiduels (2026-06-22)
-
-2ᵉ passage d'audit après v2.10.0 : une **régression** introduite par la
-remédiation + des bugs **pré-existants** ratés au 1er tour. PR atomiques,
-parallélisables (fichiers disjoints). Cible **v2.10.1**.
-
-### 1.1 — `fix/rolling-kpi-crash` (models/rolling.py)
-- [ ] **HIGH (régression #196)** `run(backtest_kpi=True)` (chemin par DÉFAUT) lève `IndexError` : `_display_kpi` lit `loss_eval[self.i]` mais `__next__` incrémente `self.i` avant `StopIteration` → après la boucle `self.i==n_iter` (taille `n_iter`). Clamp `min(self.i, n_iter-1)` + test `run(backtest_kpi=True)`.
-- [ ] **LOW** `_display_kpi` : dénominateur `T-n-T%s` peut valoir 0 → ZeroDivisionError (garder).
-
-### 1.2 — `fix/features-axis-edges` (features/scale.py, _wrappers.py, features/stats.py)
-- [ ] **HIGH (fix #193 incomplet)** `roll_standardize`/`roll_normalize(axis=1)` lèvent encore sur multi-colonnes (params non transposés ; seul `Scale` a été corrigé). Mirror `Scale._apply` + tests standalone axis=1.
-- [ ] **MED** `_wrappers.wrap_axis` : `axis=-1` calcule silencieusement `axis=0` — normaliser `axis %= ndim`.
-- [ ] **MED** `stats.accuracy`/`directional_accuracy(axis=1)` crashent sur 2-D (seul `y_true` transposé ; transposer les deux).
-
-### 1.3 — `fix/data-core-edges` (data/split.py, data/align.py, core/price_series.py)
-- [ ] **HIGH** `split.walk_forward(step<=0)` boucle infinie ; `train_test_split(test_size<0)` → indices train hors-bornes. Gardes.
-- [ ] **MED (fix #192 partiel)** `align.resample` ne valide que `kind=='M'` mais polars n'accepte que `[D]/[ms]/[us]/[ns]` ; `[s]`/`[h]`/`[Y]` passent puis erreur opaque. Valider/normaliser la résolution.
-- [ ] **MED (fix #192 partiel)** `price_series.to_returns(dropna=False)` et `pnl()` : `IndexError` sur série vide (garde non propagée depuis `apply`).
-- [ ] **MED** `align` : index dupliqué silencieusement écrasé (`dict(zip)`) → longueur change. Détecter/lever.
-- [ ] **LOW** `from_polars` doc « numeric column » mais filtre par nom seulement.
-
-### 1.4 — `fix/metrics-ratio-sign` (metrics/ratios.py)
-- [ ] **MED** `_safe_ratio` renvoie `+inf` pour un excès NÉGATIF sur dénominateur nul (devrait être `-inf`) : `sharpe(flat, rf>0)` = perte sans risque notée meilleure possible. Corriger le signe.
-- [ ] **LOW** `roll_sharpe` garde encore la convention `0.0` (incohérent avec `calmar→inf` unifié en #194) — router via `_safe_ratio`.
-
-### 1.5 — `fix/loss-gradient-saturation` (models/loss/{calmar,omega,sortino}.py)
-- [ ] **MED (qualité fix #196)** le plancher eps (~5e-9) est trop petit → le clamp `MAX_RATIO=1e3` s'active et ANNULE le gradient en régime faible-risque (Sortino : 78/300 batches). Plancher relatif plus large ou map saturante douce, pour garder un gradient ; doc Calmar honnête.
-
-### 1.6 — `fix/recurrent-fit` (models/_recurrent_base.py, rnn.py, gru.py, lstm.py)
-- [ ] **MED** RNN/GRU/LSTM se déclarent `SignalModel` mais `.fit()` lève `TypeError` (train_on exige `H`/`C`). Override `fit`/`predict` (H/C init zéro) OU message clair + retirer la conformité SignalModel.
-- [ ] **LOW** `predict` récurrent ne déplace pas X/H/C sur le device du modèle.
-
-### 1.7 — `fix/low-polish` (portfolio/allocation.py, research/{synthetic,compare}.py, features/money_management.py)
-- [ ] **LOW** `ERC`/`MVP_uc` : `low_bound>1/N` → poids infaisables ; clamper `low_bound=min(low_bound,1/N)`.
-- [ ] **LOW** `_normalize` : `print()` → `warnings.warn` ; test `MVP` pinv via colonne à variance nulle.
-- [ ] **LOW** `synthetic.gbm(0)`/`regime_switching(0)` renvoient longueur-1 (garde `n<1`) ; `compare._markdown_table` : union des clés (pas seulement `rows[0]`).
-- [ ] **LOW** `money_management.iso_vol` : coercition d'entrée manquante (`np.asarray(...).reshape(-1)`).
-
-## 3. Chore — CI / hygiène
-
-Dette d'outillage repérée pendant le batch library-bricks (v2.9.0). Non bloquant.
-
-- [ ] **CI sur les PR vers `develop`.** `ci.yml` ne s'est pas déclenché sur les PR
-  de feature ciblant `develop` (la suite n'a tourné qu'en local) — vérifier les
-  triggers du workflow pour que les 4 gates s'exécutent aussi sur ces PR.
-- [ ] **Job « Update badges » en échec.** L'étape « Commit badge if changed »
-  (workflow `Badges`) échoue à chaque push sur `develop` (problème de push du badge
-  de couverture docstring) — corriger les permissions / la condition de commit.
 
 ## 2. Research harness — extension optionnelle
 

--- a/fynance/_wrappers.py
+++ b/fynance/_wrappers.py
@@ -61,7 +61,13 @@ def wrap_axis(func):
                 stacklevel=2,
             )
 
-        if X.ndim <= axis:
+        # Normalize negative axes (e.g. -1 -> ndim - 1) before the checks
+        # below, otherwise a negative axis would slip through and the kernel,
+        # which ignores `axis`, would silently return the axis=0 result.
+        if axis < 0:
+            axis += X.ndim
+
+        if X.ndim <= axis or axis < 0:
 
             raise np.exceptions.AxisError(axis, X.ndim)
 

--- a/fynance/core/price_series.py
+++ b/fynance/core/price_series.py
@@ -155,13 +155,19 @@ class PriceSeries:
         index = data[index_col].to_numpy() if index_col is not None else None
 
         if value_col is None:
-            candidates = [c for c in data.columns if c != index_col]
+            # Match the documented default: the single non-index *numeric*
+            # column. Filtering by name alone would pick a lone string column
+            # and fail later with an opaque cast-to-float64 error.
+            candidates = [
+                c for c, dt in zip(data.columns, data.dtypes)
+                if c != index_col and dt.is_numeric()
+            ]
 
             if len(candidates) != 1:
 
                 raise ValueError(
                     "value_col is ambiguous; pass it explicitly "
-                    f"(candidates={candidates})"
+                    f"(numeric candidates={candidates})"
                 )
 
             value_col = candidates[0]
@@ -319,6 +325,11 @@ class PriceSeries:
 
             return self._new(r, index=self.index[1:])
 
+        if p.size == 0:
+            # Empty input: no leading NaN to write (full[0] would be OOB).
+
+            return self._new(np.empty(0, dtype=np.float64))
+
         full = np.empty(p.size, dtype=np.float64)
         full[0] = np.nan
         full[1:] = r
@@ -398,6 +409,11 @@ class PriceSeries:
                 f"positions length {pos.size} != returns length "
                 f"{self.values.size}"
             )
+
+        if pos.size == 0:
+            # Empty input: no leading NaN to write (shifted[0] would be OOB).
+
+            return self._new(np.empty(0, dtype=np.float64))
 
         shifted = np.empty_like(pos)
         shifted[0] = np.nan

--- a/fynance/data/align.py
+++ b/fynance/data/align.py
@@ -55,7 +55,26 @@ def align(
     dict of str to PriceSeries
         Series sharing a common index.
 
+    Raises
+    ------
+    ValueError
+        If ``how`` is unknown, or if any input series has duplicate index
+        entries. Duplicate timestamps would otherwise be silently collapsed
+        (the index-to-value mapping keeps only the last value), shrinking the
+        series to its unique count without warning.
+
     """
+    for name, ps in series.items():
+        idx_list = ps.index.tolist()
+
+        if len(idx_list) != len(set(idx_list)):
+
+            raise ValueError(
+                f"series {name!r} has duplicate index entries; align cannot "
+                "map a timestamp to more than one value (deduplicate or "
+                "aggregate the series first)"
+            )
+
     index_sets = [set(ps.index.tolist()) for ps in series.values()]
 
     if how == "outer":
@@ -96,6 +115,11 @@ def resample(
     an explanatory :class:`ValueError` rather than surfacing an opaque polars
     error.
 
+    polars only accepts ``datetime64`` resolutions ``[D]``, ``[ms]``, ``[us]``
+    and ``[ns]``. Any other resolution (the common ``[s]``, plus ``[h]``,
+    ``[m]``, ``[W]``, ``[M]``, ``[Y]``) is losslessly upcast to ``[us]`` before
+    resampling, so it works instead of triggering an opaque polars error.
+
     Parameters
     ----------
     ps : PriceSeries
@@ -127,6 +151,19 @@ def resample(
             f"{index.dtype!r}; convert the index to numpy datetime64 first "
             "(integer and object/datetime.datetime indexes are not supported)"
         )
+
+    # polars only accepts datetime64 [D]/[ms]/[us]/[ns]; upcast any other
+    # resolution (e.g. the common [s], or [h]/[m]/[W]/[M]/[Y]) to [us] so the
+    # call succeeds instead of raising an opaque polars resolution error.
+    _supported = (
+        np.dtype("datetime64[D]"),
+        np.dtype("datetime64[ms]"),
+        np.dtype("datetime64[us]"),
+        np.dtype("datetime64[ns]"),
+    )
+
+    if index.dtype not in _supported:
+        index = index.astype("datetime64[us]")
 
     df = pl.DataFrame({"_t": index, "_v": ps.values}).sort("_t")
     gb = df.group_by_dynamic("_t", every=freq)

--- a/fynance/data/split.py
+++ b/fynance/data/split.py
@@ -49,8 +49,25 @@ def train_test_split(
     (train_idx, test_idx) : tuple of numpy.ndarray
         ``test_idx`` is strictly after ``train_idx`` (no leakage).
 
+    Raises
+    ------
+    ValueError
+        If ``test_size`` is negative (a negative integer would yield
+        out-of-bounds train indices and a negative fraction would silently
+        produce an empty test set), if the resulting test count exceeds ``n``,
+        or if the train set would be empty.
+
     """
+    if test_size < 0:
+
+        raise ValueError(f"test_size must be >= 0, got {test_size}")
+
     n_test = int(round(n * test_size)) if 0 < test_size < 1 else int(test_size)
+
+    if n_test > n:
+
+        raise ValueError(f"test_size ({n_test}) exceeds n ({n})")
+
     split = n - n_test
 
     if split - gap <= 0:
@@ -95,7 +112,8 @@ def walk_forward(
     ValueError
         If ``train <= 0`` or ``purge >= train``: either would yield empty train
         windows (``[t-train : t-purge]`` becomes empty), which silently breaks a
-        downstream ``fit`` with an opaque error instead of failing here.
+        downstream ``fit`` with an opaque error instead of failing here. Also if
+        ``step <= 0``, which would never advance ``t`` and loop forever.
 
     """
     if train <= 0:
@@ -111,6 +129,13 @@ def walk_forward(
 
     if step is None:
         step = test
+
+    if step <= 0:
+
+        raise ValueError(
+            f"step must be > 0, got {step} (otherwise t never advances "
+            "and the window generator loops forever)"
+        )
 
     t = train
 

--- a/fynance/features/money_management.py
+++ b/fynance/features/money_management.py
@@ -52,6 +52,8 @@ def iso_vol(series, target_vol=0.20, leverage=1., period=252, half_life=11):
            1.07186485])
 
     """
+    # Coerce input to a 1d float array so list/tuple inputs work too.
+    series = np.asarray(series, dtype=np.float64).reshape(-1)
     # Set iso-vol vector
     iv = np.ones([series.size])
     # Compute squared daily return vector (standard return s_t / s_{t-1} - 1)

--- a/fynance/features/scale.py
+++ b/fynance/features/scale.py
@@ -424,6 +424,11 @@ def roll_standardize(X, w=None, a=0, b=1, axis=0, kind_moment="s"):
     s = std(X, w, axis=axis)
 
     if axis == 1:
+        # The rolling moments are returned in the input orientation
+        # (rows, cols); transpose them along with `X` so the time axis lands
+        # on axis 0 and the orientations match before broadcasting.
+        m = m.T if isinstance(m, np.ndarray) and m.ndim == X.ndim else m
+        s = s.T if isinstance(s, np.ndarray) and s.ndim == X.ndim else s
 
         return _standardize(X.T, m, s, a, b).T
 
@@ -508,6 +513,11 @@ def roll_normalize(X, w=None, a=0, b=1, axis=0):
     s = roll_max(X, w, axis=axis)
 
     if axis == 1:
+        # The rolling min/max are returned in the input orientation
+        # (rows, cols); transpose them along with `X` so the time axis lands
+        # on axis 0 and the orientations match before broadcasting.
+        m = m.T if isinstance(m, np.ndarray) and m.ndim == X.ndim else m
+        s = s.T if isinstance(s, np.ndarray) and s.ndim == X.ndim else s
 
         return _normalize(X.T, m, s, a, b).T
 

--- a/fynance/features/stats.py
+++ b/fynance/features/stats.py
@@ -18,7 +18,6 @@ __all__ = ['accuracy', 'directional_accuracy', 'percent_positive',
            'tail_ratio', 'z_score', 'roll_z_score', 'mad', 'roll_mad']
 
 
-@WrapperArray('axis')
 def accuracy(y_true: NDArray, y_pred: NDArray, sign: bool = True, axis: int = 0) -> float:
     r""" Compute the accuracy of prediction.
 
@@ -59,6 +58,10 @@ def accuracy(y_true: NDArray, y_pred: NDArray, sign: bool = True, axis: int = 0)
     mdd, calmar, sharpe, drawdown
 
     """
+    # No `wrap_axis` here: it can only transpose the first positional argument,
+    # leaving `y_pred` mis-oriented for axis=1. Both arrays already share the
+    # same orientation, so reduce directly along `axis` (NumPy handles the
+    # axis bounds, including negative axes).
     if sign:
         y_true = np.sign(y_true)
         y_pred = np.sign(y_pred)
@@ -66,7 +69,6 @@ def accuracy(y_true: NDArray, y_pred: NDArray, sign: bool = True, axis: int = 0)
     return np.sum(y_true == y_pred, axis=axis) / y_true.shape[axis]
 
 
-@WrapperArray('axis')
 def directional_accuracy(
     y_true: NDArray, y_pred: NDArray, axis: int = 0,
 ) -> float:
@@ -109,6 +111,10 @@ def directional_accuracy(
     accuracy
 
     """
+    # No `wrap_axis` here: it can only transpose the first positional argument,
+    # leaving `y_pred` mis-oriented for axis=1. Both arrays already share the
+    # same orientation, so reduce directly along `axis` (NumPy handles the
+    # axis bounds, including negative axes).
     return np.mean(np.sign(y_true) == np.sign(y_pred), axis=axis)
 
 

--- a/fynance/metrics/ratios.py
+++ b/fynance/metrics/ratios.py
@@ -24,9 +24,10 @@ def _safe_ratio(excess: NDArray, denom: NDArray) -> Any:
     """ ``excess / denom`` robust to a zero denominator (scalar **or** array).
 
     A zero-volatility series has an undefined ratio: it is ``+inf`` when the
-    excess return is non-zero (a riskless gain), and ``0`` when the excess is also
-    zero (a flat, do-nothing curve). Returns a numpy scalar for 0-D input and an
-    array otherwise — matching the surrounding ratio functions' shape contract.
+    excess return is positive (a riskless gain), ``-inf`` when the excess is
+    negative (a riskless loss), and ``0`` when the excess is also zero (a flat,
+    do-nothing curve). Returns a numpy scalar for 0-D input and an array
+    otherwise — matching the surrounding ratio functions' shape contract.
     """
     excess = np.asarray(excess, dtype=np.float64)
     denom = np.asarray(denom, dtype=np.float64)
@@ -36,11 +37,16 @@ def _safe_ratio(excess: NDArray, denom: NDArray) -> Any:
 
             return np.float64(excess / denom)
 
-        return np.float64(np.inf if excess != 0. else 0.)
+        if excess == 0.:
+
+            return np.float64(0.)
+
+        return np.float64(np.sign(excess) * np.inf)
 
     res = np.full(denom.shape, np.inf, dtype=np.float64)
     nz = denom != 0.
     res[nz] = excess[nz] / denom[nz]
+    res[(~nz) & (excess < 0.)] = -np.inf
     res[(~nz) & (excess == 0.)] = 0.
 
     return res
@@ -548,23 +554,13 @@ def roll_sharpe(
     """
     ret = _roll_annual_return(X, period, w, ddof)
     vol = _roll_annual_volatility(X, period, log, w, axis, ddof)
-    sharpe = np.zeros(X.shape)
-    slice_bool = (vol != 0)
 
-    if isinstance(rf, float) or isinstance(rf, int):
-        _rf = rf
-
-    elif isinstance(rf, np.ndarray) and rf.shape[0] != X.shape[0]:
+    if isinstance(rf, np.ndarray) and rf.shape[0] != X.shape[0]:
         msg_prefix = 'rf must be '
 
         raise ArraySizeError(X.shape[0], msg_prefix=msg_prefix)
 
-    else:
-        _rf = rf[slice_bool]
-
-    sharpe[slice_bool] = (ret[slice_bool] - _rf) / vol[slice_bool]
-
-    return sharpe
+    return _safe_ratio(ret - rf, vol)
 
 
 @WrapperArray('dtype', 'axis', 'window', 'ddof', min_size=2)

--- a/fynance/models/_recurrent_base.py
+++ b/fynance/models/_recurrent_base.py
@@ -150,6 +150,17 @@ class _OutputLayerMixin:
     cell state (e.g. :class:`~fynance.models.lstm.LongShortTermMemory`)
     must override both methods.
 
+    For drop-in :class:`~fynance.core.protocols.SignalModel` use the
+    mixin also provides :meth:`fit` and a single-argument
+    :meth:`predict`. Because each row is processed independently
+    (stateless gated cell), the hidden state has no carry-over meaning
+    across a fit / predict call and the natural default is to
+    zero-initialize it: :meth:`fit` zero-initializes ``H`` and threads
+    it across epochs, and :meth:`predict` called as ``predict(X)``
+    zero-initializes ``H`` and returns only the prediction. The
+    explicit-state forms ``train_on(X, y, H)`` and ``predict(X, H)``
+    remain available for callers that thread the state themselves.
+
     This mixin is designed for multiple inheritance alongside
     :class:`_RecurrentBase` or one of its subclasses. The MRO must
     place :class:`_OutputLayerMixin` **before** the recurrent base so
@@ -174,6 +185,51 @@ class _OutputLayerMixin:
     def __init__(self, forward_activation=nn.Identity):
         self.W_y = nn.Linear(self.H, self.M, bias=getattr(self, 'bias', True))
         self.f_y = nn.Softmax(dim=-1) if forward_activation is nn.Softmax else forward_activation()
+
+    def _init_state(self, X: torch.Tensor) -> torch.Tensor:
+        """ Build a zero hidden state matching ``X`` (rows, dtype, device). """
+        try:
+            param = next(self.parameters())  # type: ignore[attr-defined]
+            device, dtype = param.device, param.dtype
+
+        except StopIteration:
+            device, dtype = X.device, X.dtype
+
+        return torch.zeros(X.shape[0], self.H, dtype=dtype, device=device)  # type: ignore[attr-defined]
+
+    def fit(self, X, y, epochs: int = 1, x_type=None, y_type=None):
+        """ Fit the model on ``(X, y)`` for ``epochs`` full-batch steps.
+
+        Conforms to the :class:`~fynance.core.protocols.SignalModel`
+        contract. The hidden state is zero-initialized once and threaded
+        across epochs (detached between steps). An optimizer must have
+        been registered with
+        :meth:`~fynance.models._base.BaseNeuralNet.set_optimizer`.
+
+        Parameters
+        ----------
+        X, y : array-like
+            Input and output data (numpy / torch / polars), shapes
+            ``(T, N)`` and ``(T, M)``.
+        epochs : int
+            Number of full-batch training steps.
+        x_type, y_type : torch.dtype, optional
+            Target dtypes forwarded to
+            :meth:`~fynance.models._base.BaseNeuralNet.set_data`.
+
+        Returns
+        -------
+        _OutputLayerMixin
+            ``self``, to allow chaining.
+
+        """
+        self.set_data(X, y, x_type=x_type, y_type=y_type)  # type: ignore[attr-defined]
+        H = self._init_state(self.X)  # type: ignore[attr-defined]
+
+        for _ in range(epochs):
+            _, H = self.train_on(self.X, self.y, H)  # type: ignore[attr-defined]
+
+        return self
 
     @torch.enable_grad()
     def train_on(self, X: torch.Tensor, y: torch.Tensor, H: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
@@ -205,24 +261,56 @@ class _OutputLayerMixin:
         return loss, H.detach()
 
     @torch.no_grad()
-    def predict(self, X: torch.Tensor, H: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    def predict(self, X, H: torch.Tensor | None = None):
         """ Predicts outputs of neural network model.
+
+        Two calling conventions are supported:
+
+        - ``predict(X)`` — conforms to the
+          :class:`~fynance.core.protocols.SignalModel` contract: ``X``
+          may be array-like (coerced to a tensor), the hidden state is
+          zero-initialized, and **only** the prediction tensor ``Y`` is
+          returned.
+        - ``predict(X, H)`` — explicit-state form: ``X`` and ``H`` are
+          tensors and the updated state is threaded back, returning the
+          ``(Y, H)`` tuple.
+
+        In both cases ``X`` (and ``H``) are moved to the model's device.
 
         Parameters
         ----------
-        X : torch.Tensor
+        X : array-like or torch.Tensor
             Inputs to compute prediction.
-        H : torch.Tensor
-            States of the model.
+        H : torch.Tensor, optional
+            States of the model. If ``None`` (default), a zero state is
+            used and only the prediction is returned.
 
         Returns
         -------
         torch.Tensor
-           Outputs prediction.
-        torch.Tensor
-           Updated states of the model.
+           Outputs prediction (when ``H`` is ``None``).
+        tuple of torch.Tensor
+           ``(Y, H)`` outputs prediction and updated state (when ``H``
+           is provided).
 
         """
+        return_state = H is not None
+
+        if not isinstance(X, torch.Tensor):
+            X = self._set_data(X)  # type: ignore[attr-defined]
+
+        try:
+            device = next(self.parameters()).device  # type: ignore[attr-defined]
+            X = X.to(device)
+            if return_state:
+                H = H.to(device)  # type: ignore[union-attr]
+
+        except StopIteration:
+            pass
+
+        if H is None:
+            H = self._init_state(X)
+
         was_training = self.training  # type: ignore[attr-defined]
         self.eval()  # type: ignore[attr-defined]
         try:
@@ -231,4 +319,8 @@ class _OutputLayerMixin:
         finally:
             self.train(was_training)  # type: ignore[attr-defined]
 
-        return Y.detach(), H.detach()
+        if return_state:
+
+            return Y.detach(), H.detach()
+
+        return Y.detach()

--- a/fynance/models/loss/calmar.py
+++ b/fynance/models/loss/calmar.py
@@ -30,9 +30,20 @@ class CalmarLoss(BaseLoss):
     Drawdowns are :math:`O(\text{returns})`, so a fixed absolute ``eps``
     (e.g. ``1e-8``) is dimensionally wrong: on a low- or zero-drawdown
     batch the ratio would explode and dominate gradients. The drawdown is
-    therefore floored with a **returns-scaled** epsilon,
-    ``eps * |equity|.mean()``, keeping the loss finite and bounded while
-    preserving its sign convention (minimizing it maximizes the ratio).
+    therefore floored with a **returns-scaled** value
+    ``|equity|.mean() / MAX_RATIO`` (plus a bare ``eps`` backstop for the
+    degenerate all-zero batch), capping the ratio at roughly ``MAX_RATIO``
+    in the low-drawdown regime regardless of the return scale.
+
+    The ratio is then passed through a **smooth saturating map**,
+    ``MAX_RATIO * tanh(ratio / MAX_RATIO)``, instead of a hard clamp. A
+    hard clamp pins the loss to a constant on a near-zero-drawdown batch
+    and so zeroes the gradient in exactly the strong-uptrend regime
+    training still wants to push on; ``tanh`` is near-linear for
+    normal-regime ratios (leaving their numerics unchanged) yet keeps a
+    residual, non-zero gradient when the ratio is large. This keeps the
+    loss finite and bounded while preserving its sign convention
+    (minimizing it maximizes the ratio).
 
     """
 
@@ -47,11 +58,13 @@ class CalmarLoss(BaseLoss):
         annual_return = y_pred.mean() * self.period
         # Returns-scaled floor: a fixed absolute eps is dimensionally wrong for
         # an O(returns) drawdown and lets the ratio explode on a low-drawdown
-        # batch. Scaling by the equity magnitude keeps the floor on the right
-        # scale; the bare eps backstop guards the degenerate all-zero-return
-        # case and the final clamp bounds the magnitude when the drawdown is
-        # near zero (so the loss stays finite with well-scaled gradients).
-        floor = self.eps * equity.abs().mean() + self.eps
+        # batch. Scaling by ``|equity|.mean() / MAX_RATIO`` caps the ratio at
+        # ~MAX_RATIO in the near-zero-drawdown regime; the bare eps backstop
+        # guards the degenerate all-zero-return case.
+        floor = equity.abs().mean() / _MAX_RATIO + self.eps
         ratio = annual_return / torch.clamp(max_drawdown, min=floor)
 
-        return -torch.clamp(ratio, min=-_MAX_RATIO, max=_MAX_RATIO)
+        # Smooth saturating map instead of a hard clamp: tanh is near-linear for
+        # normal-regime ratios (numerics unchanged) but keeps a non-zero
+        # gradient when the ratio is large, unlike a clamp that zeroes it.
+        return -_MAX_RATIO * torch.tanh(ratio / _MAX_RATIO)

--- a/fynance/models/loss/omega.py
+++ b/fynance/models/loss/omega.py
@@ -28,8 +28,18 @@ class OmegaLoss(BaseLoss):
     Both gains and losses are :math:`O(|r - L|)`, so a fixed absolute
     ``eps`` is dimensionally wrong: on an all-gains batch (zero losses) the
     ratio would explode (e.g. ``-1e6``) and dominate gradients. The
-    denominator is therefore floored with a **returns-scaled** epsilon,
-    ``eps * |r - L|.mean()``, keeping the loss finite and bounded while
+    denominator is therefore floored with a **returns-scaled** value
+    ``|r - L|.mean() / MAX_RATIO`` (plus a bare ``eps`` backstop for the
+    degenerate all-zero-diff batch), capping the ratio at roughly
+    ``MAX_RATIO`` in the low-loss regime regardless of the return scale.
+
+    The ratio is then passed through a **smooth saturating map**,
+    ``MAX_RATIO * tanh(ratio / MAX_RATIO)``, instead of a hard clamp. A
+    hard clamp pins the loss to a constant on an all-gains batch and so
+    zeroes the gradient in exactly the regime training still wants to push
+    on; ``tanh`` is near-linear for normal-regime ratios (leaving their
+    numerics unchanged) yet keeps a residual, non-zero gradient when the
+    ratio is large. This keeps the loss finite and bounded while
     preserving the sign convention (minimizing it maximizes the ratio).
 
     Parameters
@@ -55,9 +65,13 @@ class OmegaLoss(BaseLoss):
         losses = torch.relu(-diff).mean()
         # Returns-scaled floor: a fixed absolute eps is dimensionally wrong for
         # O(|r - L|) losses and lets the ratio explode on an all-gains batch.
-        # The bare eps backstop guards the degenerate all-zero-diff case and
-        # the final clamp bounds the magnitude when losses are near zero.
-        floor = self.eps * diff.abs().mean() + self.eps
+        # Scaling by ``|r - L|.mean() / MAX_RATIO`` caps the ratio at ~MAX_RATIO
+        # in the low-loss regime; the bare eps backstop guards the degenerate
+        # all-zero-diff case.
+        floor = diff.abs().mean() / _MAX_RATIO + self.eps
         ratio = gains / torch.clamp(losses, min=floor)
 
-        return -torch.clamp(ratio, min=-_MAX_RATIO, max=_MAX_RATIO)
+        # Smooth saturating map instead of a hard clamp: tanh is near-linear for
+        # normal-regime ratios (numerics unchanged) but keeps a non-zero
+        # gradient when the ratio is large, unlike a clamp that zeroes it.
+        return -_MAX_RATIO * torch.tanh(ratio / _MAX_RATIO)

--- a/fynance/models/loss/sortino.py
+++ b/fynance/models/loss/sortino.py
@@ -42,9 +42,20 @@ class SortinoLoss(BaseLoss):
     The downside deviation is :math:`O(\text{returns})`, so a fixed
     absolute ``eps`` inside the square root is dimensionally wrong: on an
     all-gains batch (zero downside) the loss would explode (e.g. ``-100``).
-    The downside is therefore floored with a **returns-scaled** epsilon
-    proportional to the excess-return magnitude, keeping the loss finite
-    and bounded while preserving the sign convention.
+    The downside is therefore floored with a **returns-scaled** value
+    ``|excess|.mean() / MAX_RATIO`` (plus a bare ``eps`` backstop for the
+    degenerate all-zero batch). This caps the ratio at roughly
+    ``MAX_RATIO`` in the low-downside regime regardless of the return
+    scale, keeping the loss finite and bounded while preserving the sign
+    convention.
+
+    The ratio is then passed through a **smooth saturating map**,
+    ``MAX_RATIO * tanh(ratio / MAX_RATIO)``, instead of a hard clamp. A
+    hard clamp pins the loss to a constant on a low-downside batch and so
+    kills the gradient in exactly the strong-uptrend regime training still
+    wants to push on; ``tanh`` is near-linear for normal-regime ratios
+    (leaving their numerics unchanged) yet keeps a residual, non-zero
+    gradient when the ratio is large.
 
     Parameters
     ----------
@@ -53,8 +64,9 @@ class SortinoLoss(BaseLoss):
     period : int, optional
         Number of periods per year. Default is 252.
     eps : float, optional
-        Relative numerical stabilizer scaling the downside-deviation floor
-        (see Notes). Default is 1e-8.
+        Bare numerical stabilizer added to the returns-scaled downside floor
+        as a backstop for the degenerate all-zero batch (see Notes).
+        Default is 1e-8.
 
     Examples
     --------
@@ -100,10 +112,13 @@ class SortinoLoss(BaseLoss):
         downside = torch.sqrt(torch.mean(F.relu(-excess) ** 2))
         # Floor the downside relative to the return scale: a fixed absolute eps
         # inside the sqrt is dimensionally wrong for an O(returns) downside and
-        # lets the ratio explode on an all-gains batch. ``eps`` backstops the
-        # degenerate all-zero case; the final clamp bounds the magnitude in the
-        # near-zero-downside regime (where pushing for more gains is fine, so
-        # saturating the gradient there is harmless for this training proxy).
-        floor = self.eps * excess.abs().mean() + self.eps
+        # lets the ratio explode on an all-gains batch. Scaling the floor by
+        # ``|excess|.mean() / MAX_RATIO`` caps the ratio at ~MAX_RATIO in the
+        # low-downside regime (scale-invariantly); ``eps`` backstops the
+        # degenerate all-zero case.
+        floor = excess.abs().mean() / _MAX_RATIO + self.eps
         ratio = excess.mean() / torch.clamp(downside, min=floor)
-        return -torch.clamp(ratio, min=-_MAX_RATIO, max=_MAX_RATIO)
+        # Smooth saturating map instead of a hard clamp: tanh is near-linear for
+        # normal-regime ratios (numerics unchanged) but keeps a non-zero
+        # gradient when the ratio is large, unlike a clamp that zeroes it.
+        return -_MAX_RATIO * torch.tanh(ratio / _MAX_RATIO)

--- a/fynance/models/lstm.py
+++ b/fynance/models/lstm.py
@@ -319,6 +319,52 @@ class LongShortTermMemory(_OutputLayerMixin, LSTMCell):
 
         return Y, H, C
 
+    def fit(self, X, y, epochs: int = 1, x_type=None, y_type=None):
+        """ Fit the model on ``(X, y)`` for ``epochs`` full-batch steps.
+
+        Conforms to the :class:`~fynance.core.protocols.SignalModel`
+        contract. The hidden state ``H`` and cell state ``C`` are both
+        zero-initialized once and threaded across epochs (detached
+        between steps). An optimizer must have been registered with
+        :meth:`~fynance.models._base.BaseNeuralNet.set_optimizer`.
+
+        Parameters
+        ----------
+        X, y : array-like
+            Input and output data (numpy / torch / polars), shapes
+            ``(T, N)`` and ``(T, M)``.
+        epochs : int
+            Number of full-batch training steps.
+        x_type, y_type : torch.dtype, optional
+            Target dtypes forwarded to
+            :meth:`~fynance.models._base.BaseNeuralNet.set_data`.
+
+        Returns
+        -------
+        LongShortTermMemory
+            ``self``, to allow chaining.
+
+        """
+        self.set_data(X, y, x_type=x_type, y_type=y_type)
+        H = self._init_state(self.X)
+        C = self._init_cell_state(self.X)
+
+        for _ in range(epochs):
+            _, H, C = self.train_on(self.X, self.y, H, C)
+
+        return self
+
+    def _init_cell_state(self, X: torch.Tensor) -> torch.Tensor:
+        """ Build a zero cell state matching ``X`` (rows, dtype, device). """
+        try:
+            param = next(self.parameters())
+            device, dtype = param.device, param.dtype
+
+        except StopIteration:
+            device, dtype = X.device, X.dtype
+
+        return torch.zeros(X.shape[0], self.C, dtype=dtype, device=device)
+
     @torch.enable_grad()
     def train_on(self, X: torch.Tensor, y: torch.Tensor, H: torch.Tensor, C: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:  # type: ignore[override]
         """ Trains the neural network model.
@@ -352,28 +398,64 @@ class LongShortTermMemory(_OutputLayerMixin, LSTMCell):
         return loss, H.detach(), C.detach()
 
     @torch.no_grad()
-    def predict(self, X: torch.Tensor, H: torch.Tensor, C: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:  # type: ignore[override]
+    def predict(self, X, H: torch.Tensor | None = None, C: torch.Tensor | None = None):  # type: ignore[override]
         """ Predicts outputs of neural network model.
+
+        Two calling conventions are supported:
+
+        - ``predict(X)`` — conforms to the
+          :class:`~fynance.core.protocols.SignalModel` contract: ``X``
+          may be array-like (coerced to a tensor), the hidden state and
+          cell state are zero-initialized, and **only** the prediction
+          tensor ``Y`` is returned.
+        - ``predict(X, H, C)`` — explicit-state form: the updated states
+          are threaded back, returning the ``(Y, H, C)`` tuple. ``C`` is
+          zero-initialized when omitted.
+
+        In both cases ``X`` (and any supplied state) is moved to the
+        model's device.
 
         Parameters
         ----------
-        X : torch.Tensor
+        X : array-like or torch.Tensor
             Inputs to compute prediction.
-        H : torch.Tensor
-            States of the model.
-        C : torch.Tensor
-            Cell memory of the model.
+        H : torch.Tensor, optional
+            States of the model. If ``None`` (default), a zero state is
+            used and only the prediction is returned.
+        C : torch.Tensor, optional
+            Cell memory of the model. Zero-initialized when ``None``.
 
         Returns
         -------
         torch.Tensor
-            Outputs prediction.
-        torch.Tensor
-            Updated states of the model.
-        torch.Tensor
-            Cell memory of the model.
+            Outputs prediction (when ``H`` is ``None``).
+        tuple of torch.Tensor
+            ``(Y, H, C)`` outputs prediction and updated states (when
+            ``H`` is provided).
 
         """
+        return_state = H is not None
+
+        if not isinstance(X, torch.Tensor):
+            X = self._set_data(X)
+
+        try:
+            device = next(self.parameters()).device
+            X = X.to(device)
+            if H is not None:
+                H = H.to(device)
+            if C is not None:
+                C = C.to(device)
+
+        except StopIteration:
+            pass
+
+        if H is None:
+            H = self._init_state(X)
+
+        if C is None:
+            C = self._init_cell_state(X)
+
         was_training = self.training
         self.eval()
         try:
@@ -382,4 +464,8 @@ class LongShortTermMemory(_OutputLayerMixin, LSTMCell):
         finally:
             self.train(was_training)
 
-        return Y.detach(), H.detach(), C.detach()
+        if return_state:
+
+            return Y.detach(), H.detach(), C.detach()
+
+        return Y.detach()

--- a/fynance/models/rolling.py
+++ b/fynance/models/rolling.py
@@ -468,12 +468,18 @@ class _RollingBasis:
 
     def _display_kpi(self, t):
         pct = t - self.n - self.s
-        pct = pct / (self.T - self.n - self.T % self.s)
+        # Guard the denominator: ``T - n - T % s`` can be 0 (e.g. T=45, n=40,
+        # s=10) which would raise ``ZeroDivisionError``. Floor it at 1.
+        pct = pct / max(self.T - self.n - self.T % self.s, 1)
         txt = '{:5.2%} is done | '.format(pct)
         # Use the current iteration index ``self.i`` — ``[-1]`` is the last
-        # array slot, which stays 0 until the final iteration.
-        txt += 'Eval loss is {:5.2} | '.format(self.loss_eval[self.i])
-        txt += 'Test loss is {:5.2} | '.format(self.loss_test[self.i])
+        # array slot, which stays 0 until the final iteration. ``__next__``
+        # bumps ``self.i`` before the ``StopIteration`` check, so after the
+        # loop ``self.i == loss_eval.size``; clamp to the last filled slot to
+        # avoid an out-of-bounds read on the final out-of-loop print.
+        i = min(self.i, self.loss_eval.size - 1)
+        txt += 'Eval loss is {:5.2} | '.format(self.loss_eval[i])
+        txt += 'Test loss is {:5.2} | '.format(self.loss_test[i])
         print(txt, end='\r')
 
     def _display_plot_loss(self, bnn, i):

--- a/fynance/portfolio/allocation.py
+++ b/fynance/portfolio/allocation.py
@@ -32,6 +32,7 @@ Main entry points
 from __future__ import annotations
 
 # Built-in packages
+import warnings
 from typing import Callable
 
 # Third-party
@@ -114,6 +115,11 @@ def ERC(
         return np.ones([1, 1])
 
     up_bound = max(up_bound, 1 / N)
+    # Clamp low_bound so the box stays compatible with the sum-to-one
+    # constraint: with low_bound > 1/N every feasible weight already exceeds
+    # its share, the constraint is infeasible and SLSQP would silently return
+    # weights summing to more than one (as HRP/IVP already guard against).
+    low_bound = min(low_bound, 1 / N)
     # The risk-contribution surrogate is quartic in the covariance, so on
     # return-scale inputs (values ~1e-4) it collapses to ~1e-16, far below
     # SLSQP's default ftol and the optimizer stops at the 1/N start. Rescale
@@ -533,6 +539,11 @@ def MVP_uc(
         return np.ones([1, 1])
 
     up_bound = max(up_bound, 1 / N)
+    # Clamp low_bound so the box stays compatible with the sum-to-one
+    # constraint: with low_bound > 1/N the feasible set is empty and SLSQP
+    # would silently return weights summing to more than one (as HRP/IVP
+    # already guard against).
+    low_bound = min(low_bound, 1 / N)
     # On return-scale inputs the portfolio variance w'Sigma w is ~1e-4 or
     # smaller, which can sit below SLSQP's default ftol so the optimizer stops
     # at the 1/N start. Rescale the covariance to unit trace so the objective
@@ -832,6 +843,9 @@ def _normalize(w: NDArray[np.float64], low_bound: float = 0., up_bound: float = 
         j += 1
 
     if j >= max_iter:
-        print('Iterative normalize algorithm exceeded max iterations')
+        warnings.warn(
+            'Iterative normalize algorithm exceeded max iterations',
+            stacklevel=2,
+        )
 
     return w

--- a/fynance/research/compare.py
+++ b/fynance/research/compare.py
@@ -100,7 +100,14 @@ def _markdown_table(rows: list[dict[str, float | str]]) -> str:
     if not rows:
         return "_no experiments_\n"
 
-    cols = ["name"] + [k for k in rows[0] if k != "name"]
+    # Union the metric keys across every row (preserving first-seen order) so a
+    # metric present only in lower-ranked rows is not silently dropped.
+    metric_cols: list[str] = []
+    for row in rows:
+        for k in row:
+            if k != "name" and k not in metric_cols:
+                metric_cols.append(k)
+    cols = ["name"] + metric_cols
     head = "| " + " | ".join(cols) + " |"
     sep = "| " + " | ".join("---" for _ in cols) + " |"
     body = []

--- a/fynance/research/synthetic.py
+++ b/fynance/research/synthetic.py
@@ -66,6 +66,9 @@ def gbm(
     5
 
     """
+    if n < 1:
+        raise ValueError(f"n must be a positive integer, got {n}")
+
     rng = np.random.default_rng(seed)
     log_ret = mu + sigma * rng.standard_normal(max(n - 1, 0))
     path = np.concatenate([[0.0], np.cumsum(log_ret)])
@@ -117,6 +120,9 @@ def regime_switching(
     True
 
     """
+    if n < 1:
+        raise ValueError(f"n must be a positive integer, got {n}")
+
     rng = np.random.default_rng(seed)
     mus = np.array([r[0] for r in regimes], dtype=np.float64)
     sigmas = np.array([r[1] for r in regimes], dtype=np.float64)

--- a/fynance/tests/core/test_price_series.py
+++ b/fynance/tests/core/test_price_series.py
@@ -75,6 +75,14 @@ def test_to_returns_dropna_false_keeps_length():
     assert np.isnan(r.values[0])
 
 
+def test_to_returns_dropna_false_empty_series():
+    # Empty input must not IndexError on the leading-NaN write (full[0]).
+    ps = PriceSeries([])
+    r = ps.to_returns("pct", dropna=False)
+    assert len(r) == 0
+    assert r.values.dtype == np.float64
+
+
 def test_to_returns_unknown_kind_raises():
     ps = PriceSeries([100.0, 110.0, 99.0])
     with pytest.raises(ValueError, match="unknown kind"):
@@ -162,6 +170,13 @@ def test_pnl_is_causal():
     assert np.isclose(pnl.values[3], -1.0 * 0.04)
 
 
+def test_pnl_empty_series():
+    # Empty input must not IndexError on the shift (shifted[0]).
+    out = PriceSeries([]).pnl([])
+    assert len(out) == 0
+    assert out.values.dtype == np.float64
+
+
 def test_pnl_no_lookahead():
     # changing a future position must not change earlier pnl
     returns = PriceSeries([0.01, 0.02, -0.03, 0.04])
@@ -208,3 +223,31 @@ def test_from_polars_series_and_frame():
     df = pl.DataFrame({"px": [10.0, 11.0, 12.0]})
     ps2 = PriceSeries.from_polars(df, value_col="px")
     assert np.array_equal(ps2.values, [10.0, 11.0, 12.0])
+
+
+def test_from_polars_default_value_col_picks_numeric():
+    # With a temporal index column and one numeric + one string column, the
+    # default value column must be the numeric one (documented behavior), not
+    # the string column (which would fail with an opaque cast error).
+    pl = pytest.importorskip("polars")
+    df = pl.DataFrame(
+        {
+            "date": ["2020-01-01", "2020-01-02"],
+            "label": ["a", "b"],
+            "px": [10.0, 11.0],
+        }
+    ).with_columns(pl.col("date").str.to_date())
+    ps = PriceSeries.from_polars(df)
+    assert ps.name == "px"
+    assert np.array_equal(ps.values, [10.0, 11.0])
+
+
+def test_from_polars_lone_string_column_raises_clean_error():
+    # A single non-index column that is a string is not a numeric candidate;
+    # value_col resolution must reject it cleanly, not cast-fail later.
+    pl = pytest.importorskip("polars")
+    df = pl.DataFrame(
+        {"date": ["2020-01-01", "2020-01-02"], "label": ["a", "b"]}
+    ).with_columns(pl.col("date").str.to_date())
+    with pytest.raises(ValueError, match="value_col is ambiguous"):
+        PriceSeries.from_polars(df)

--- a/fynance/tests/data/test_align.py
+++ b/fynance/tests/data/test_align.py
@@ -50,6 +50,15 @@ def test_ffill_leading_nan_stays_nan():
     assert out["b"].values[2] == 30.0
 
 
+def test_align_rejects_duplicate_index():
+    # Duplicate timestamps would be silently collapsed (index-to-value mapping
+    # keeps only the last), shrinking the series to its unique count.
+    a = PriceSeries([1.0, 2.0, 3.0], index=[1, 2, 2], name="a")
+    b = PriceSeries([10.0, 20.0, 30.0], index=[1, 2, 3], name="b")
+    with pytest.raises(ValueError, match="duplicate"):
+        align({"a": a, "b": b}, how="outer")
+
+
 # --- resample ----------------------------------------------------------------
 
 def _weekly_ps():
@@ -103,3 +112,36 @@ def test_resample_object_datetime_index_raises_clean_error():
     ps = PriceSeries([1.0, 2.0], index=idx)
     with pytest.raises(ValueError, match="datetime64"):
         resample(ps, "1w", agg="last")
+
+
+def _weekly_ps_seconds():
+    # Same as _weekly_ps but with the common datetime64[s] resolution, which
+    # polars does not accept directly (only [D]/[ms]/[us]/[ns]).
+    idx = np.array(
+        ["2020-01-01", "2020-01-02", "2020-01-08", "2020-01-09"],
+        dtype="datetime64[s]",
+    )
+    return PriceSeries([1.0, 2.0, 3.0, 4.0], index=idx, name="x")
+
+
+def test_resample_last_datetime64_seconds():
+    # datetime64[s] used to slip past the dtype.kind guard then raise the
+    # opaque polars resolution error; it now resamples correctly.
+    out = resample(_weekly_ps_seconds(), "1w", agg="last")
+    assert isinstance(out, PriceSeries)
+    assert np.allclose(out.values, [2.0, 4.0])
+    assert out.index.dtype.kind == "M"
+
+
+def test_resample_mean_datetime64_seconds():
+    out = resample(_weekly_ps_seconds(), "1w", agg="mean")
+    assert np.allclose(out.values, [1.5, 3.5])
+
+
+def test_resample_ohlc_datetime64_seconds():
+    out = resample(_weekly_ps_seconds(), "1w", agg="ohlc")
+    assert set(out) == {"open", "high", "low", "close"}
+    assert np.allclose(out["open"].values, [1.0, 3.0])
+    assert np.allclose(out["high"].values, [2.0, 4.0])
+    assert np.allclose(out["low"].values, [1.0, 3.0])
+    assert np.allclose(out["close"].values, [2.0, 4.0])

--- a/fynance/tests/data/test_split.py
+++ b/fynance/tests/data/test_split.py
@@ -71,3 +71,29 @@ def test_train_test_split_zero_is_empty_test():
     train, test = train_test_split(100, test_size=0.0)
     assert len(test) == 0
     assert len(train) == 100
+
+
+def test_train_test_split_rejects_negative_test_size():
+    # A negative integer would yield out-of-bounds train indices
+    # (e.g. test_size=-3, n=10 -> split=13 -> arange(0, 13)); a negative
+    # fraction would silently produce an empty test set.
+    with pytest.raises(ValueError, match="test_size"):
+        train_test_split(10, test_size=-3)
+    with pytest.raises(ValueError, match="test_size"):
+        train_test_split(10, test_size=-0.2)
+
+
+def test_train_test_split_rejects_test_size_over_n():
+    # A test count larger than n would leave a negative-length train set.
+    with pytest.raises(ValueError, match="exceeds n"):
+        train_test_split(10, test_size=11)
+
+
+def test_walk_forward_rejects_nonpositive_step():
+    # step <= 0 never advances t -> the while loop runs forever.
+    # Use a tiny n and assert the ValueError is raised eagerly (the generator
+    # validates step on the first __next__), so the loop is never entered.
+    with pytest.raises(ValueError, match="step"):
+        next(walk_forward(5, train=2, test=1, step=0))
+    with pytest.raises(ValueError, match="step"):
+        next(walk_forward(5, train=2, test=1, step=-1))

--- a/fynance/tests/features/test_momentums.py
+++ b/fynance/tests/features/test_momentums.py
@@ -242,3 +242,92 @@ def test_mad_axis1_matches_per_row():
     assert np.allclose(
         mad(X, axis=0), [mad(X[:, j]) for j in range(X.shape[1])]
     )
+
+
+# --------------------------------------------------------------------------- #
+#   wrap_axis: negative axes (roadmap 1.2)                                     #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("name", ["sma", "wma", "smstd", "wmstd"])
+def test_negative_axis_matches_positive(name):
+    # axis=-1 used to slip through the wrap_axis checks and the kernel, which
+    # ignores `axis`, silently returned the axis=0 result. It must now resolve
+    # to the last axis (axis=1 for a 2-D array).
+    f = getattr(fy, name)
+    X = np.array([
+        [1., 2., 3., 4.],
+        [5., 7., 9., 11.],
+        [2., 4., 8., 16.],
+    ])
+    assert np.allclose(f(X, w=2, axis=-1), f(X, w=2, axis=1))
+    assert not np.allclose(f(X, w=2, axis=-1), f(X, w=2, axis=0))
+
+
+@pytest.mark.parametrize("name", ["sma", "wma", "smstd", "wmstd"])
+def test_negative_axis_1d_matches_axis0(name):
+    # On a 1-D array axis=-1 must resolve to axis 0 (the only axis).
+    f = getattr(fy, name)
+    x = np.array([1., 3., 2., 5., 4., 6.])
+    assert np.allclose(f(x, w=2, axis=-1), f(x, w=2, axis=0))
+
+
+# --------------------------------------------------------------------------- #
+#   stats.accuracy / directional_accuracy: 2-D axis=1 (roadmap 1.2)           #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture()
+def accuracy_pair():
+    # Two distinct rows, time on axis 1.
+    y_true = np.array([
+        [1., -.5, .5, -.2],
+        [.3, -.1, .8, -.4],
+    ])
+    y_pred = np.array([
+        [.5, -.2, -.5, .1],
+        [.2, .1, .7, -.3],
+    ])
+    return y_true, y_pred
+
+
+@pytest.mark.parametrize("sign", [True, False])
+def test_accuracy_axis1_matches_per_row(accuracy_pair, sign):
+    # wrap_axis only transposes the first positional arg, leaving y_pred
+    # mis-oriented for axis=1; accuracy used to raise a broadcast ValueError.
+    from fynance.features.stats import accuracy
+    y_true, y_pred = accuracy_pair
+    out = accuracy(y_true, y_pred, sign=sign, axis=1)
+    expected = np.array([
+        accuracy(y_true[i], y_pred[i], sign=sign)
+        for i in range(y_true.shape[0])
+    ])
+    assert np.allclose(out, expected)
+
+
+def test_directional_accuracy_axis1_matches_per_row(accuracy_pair):
+    from fynance.features.stats import directional_accuracy
+    y_true, y_pred = accuracy_pair
+    out = directional_accuracy(y_true, y_pred, axis=1)
+    expected = np.array([
+        directional_accuracy(y_true[i], y_pred[i])
+        for i in range(y_true.shape[0])
+    ])
+    assert np.allclose(out, expected)
+
+
+def test_accuracy_axis0_unchanged(accuracy_pair):
+    # The default axis=0 path (per-column) must keep working.
+    from fynance.features.stats import accuracy, directional_accuracy
+    y_true, y_pred = accuracy_pair
+    assert np.allclose(
+        accuracy(y_true, y_pred, axis=0),
+        [accuracy(y_true[:, j], y_pred[:, j]) for j in range(y_true.shape[1])],
+    )
+    assert np.allclose(
+        directional_accuracy(y_true, y_pred, axis=0),
+        [
+            directional_accuracy(y_true[:, j], y_pred[:, j])
+            for j in range(y_true.shape[1])
+        ],
+    )

--- a/fynance/tests/features/test_money_management.py
+++ b/fynance/tests/features/test_money_management.py
@@ -72,3 +72,18 @@ def test_iso_vol_warmup_is_one():
 
     assert out[0] == 1.0
     assert out[1] == 1.0
+
+
+def test_iso_vol_accepts_list_input():
+    # A plain list/tuple used to raise a bare AttributeError ('list' object has
+    # no attribute 'size'); the input is now coerced like in sibling modules.
+    data = [95.0, 100.0, 85.0, 105.0, 110.0, 90.0]
+    out_list = iso_vol(data, target_vol=0.5, leverage=2, period=12, half_life=3)
+    out_arr = iso_vol(np.asarray(data), target_vol=0.5, leverage=2,
+                      period=12, half_life=3)
+
+    assert isinstance(out_list, np.ndarray)
+    assert np.allclose(out_list, out_arr)
+    # Tuples work too.
+    assert np.allclose(iso_vol(tuple(data), target_vol=0.5, leverage=2,
+                               period=12, half_life=3), out_arr)

--- a/fynance/tests/features/test_scale.py
+++ b/fynance/tests/features/test_scale.py
@@ -195,3 +195,56 @@ def test_scale_axis1_differs_from_axis0(multi_col, kind):
     s1 = fy.Scale(multi_col, kind=kind, axis=1, a=0, b=1)
     s0 = fy.Scale(multi_col, kind=kind, axis=0, a=0, b=1)
     assert not np.allclose(s1.scale(multi_col), s0.scale(multi_col))
+
+
+# --------------------------------------------------------------------------- #
+#   Standalone rolling functions: genuine multi-column axis=1 parity          #
+#   (roadmap 1.2 — PR #193 fixed the Scale path but not these functions)      #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture()
+def roll_multi_col():
+    # Time on axis 1, distinct rows, non-square (3, 6); no constant rolling
+    # window so the rolling std/range never collapses to zero.
+    return np.array([
+        [1., 3., 2., 5., 4., 6.],
+        [6., 4., 7., 2., 8., 3.],
+        [2., 9., 1., 4., 7., 5.],
+    ])
+
+
+@pytest.mark.parametrize("kind_moment", ["s", "w", "e"])
+def test_roll_standardize_axis1_matches_per_row(roll_multi_col, kind_moment):
+    # The standalone roll_standardize used to raise on genuine multi-column
+    # data with axis=1: its rolling-moment parameters stayed in input
+    # orientation (rows, cols) while X.T was (cols, rows), so the broadcast
+    # failed. The result must now equal stacking the 1-D transform of each row.
+    from fynance.features.scale import roll_standardize
+    out = roll_standardize(roll_multi_col, w=3, axis=1, kind_moment=kind_moment)
+    expected = np.vstack([
+        roll_standardize(roll_multi_col[i], w=3, kind_moment=kind_moment)
+        for i in range(roll_multi_col.shape[0])
+    ])
+    assert np.allclose(out, expected, equal_nan=True)
+
+
+def test_roll_normalize_axis1_matches_per_row(roll_multi_col):
+    # Same broadcast bug as roll_standardize, on the rolling min/max path.
+    from fynance.features.scale import roll_normalize
+    out = roll_normalize(roll_multi_col, w=3, axis=1)
+    expected = np.vstack([
+        roll_normalize(roll_multi_col[i], w=3)
+        for i in range(roll_multi_col.shape[0])
+    ])
+    assert np.allclose(out, expected, equal_nan=True)
+
+
+@pytest.mark.parametrize("func", ["roll_standardize", "roll_normalize"])
+def test_standalone_roll_axis1_differs_from_axis0(roll_multi_col, func):
+    # Guard against silently falling back to the axis=0 result.
+    from fynance.features import scale
+    f = getattr(scale, func)
+    out1 = f(roll_multi_col, w=3, axis=1)
+    out0 = f(roll_multi_col, w=3, axis=0)
+    assert not np.allclose(out1, out0, equal_nan=True)

--- a/fynance/tests/metrics/test_metrics.py
+++ b/fynance/tests/metrics/test_metrics.py
@@ -501,10 +501,11 @@ def test_sortino(set_variables):
         f(x_2d, axis=0, ddof=7)
     execinfo.match(r'7.*6')
 
-    # All positive returns → downside vol == 0 → inf (tested on 2D; 1D scalar
-    # path shares the same pre-existing limitation as sharpe)
-    x_up_2d = np.array([100., 110., 120., 130., 140., 150.]).reshape(6, 1)
-    assert f(x_up_2d, period=12) == np.array([np.inf])
+    # All positive returns → downside vol == 0 → inf, on both the 2-D array
+    # path and the 1-D scalar (0-D) path.
+    x_up = np.array([100., 110., 120., 130., 140., 150.])
+    assert f(x_up.reshape(6, 1), period=12) == np.array([np.inf])
+    assert np.isposinf(f(x_up, period=12))
 
     # Numeric check: sortino >= sharpe (downside vol <= total vol)
     s_sharpe = fy.sharpe(x_1d.astype(np.float64), period=12)

--- a/fynance/tests/metrics/test_zero_vol_ratios.py
+++ b/fynance/tests/metrics/test_zero_vol_ratios.py
@@ -7,7 +7,7 @@
 import numpy as np
 
 # Local
-from fynance.metrics import calmar, roll_calmar, sharpe, sortino
+from fynance.metrics import calmar, roll_calmar, roll_sharpe, sharpe, sortino
 from fynance.metrics.ratios import _safe_ratio
 from fynance.metrics.summary import summary
 
@@ -19,11 +19,50 @@ def test_flat_curve_is_zero_not_crash():
 
 
 def test_safe_ratio_zero_denominator():
-    # Riskless gain -> +inf; flat (0/0) -> 0; mixed array handled element-wise.
+    # Riskless gain -> +inf; riskless loss -> -inf; flat (0/0) -> 0; mixed
+    # array handled element-wise.
     assert np.isposinf(_safe_ratio(1.0, 0.0))
+    assert np.isneginf(_safe_ratio(-1.0, 0.0))
     assert _safe_ratio(0.0, 0.0) == 0.0
-    r = _safe_ratio(np.array([1.0, 0.0, 2.0]), np.array([0.0, 0.0, 2.0]))
-    assert np.isposinf(r[0]) and r[1] == 0.0 and r[2] == 1.0
+    r = _safe_ratio(np.array([1.0, -1.0, 0.0, 2.0]),
+                    np.array([0.0, 0.0, 0.0, 2.0]))
+    assert np.isposinf(r[0])
+    assert np.isneginf(r[1])
+    assert r[2] == 0.0
+    assert r[3] == 1.0
+
+
+def test_flat_curve_with_rf_is_riskless_loss():
+    # A flat (zero-volatility) curve evaluated against a positive risk-free
+    # rate is a guaranteed underperformance: the ratio limit is -inf, not the
+    # best-possible +inf. This guards the sign bug in _safe_ratio.
+    flat = np.full(20, 100.0)
+    assert np.isneginf(sharpe(flat, rf=0.05))
+    assert np.isneginf(sortino(flat, rf=0.05))
+
+
+def test_2d_zero_vol_negative_excess_is_neg_inf():
+    # 2-D array path: a flat column with a positive rf scores -inf (riskless
+    # loss), while a real column stays finite.
+    flat = np.full(50, 100.0)
+    rng = np.random.default_rng(0)
+    normal = 100.0 * np.cumprod(1 + rng.standard_normal(50) * 0.01)
+    X = np.column_stack([flat, normal])
+
+    res = sharpe(X, rf=0.05, axis=0)
+    assert res.shape == (2,)
+    assert np.isneginf(res[0])
+    assert np.isfinite(res[1])
+
+
+def test_roll_sharpe_zero_vol_is_signed_inf_not_zero():
+    # A zero-rolling-vol window must follow the calmar/roll_calmar +/-inf
+    # convention, not the old 0.0 zeroing. A flat curve has zero return over
+    # zero volatility at every window: a negative risk-free rate makes the
+    # excess positive (+inf), a positive one makes it a riskless loss (-inf).
+    flat = np.full(6, 100.0)
+    assert np.all(np.isposinf(roll_sharpe(flat, rf=-0.05, period=12)))
+    assert np.all(np.isneginf(roll_sharpe(flat, rf=0.05, period=12)))
 
 
 def test_2d_mixed_columns_no_crash():

--- a/fynance/tests/models/test_loss.py
+++ b/fynance/tests/models/test_loss.py
@@ -111,6 +111,30 @@ class TestSortinoLoss:
         # scale invariance (old absolute-eps code is off by ~10x here)
         assert loss_10x.item() == pytest.approx(loss.item(), rel=1e-2)
 
+    def test_low_risk_gradient_survives(self):
+        # On a strong-uptrend (near-zero-downside) batch the ratio blows past
+        # MAX_RATIO. A hard clamp pinned the loss to a constant there and so
+        # ZEROED the gradient in exactly the regime we still want to optimize.
+        # The smooth tanh saturation must keep the loss finite AND leave a
+        # non-zero gradient w.r.t. the input.
+        gen = torch.Generator().manual_seed(0)
+        r = (torch.rand(60, generator=gen) * 0.01 + 0.005).requires_grad_(True)
+        loss = SortinoLoss()(r)
+        assert torch.isfinite(loss)
+        loss.backward()
+        assert r.grad is not None
+        assert torch.any(r.grad != 0)
+        assert not torch.isnan(r.grad).any()
+
+    def test_higher_sortino_gives_lower_loss(self):
+        # Sign convention must survive the smooth saturation: a higher-Sortino
+        # batch (more upside, same downside) must give a strictly lower loss
+        # even when both batches are well into the saturating regime.
+        gen = torch.Generator().manual_seed(1)
+        base = torch.rand(60, generator=gen) * 0.01 + 0.005
+        better = base + 0.01   # uniformly higher mean, downside still ~0
+        assert SortinoLoss()(better).item() < SortinoLoss()(base).item()
+
     def test_positive_when_negative_mean(self):
         # Sign convention (like SharpeLoss): a negative-mean return series has a
         # negative Sortino ratio, so the negated loss must be positive.
@@ -208,6 +232,30 @@ class TestCalmarLoss:
         loss = CalmarLoss(eps=1e-8)(torch.zeros(50))
         assert torch.isfinite(loss)
 
+    def test_low_drawdown_gradient_survives(self):
+        from fynance.models.loss import CalmarLoss
+        # Near-zero-drawdown (almost monotone equity) batch: the ratio blows
+        # past MAX_RATIO. A hard clamp pinned the loss to a constant and ZEROED
+        # the gradient there; the smooth tanh saturation must keep the loss
+        # finite AND leave a non-zero gradient w.r.t. the input.
+        gen = torch.Generator().manual_seed(0)
+        r = (torch.rand(100, generator=gen) * 0.01 + 0.005).requires_grad_(True)
+        loss = CalmarLoss()(r)
+        assert torch.isfinite(loss)
+        loss.backward()
+        assert r.grad is not None
+        assert torch.any(r.grad != 0)
+        assert not torch.isnan(r.grad).any()
+
+    def test_higher_calmar_gives_lower_loss(self):
+        from fynance.models.loss import CalmarLoss
+        # Sign convention must survive the smooth saturation: a higher-Calmar
+        # batch (higher return, same near-zero drawdown) gives a lower loss.
+        gen = torch.Generator().manual_seed(1)
+        base = torch.rand(100, generator=gen) * 0.01 + 0.005
+        better = base + 0.01   # higher mean return, drawdown still ~0
+        assert CalmarLoss()(better).item() < CalmarLoss()(base).item()
+
 
 class TestOmegaLoss:
     def test_known_value(self):
@@ -241,6 +289,31 @@ class TestOmegaLoss:
         # backstop must keep the loss finite (not NaN).
         loss = OmegaLoss(threshold=0.0, eps=1e-8)(torch.zeros(50))
         assert torch.isfinite(loss)
+
+    def test_all_gains_gradient_survives(self):
+        from fynance.models.loss import OmegaLoss
+        # All-gains (zero-loss) batch: the ratio blows past MAX_RATIO. A hard
+        # clamp pinned the loss to a constant and ZEROED the gradient there;
+        # the smooth tanh saturation must keep the loss finite AND leave a
+        # non-zero gradient w.r.t. the input.
+        gen = torch.Generator().manual_seed(0)
+        r = (torch.rand(100, generator=gen) * 0.01 + 0.005).requires_grad_(True)
+        loss = OmegaLoss()(r)
+        assert torch.isfinite(loss)
+        loss.backward()
+        assert r.grad is not None
+        assert torch.any(r.grad != 0)
+        assert not torch.isnan(r.grad).any()
+
+    def test_higher_omega_gives_lower_loss(self):
+        from fynance.models.loss import OmegaLoss
+        # Sign convention must survive the smooth saturation: an all-gains batch
+        # (Omega -> high) must give a strictly lower loss than a mixed batch
+        # with real losses (finite, smaller Omega).
+        gen = torch.Generator().manual_seed(2)
+        all_gains = torch.rand(100, generator=gen) * 0.01 + 0.005
+        mixed = torch.rand(100, generator=gen) * 0.02 - 0.01
+        assert OmegaLoss()(all_gains).item() < OmegaLoss()(mixed).item()
 
 
 class TestHybridLoss:

--- a/fynance/tests/models/test_rnn.py
+++ b/fynance/tests/models/test_rnn.py
@@ -102,3 +102,47 @@ class TestRecurrentNeuralNetwork:
         assert torch.allclose(H_base[idx], H_pert[idx], atol=1e-5)
         # the perturbed row itself does change
         assert not torch.allclose(Y_base[3], Y_pert[3])
+
+    def test_fit_predict_signalmodel_contract(self):
+        """ fit(X, y) / predict(X) work end-to-end with zero-init state. """
+        model = _make_rnn()
+        out = model.fit(X_np, y_np, epochs=2)
+        assert out is model  # fit returns self for chaining
+        Y = model.predict(X_np)
+        # single-arg predict returns only the prediction tensor
+        assert isinstance(Y, torch.Tensor)
+        assert Y.shape == (T, N_OUT)
+        assert not Y.requires_grad
+
+    def test_fit_matches_explicit_zero_state(self):
+        """ fit(X, y) is equivalent to threading an explicit zero state. """
+        torch.manual_seed(0)
+        model_a = _make_rnn()
+        torch.manual_seed(0)
+        model_b = _make_rnn()
+        # path A: SignalModel fit
+        model_a.fit(X_t, y_t, epochs=3)
+        # path B: explicit zero-state threading
+        H = torch.zeros(T, model_b.H)
+        for _ in range(3):
+            _, H = model_b.train_on(X_t, y_t, H)
+        with torch.no_grad():
+            Y_a = model_a.predict(X_t)
+            Y_b, _ = model_b.predict(X_t, torch.zeros(T, model_b.H))
+        assert torch.allclose(Y_a, Y_b, atol=1e-6)
+
+    def test_predict_explicit_state_still_returns_tuple(self):
+        """ predict(X, H) keeps the explicit-state (Y, H) contract. """
+        model = _make_rnn()
+        H = torch.zeros(T, model.H)
+        Y, H_out = model.predict(X_t, H)
+        assert Y.shape == (T, N_OUT)
+        assert H_out.shape == (T, model.H)
+
+    def test_predict_moves_input_to_model_device(self):
+        """ predict coerces / moves X to the model's parameter device. """
+        model = _make_rnn()
+        device = next(model.parameters()).device
+        # numpy input (not yet a tensor, not on device) must still work
+        Y = model.predict(X_np)
+        assert Y.device == device

--- a/fynance/tests/models/test_rolling.py
+++ b/fynance/tests/models/test_rolling.py
@@ -251,6 +251,31 @@ class TestDisplayKpi:
         assert '0.42' in out
         assert '0.73' in out
 
+    def test_kpi_index_clamped_after_loop(self):
+        # __next__ bumps self.i before the StopIteration check, so after the
+        # loop self.i == loss_eval.size. The final out-of-loop _print must not
+        # index out of bounds: the index has to be clamped to the last slot.
+        rb = make_rb()
+        rb.loss_eval = np.zeros(4)
+        rb.loss_test = np.zeros(4)
+        rb.loss_eval[-1] = 0.5
+        rb.loss_test[-1] = 0.6
+        rb.i = rb.loss_eval.size   # one past the last valid slot
+        rb._display_kpi(t=rb.n + rb.s)   # must not raise IndexError
+
+    def test_kpi_zero_denominator_does_not_divide_by_zero(self):
+        # For T=45, n=40, s=10 the denominator (T - n - T % s) is 0; the
+        # progress percentage must be guarded against ZeroDivisionError.
+        X = torch.from_numpy(RNG.standard_normal((45, N_IN)).astype(np.float32))
+        y = torch.from_numpy(RNG.standard_normal((45, N_OUT)).astype(np.float32))
+        rb = _RollingBasis(X, y)
+        rb(train_period=40, test_period=10, roll_period=10)
+        assert rb.T - rb.n - rb.T % rb.s == 0   # degenerate denominator
+        rb.loss_eval = np.zeros(1)
+        rb.loss_test = np.zeros(1)
+        rb.i = 0
+        rb._display_kpi(t=rb.n + rb.s)   # must not raise ZeroDivisionError
+
 
 # ---------------------------------------------------------------------------
 # run(): minimal walk-forward sanity (display off)
@@ -287,3 +312,19 @@ class TestRunWalkForward:
         stats = model.get_stats()
         assert stats.size > 0
         assert np.all(np.isfinite(stats["train_loss"]))
+
+    def test_run_default_kpi_path_completes(self):
+        # The DEFAULT path run(backtest_kpi=True) used to raise IndexError on
+        # the final out-of-loop print: __next__ bumps self.i past the last
+        # filled loss slot before StopIteration. A tiny seeded run with the KPI
+        # display on (plot off) must complete without error.
+        torch.manual_seed(0)
+        model = RollMultiLayerPerceptron(X_t, y_t, layers=[8])
+        model.set_optimizer(nn.MSELoss, torch.optim.Adam, lr=1e-3)
+        model.set_roll_period(
+            train_period=TRAIN, test_period=TEST, roll_period=ROLL, epochs=1,
+        )
+        out = model.run(backtest_plot=False, backtest_kpi=True)
+        assert out is model
+        stats = model.get_stats()
+        assert stats.size > 0

--- a/fynance/tests/models/test_signalmodel.py
+++ b/fynance/tests/models/test_signalmodel.py
@@ -5,12 +5,16 @@
 
 # Third-party packages
 import numpy as np
+import pytest
 import torch
 import torch.nn as nn
 
 # Local packages
 from fynance.core import SignalModel
 from fynance.models import MultiLayerPerceptron
+from fynance.models.gru import GatedRecurrentUnit
+from fynance.models.lstm import LongShortTermMemory
+from fynance.models.rnn import RecurrentNeuralNetwork
 
 
 def _xy(n=40, feat=3):
@@ -18,6 +22,38 @@ def _xy(n=40, feat=3):
     X = rng.normal(size=(n, feat)).astype(np.float32)
     y = (X.sum(axis=1, keepdims=True)).astype(np.float32)
     return X, y
+
+
+# Recurrent models advertise the SignalModel protocol; they must honor
+# fit(X, y) / predict(X) with a zero-initialized hidden (and cell) state.
+RECURRENT_MODELS = [RecurrentNeuralNetwork, GatedRecurrentUnit, LongShortTermMemory]
+
+
+@pytest.mark.parametrize("Model", RECURRENT_MODELS)
+def test_recurrent_conforms_and_fit_predict(Model):
+    X, y = _xy()
+    model = Model(X, y, hidden_state_size=6)
+    model.set_optimizer(nn.MSELoss, torch.optim.SGD, lr=1e-3)
+    assert isinstance(model, SignalModel)
+    # fit(X, y) must not raise and must return self; predict(X) returns Y only
+    out = model.fit(X, y, epochs=2)
+    assert out is model
+    Y = out.predict(X)
+    assert isinstance(Y, torch.Tensor)
+    arr = np.asarray(Y)
+    assert arr.shape == (X.shape[0], y.shape[1])
+
+
+@pytest.mark.parametrize("Model", RECURRENT_MODELS)
+def test_recurrent_fit_predict_float64_numpy(Model):
+    """ Plain float64 numpy must fit/predict on a recurrent model. """
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(30, 3))  # float64
+    y = X.sum(axis=1, keepdims=True)  # float64
+    model = Model(X, y, hidden_state_size=5)
+    model.set_optimizer(nn.MSELoss, torch.optim.SGD, lr=1e-3)
+    out = model.fit(X, y, epochs=2).predict(X)
+    assert np.asarray(out).shape[0] == X.shape[0]
 
 
 def test_mlp_conforms_and_fit_predict():

--- a/fynance/tests/portfolio/test_allocation.py
+++ b/fynance/tests/portfolio/test_allocation.py
@@ -126,12 +126,22 @@ def test_mvp_single_asset():
 
 
 def test_mvp_singular_covariance_pinv():
-    """ Linearly dependent columns trigger the pseudo-inverse fallback. """
+    """ An exactly singular covariance triggers the pseudo-inverse fallback.
+
+    A constant (zero-variance) column makes its covariance row/column exactly
+    zero, so the matrix is singular and ``np.linalg.inv`` raises
+    ``LinAlgError`` — genuinely exercising the ``pinv`` branch (a merely
+    near-singular matrix does not raise, so ``inv`` would silently succeed).
+    """
     rng = np.random.default_rng(11)
     a = rng.normal(0.0, 0.01, size=(200, 1))
     b = rng.normal(0.0, 0.01, size=(200, 1))
-    # Third column is an exact linear combination → singular covariance.
-    X = np.column_stack([a, b, 2.0 * a - 3.0 * b])
+    # Third column is constant → zero variance → exactly singular covariance.
+    X = np.column_stack([a, b, np.full((200, 1), 100.0)])
+    # Guard: this construction must actually make inv raise (else the test
+    # would pass without ever reaching the pinv fallback it claims to cover).
+    with pytest.raises(np.linalg.LinAlgError):
+        np.linalg.inv(np.atleast_2d(np.cov(X, rowvar=False)))
     w = MVP(X).flatten()
     assert w.shape == (3,)
     assert abs(w.sum() - 1.0) < 1e-6
@@ -181,6 +191,18 @@ def test_mvp_uc_single_asset():
     w = MVP_uc(X)
     assert w.shape == (1, 1)
     np.testing.assert_allclose(w, [[1.0]])
+
+
+def test_mvp_uc_high_low_bound_still_sums_to_one(returns):
+    """ low_bound > 1/N must be clamped, not break the sum-to-one constraint.
+
+    With N=5 the feasible share per asset is 1/N=0.2; a low_bound of 0.3 makes
+    the box incompatible with sum-to-one. Before the clamp, SLSQP silently
+    returned weights summing to 1.5. low_bound is now clamped to 1/N (as
+    HRP/IVP already do) so the weights still sum to one.
+    """
+    w = MVP_uc(returns, low_bound=0.3).flatten()
+    assert abs(w.sum() - 1.0) < 1e-5, f"weights sum to {w.sum():.6f}"
 
 
 # ---------------------------------------------------------------------------
@@ -239,6 +261,18 @@ def test_erc_single_asset():
     w = ERC(X)
     assert w.shape == (1, 1)
     np.testing.assert_allclose(w, [[1.0]])
+
+
+def test_erc_high_low_bound_still_sums_to_one(returns):
+    """ low_bound > 1/N must be clamped, not break the sum-to-one constraint.
+
+    With N=5 the feasible share per asset is 1/N=0.2; a low_bound of 0.3 makes
+    the box incompatible with sum-to-one. Before the clamp, SLSQP silently
+    returned weights summing to 1.5. low_bound is now clamped to 1/N (as
+    HRP/IVP already do) so the weights still sum to one.
+    """
+    w = ERC(returns, low_bound=0.3).flatten()
+    assert abs(w.sum() - 1.0) < 1e-4, f"weights sum to {w.sum():.6f}"
 
 
 # ---------------------------------------------------------------------------
@@ -396,11 +430,10 @@ def test_normalize_does_not_mutate_input():
     assert out is not w
 
 
-def test_normalize_max_iter_warning(capsys):
+def test_normalize_max_iter_warning():
     w = np.array([0.99, 0.005, 0.003, 0.002])
-    _normalize(w.copy(), low_bound=0.0, up_bound=0.3, max_iter=2)
-    captured = capsys.readouterr()
-    assert "exceeded max iterations" in captured.out
+    with pytest.warns(UserWarning, match="exceeded max iterations"):
+        _normalize(w.copy(), low_bound=0.0, up_bound=0.3, max_iter=2)
 
 
 def test_rolling_allocation_regression():

--- a/fynance/tests/research/test_compare.py
+++ b/fynance/tests/research/test_compare.py
@@ -73,6 +73,24 @@ def test_leaderboard_nan_sinks_ascending():
     assert rows[-1]["name"] == "bad"
 
 
+def test_compare_report_table_unions_heterogeneous_metrics(tmp_path):
+    # A metric present only in a lower-ranked row must not be dropped: the table
+    # columns used to be derived from rows[0] alone, silently hiding it.
+    exps = [
+        Experiment(name="top", metrics={"sharpe": 2.0}),
+        Experiment(name="low", metrics={"sharpe": 1.0, "sortino": 3.5}),
+    ]
+
+    out = compare_report(exps, tmp_path, name="het", sort_by="sharpe")
+    text = out["markdown"].read_text()
+
+    header = next(line for line in text.splitlines() if line.startswith("| name"))
+    assert "sharpe" in header
+    assert "sortino" in header  # the lower-ranked-only metric survives
+    # And its value is rendered for the row that has it.
+    assert "3.5000" in text
+
+
 def test_compare_report_writes_md_and_png(tmp_path, experiments):
     out = compare_report(experiments, tmp_path, name="cmp")
 

--- a/fynance/tests/research/test_synthetic.py
+++ b/fynance/tests/research/test_synthetic.py
@@ -54,6 +54,15 @@ def test_zero_length_edge_cases():
     assert regime_switching(1, s0=100.0, seed=0).to_numpy().tolist() == [100.0]
 
 
+@pytest.mark.parametrize("gen", [gbm, regime_switching])
+@pytest.mark.parametrize("n", [0, -1, -5])
+def test_non_positive_length_raises(gen, n):
+    # n < 1 used to silently return a length-1 path ([s0]) instead of erroring;
+    # it must now raise rather than fabricate an observation out of no data.
+    with pytest.raises(ValueError, match="positive integer"):
+        gen(n, seed=0)
+
+
 def test_regime_switching_initial_state_is_drawn():
     # With p_switch=0 the only regime randomness is the *initial* state. It used
     # to be hard-coded to regime 0 (biasing short paths); now it is drawn, so

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fynance"
-version = "2.10.0"
+version = "2.10.1"
 description = "Pure-Python (Numba-accelerated) machine learning, econometrics and statistical tools for financial analysis and backtesting"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Release **v2.10.1** — audit round-2 remediation (7 PRs, #201–#207). Merge after `chore/release-2.10.1` lands in develop. Release **v2.10.1** — audit round-2 remediation (7 PRs, #201–#207).

### Changed
- RNN/GRU/LSTM honor SignalModel (zero-init state); custom losses use smooth tanh saturation (gradient preserved).

### Fixed
- `roll_standardize`/`roll_normalize` axis=1; `run(backtest_kpi=True)` IndexError (regression); `_safe_ratio` −inf sign + `roll_sharpe`; `walk_forward` step≤0 / negative `test_size`; `resample` resolutions; dup-index; empty `to_returns`/`pnl`; negative-axis + 2-D `accuracy`; ERC/MVP_uc `low_bound`; synthetic `n<1`; leaderboard columns; `iso_vol` list input.

## Test plan
5 gates green on develop: 880 passed/1 skipped, ruff, mypy (171), interrogate 94.7%, Sphinx -W.