### PR TITLE
Release v2.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Research reports plot against dates.** When the `PriceSeries` passed to
+  `run_experiment` carries a `datetime64` index, the experiment now persists a
+  tail-aligned date index and `write_report`'s tearsheet draws equity, drawdown
+  and rolling Sharpe against real dates instead of bar numbers (it falls back to
+  bar numbers when no temporal index is present).
+
 ### Fixed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [2.10.2] - 2026-06-23
+
+### Breaking Changes
+
+### Added
+
+### Changed
+
 - **Research reports plot against dates.** When the `PriceSeries` passed to
   `run_experiment` carries a `datetime64` index, the experiment now persists a
   tail-aligned date index and `write_report`'s tearsheet draws equity, drawdown

--- a/fynance/research/experiment.py
+++ b/fynance/research/experiment.py
@@ -53,8 +53,9 @@ class Experiment:
         Master seed driving every stochastic step.
     metrics : dict of str to float, optional
         Summary metrics (``sharpe``/``sortino``/…); empty until a run fills it.
-    series : dict of str to list of float, optional
-        JSON-friendly curves (e.g. ``equity``/``returns``) for the report.
+    series : dict of str to list, optional
+        JSON-friendly curves (e.g. ``equity``/``returns`` of float, plus an
+        optional ``index`` of ISO-8601 date strings) for the report.
     created_at : str
         ISO-8601 UTC creation time (set automatically).
     fynance_version : str
@@ -75,7 +76,7 @@ class Experiment:
     code: str | None = None
     seed: int = 0
     metrics: dict[str, float] = field(default_factory=dict)
-    series: dict[str, list[float]] | None = None
+    series: dict[str, list[Any]] | None = None
     created_at: str = field(default_factory=_utc_now)
     fynance_version: str = field(default_factory=_fynance_version)
 

--- a/fynance/research/report.py
+++ b/fynance/research/report.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 import warnings
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
 
 # Third-party
 import numpy as np
@@ -95,7 +97,16 @@ def _write_png(experiment: Experiment, png_path: Path, period: int) -> bool:
     from fynance.plot import tearsheet
 
     equity = np.asarray(experiment.series["equity"], dtype=float)
-    fig = tearsheet(equity, period=period)
+    # Duck-type a result carrying both the curve and its dates so the plot layer
+    # (via as_equity) draws against real dates; fall back to the bare curve (bar
+    # numbers) when the experiment has no datetime index.
+    result: Any = equity
+    date_index = experiment.series.get("index")
+    if date_index:
+        index = np.asarray(date_index, dtype="datetime64[ns]")
+        if index.shape[0] == equity.shape[0]:
+            result = SimpleNamespace(equity=equity, index=index)
+    fig = tearsheet(result, period=period)
     fig.savefig(png_path, dpi=110, bbox_inches="tight")
     plt.close(fig)
 
@@ -124,11 +135,18 @@ def _build_notebook(experiment: Experiment, target: Path, period: int,
         new_code_cell(
             "import json\n"
             "import numpy as np\n"
+            "from types import SimpleNamespace\n"
             "from fynance.plot import tearsheet\n"
             "\n"
             "exp = json.load(open('experiment.json'))\n"
-            "equity = np.asarray(exp['series']['equity'], dtype=float)\n"
-            f"fig = tearsheet(equity, period={period})\n"
+            "series = exp['series']\n"
+            "equity = np.asarray(series['equity'], dtype=float)\n"
+            "idx = series.get('index')\n"
+            "# Plot against dates when the experiment carries a datetime index.\n"
+            "result = (SimpleNamespace(equity=equity,\n"
+            "                          index=np.asarray(idx, dtype='datetime64[ns]'))\n"
+            "          if idx else equity)\n"
+            f"fig = tearsheet(result, period={period})\n"
             "fig"
         ),
     ]

--- a/fynance/research/runner.py
+++ b/fynance/research/runner.py
@@ -51,6 +51,24 @@ def _index_bound(data: Any, pos: int) -> Any:
     return value.item() if hasattr(value, "item") else value
 
 
+def _series_index(data: Any, n: int) -> list[str] | None:
+    """ Tail-aligned datetime index (ISO strings) for an ``n``-point curve.
+
+    Returns the last ``n`` index entries as ISO-8601 strings when ``data`` carries
+    a genuine ``datetime64`` index long enough to cover the result curve; ``None``
+    otherwise (the report then falls back to bar numbers). Right-aligned because a
+    walk-forward equity curve covers the chronological *tail* of the series.
+    """
+    index = getattr(data, "index", None)
+    if index is None:
+        return None
+    arr = np.asarray(index).reshape(-1)
+    if not np.issubdtype(arr.dtype, np.datetime64) or arr.shape[0] < n:
+        return None
+
+    return [str(v) for v in arr[-n:]]
+
+
 def _callable_name(fn: Any) -> str | None:
     """ Best-effort readable name for a signal/feature callable. """
     if fn is None:
@@ -205,10 +223,16 @@ def run_experiment(
         "seed": seed,
     }
 
