### PR TITLE
chore: release v2.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [2.10.2] - 2026-06-23
+
+### Breaking Changes
+
+### Added
+
+### Changed
+
 - **Research reports plot against dates.** When the `PriceSeries` passed to
   `run_experiment` carries a `datetime64` index, the experiment now persists a
   tail-aligned date index and `write_report`'s tearsheet draws equity, drawdown

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fynance"
-version = "2.10.1"
+version = "2.10.2"
 description = "Pure-Python (Numba-accelerated) machine learning, econometrics and statistical tools for financial analysis and backtesting"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Release **v2.10.2** (patch).

### Changed

- **Research reports plot against dates.** When the `PriceSeries` passed to
  `run_experiment` carries a `datetime64` index, the experiment now persists a
  tail-aligned date index and `write_report`'s tearsheet draws equity, drawdown
  and rolling Sharpe against real dates instead of bar numbers (falls back to
  bar numbers when no temporal index is present). (#211)

## Test plan

- Full suite green on develop (884 passed, 1 skipped); ruff, mypy, Sphinx -W all clean.
- CI green on #211 across Python 3.10–3.13.