-    series = {
+    series: dict[str, list[Any]] = {
         "equity": np.asarray(result.equity, dtype=float).tolist(),
         "returns": np.asarray(result.returns, dtype=float).tolist(),
     }
+    # Persist the datetime index (tail-aligned to the curve) so the report can
+    # plot against real dates rather than bar numbers; omitted when the series
+    # carries no temporal index.
+    date_index = _series_index(data, len(series["equity"]))
+    if date_index is not None:
+        series["index"] = date_index
 
     experiment = Experiment(
         name=name,

--- a/fynance/tests/research/test_report.py
+++ b/fynance/tests/research/test_report.py
@@ -6,6 +6,7 @@
 # Built-in
 import importlib.util
 from pathlib import Path
+from types import SimpleNamespace
 
 # Third-party
 import numpy as np
@@ -85,3 +86,48 @@ def test_notebook_execution(tmp_path, experiment):
     parsed = nbformat.read(out["notebook"], as_version=4)
     code_cells = [c for c in parsed.cells if c.cell_type == "code"]
     assert any(c.get("outputs") for c in code_cells)
+
+
+@pytest.fixture
+def dated_experiment():
+    """ A real experiment whose price series carries a datetime index. """
+    from fynance.core import PriceSeries
+
+    n = 400
+    values = gbm(n, seed=7).to_numpy()
+    dates = np.datetime64("2019-01-01") + np.arange(n)
+    ps = PriceSeries(values, index=dates, name="dated")
+    strat = Strategy(features=lambda p: np.diff(p, prepend=p[0]))
+
+    return run_experiment(strat, ps, name="dated")
+
+
+def test_report_uses_date_axis_when_indexed(tmp_path, dated_experiment):
+    # The dated experiment persists an index; the tearsheet PNG is written from
+    # it without error (drawn against dates rather than bar numbers).
+    assert "index" in dated_experiment.series
+
+    out = write_report(dated_experiment, tmp_path, notebook=False)
+    png = tmp_path / "dated" / "tearsheet.png"
+
+    assert out["png"] == png and png.is_file() and png.stat().st_size > 0
+
+
+def test_tearsheet_plots_dates_for_indexed_curve():
+    # Threading a datetime index through to the plot layer yields a date axis
+    # (datetime64 x-data + a date locator) instead of integer bar numbers.
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.dates as mdates
+
+    from fynance.plot.equity import plot_equity
+
+    dates = np.datetime64("2021-01-01") + np.arange(60)
+    equity = np.linspace(1.0, 1.3, dates.size)
+
+    ax = plot_equity(SimpleNamespace(equity=equity, index=dates))
+    xdata = np.asarray(ax.get_lines()[0].get_xdata())
+
+    assert np.issubdtype(xdata.dtype, np.datetime64)
+    assert isinstance(ax.xaxis.get_major_locator(), mdates.AutoDateLocator)

--- a/fynance/tests/research/test_run_experiment.py
+++ b/fynance/tests/research/test_run_experiment.py
@@ -12,6 +12,7 @@ import numpy as np
 # Local
 import fynance
 from fynance.backtest import ProportionalCost
+from fynance.core import PriceSeries
 from fynance.research import Experiment, gbm, run_experiment
 from fynance.strategy import Strategy
 
@@ -110,3 +111,31 @@ def test_no_lookahead_walk_forward():
 
     k = len(base.series["returns"]) // 3
     assert np.allclose(base.series["returns"][:k], pert_exp.series["returns"][:k])
+
+
+def test_datetime_index_captured_tail_aligned():
+    # A PriceSeries carrying a real datetime index makes run_experiment persist a
+    # tail-aligned ISO date index, so the report plots against dates not bars.
+    n = 300
+    values = gbm(n, seed=11).to_numpy()
+    dates = np.datetime64("2020-01-01") + np.arange(n)
+    ps = PriceSeries(values, index=dates, name="dated")
+
+    exp = run_experiment(momentum(), ps, name="dated")
+
+    idx = exp.series.get("index")
+    assert idx is not None
+    # One date per equity point, right-aligned (ends on the last observation).
+    assert len(idx) == len(exp.series["equity"])
+    assert np.datetime64(idx[-1]) == dates[-1]
+    assert np.datetime64(idx[0]) == dates[-len(idx)]
+    # ISO strings survive the JSON round-trip.
+    assert Experiment.from_dict(exp.to_dict()).series["index"] == idx
+
+
+def test_non_datetime_index_yields_no_date_axis():
+    # gbm's default 0..n-1 integer index is not temporal: no index is stored, so
+    # the report falls back to bar numbers (unchanged behavior).
+    exp = run_experiment(momentum(), gbm(200, seed=2), name="bars")
+
+    assert "index" not in exp.series

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fynance"
-version = "2.10.1"
+version = "2.10.2"
 description = "Pure-Python (Numba-accelerated) machine learning, econometrics and statistical tools for financial analysis and backtesting"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Release **v2.10.2** (patch).

### Changed

- **Research reports plot against dates.** `run_experiment` captures the
  `PriceSeries` `datetime64` index (tail-aligned, persisted as ISO strings) and
  `write_report`'s tearsheet draws equity / drawdown / rolling Sharpe against
  real dates instead of bar numbers; falls back to bar numbers when no temporal
  index is present. (#211)

Merged after `chore/release-2.10.2` (#212) landed in `develop`.