### PR TITLE
feat: information coefficient metric and horizon-returns helper

### DIFF
--- a/fynance/features/__init__.py
+++ b/fynance/features/__init__.py
@@ -29,6 +29,7 @@ from . import (
     engineering,
     filters,
     garch,
+    horizon,
     indicators,
     momentums,
     money_management,
@@ -41,6 +42,7 @@ from . import (
 from .engineering import *
 from .filters import *
 from .garch import *
+from .horizon import *
 from .indicators import *
 from .momentums import *
 from .money_management import *
@@ -54,6 +56,7 @@ __all__ = engineering.__all__
 __all__ += regime.__all__
 __all__ += filters.__all__
 __all__ += garch.__all__
+__all__ += horizon.__all__
 __all__ += momentums.__all__
 __all__ += indicators.__all__
 __all__ += money_management.__all__

--- a/fynance/features/horizon.py
+++ b/fynance/features/horizon.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Forward horizon-return labels.
+
+Helpers to turn a price series into forward (look-ahead) return labels over a
+fixed horizon ``h``. These are the *targets* an Information Coefficient
+(:func:`fynance.metrics.information_coefficient`) is computed against. The
+non-overlapping variant (the default) is the safe choice for IC estimation:
+overlapping H-bar labels share data and inflate the apparent correlation.
+
+"""
+
+from __future__ import annotations
+
+# Built-in packages
+# Third-party packages
+import numpy as np
+from numpy.typing import NDArray
+
+# Local packages
+
+__all__ = ['horizon_returns']
+
+
+def horizon_returns(
+    prices: NDArray,
+    h: int,
+    *,
+    overlapping: bool = False,
+) -> NDArray:
+    r""" Forward return over a fixed horizon ``h``, strictly causal.
+
+    The label at time ``t`` is the simple return realized over the next ``h``
+    steps, :math:`prices_{t+h} / prices_t - 1`. It looks *forward* (the label
+    at ``t`` is only known at ``t + h``), so it is a prediction *target*, not a
+    feature — never feed it back into the model as an input at time ``t``.
+
+    By default the labels are **non-overlapping**: one sample every ``h`` steps
+    (``t = 0, h, 2h, ...``), so no two labels share any underlying price move.
+    This matters for Information Coefficient estimation — overlapping H-bar
+    labels are autocorrelated by construction and inflate the apparent IC. Set
+    ``overlapping=True`` to get one label per bar (``t = 0, 1, 2, ...``) when
+    that autocorrelation is acceptable.
+
+    Notes
+    -----
+    With :math:`T` observations and horizon :math:`h`, the forward return is
+
+    .. math::
+
+        r^{(h)}_t = \frac{prices_{t+h}}{prices_t} - 1
+
+    defined for :math:`t + h < T`. The non-overlapping output keeps
+    :math:`t \in \{0, h, 2h, \dots\}` and has length
+    :math:`\lfloor (T - 1) / h \rfloor`; the overlapping output keeps every
+    :math:`t \in \{0, 1, \dots\}` and has length :math:`T - h`.
+
+    Parameters
+    ----------
+    prices : np.ndarray[dtype, ndim=1 or 2]
+        Time-series of prices indexed by time on the first axis. For a 2-D
+        ``(T, N)`` panel each column is an independent series.
+    h : int
+        Forward horizon in number of steps, must be a positive integer.
+    overlapping : bool, optional
+        If ``False`` (default), keep one label every ``h`` steps
+        (non-overlapping). If ``True``, keep one label per bar (overlapping).
+
+    Returns
+    -------
+    np.ndarray[np.float64, ndim=1 or 2]
+        Forward horizon returns. A 1-D input of length ``T`` yields a 1-D
+        output; a 2-D ``(T, N)`` input yields a ``(K, N)`` output where ``K`` is
+        the number of retained labels.
+
+    References
+    ----------
+    .. [1] https://en.wikipedia.org/wiki/Rate_of_return
+
+    Examples
+    --------
+    Non-overlapping 2-step forward returns (one label every 2 bars):
+
+    >>> import numpy as np
+    >>> prices = np.array([100., 110., 121., 133.1, 146.41, 161.051])
+    >>> horizon_returns(prices, 2)
+    array([0.21, 0.21])
+
+    Overlapping labels keep one per bar:
+
+    >>> horizon_returns(prices, 2, overlapping=True)
+    array([0.21, 0.21, 0.21, 0.21])
+
+    See Also
+    --------
+    fynance.metrics.information_coefficient
+
+    """
+    if not isinstance(h, (int, np.integer)) or h <= 0:
+
+        raise ValueError(f"h must be a positive integer, got {h!r}")
+
+    prices = np.asarray(prices, dtype=np.float64)
+
+    if prices.ndim not in (1, 2):
+
+        raise ValueError(
+            f"only 1-D and 2-D arrays are supported, got ndim={prices.ndim}"
+        )
+
+    T = prices.shape[0]
+
+    if T <= h:
+
+        raise ValueError(
+            f"prices must have more than h={h} observations on axis 0, got {T}"
+        )
+
+    step = h if not overlapping else 1
+    base_idx = np.arange(0, T - h, step)
+    fwd = prices[base_idx + h] / prices[base_idx] - 1.
+
+    return fwd

--- a/fynance/metrics/__init__.py
+++ b/fynance/metrics/__init__.py
@@ -15,6 +15,7 @@ Risk-adjusted ratios, return and drawdown metrics for evaluating a strategy
 import sys as _sys
 
 # Local packages
+from .correlation import *
 from .drawdown import *
 from .ratios import *
 from .returns import *
@@ -23,8 +24,12 @@ from .summary import METRICS, summary  # noqa: F401
 
 # Aggregate __all__ via sys.modules (the star imports above rebind names that
 # collide with a submodule, e.g. the ``drawdown`` function vs the module).
+# ``information_coefficient`` is exported here but intentionally NOT added to the
+# ``METRICS`` registry: that registry maps a name to a callable taking a single
+# equity/price curve (see ``summary``), whereas the IC takes an aligned
+# (pred, real) pair and so does not fit that single-series contract.
 __all__ = []
-for _m in ("returns", "ratios", "drawdown"):
+for _m in ("correlation", "returns", "ratios", "drawdown"):
     __all__ += _sys.modules[f"{__name__}.{_m}"].__all__
 __all__ += ['perf_strat', 'returns_strat', 'METRICS', 'summary']
 

--- a/fynance/metrics/correlation.py
+++ b/fynance/metrics/correlation.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Predict-vs-realize correlation metrics (Information Coefficient).
+
+The Information Coefficient (IC) is a predict-then-rule guardrail: it scores how
+well a *prediction* lines up with the *realized* outcome. Unlike the risk-adjusted
+ratios in :mod:`fynance.metrics.ratios`, which evaluate a single equity curve, the
+IC takes two aligned series (a prediction and a realization) and returns their
+correlation along the time axis.
+
+"""
+
+from __future__ import annotations
+
+# Built-in packages
+from typing import Any
+
+# Third-party packages
+import numpy as np
+from numpy.typing import NDArray
+from scipy.stats import rankdata
+
+# Local packages
+
+__all__ = ['information_coefficient']
+
+
+def _pearson_pair(a: NDArray, b: NDArray) -> float:
+    """ Pearson correlation of two 1-D vectors, NaN-robust.
+
+    Drops index pairs where either side is NaN, and returns ``np.nan`` when
+    fewer than two valid pairs remain or either side has zero variance.
+    """
+    a = np.asarray(a, dtype=np.float64)
+    b = np.asarray(b, dtype=np.float64)
+    valid = np.isfinite(a) & np.isfinite(b)
+    a = a[valid]
+    b = b[valid]
+
+    if a.size < 2:
+
+        return np.nan
+
+    a = a - a.mean()
+    b = b - b.mean()
+    denom = np.sqrt(np.sum(a * a) * np.sum(b * b))
+
+    if denom == 0.:
+
+        return np.nan
+
+    return float(np.sum(a * b) / denom)
+
+
+def _spearman_pair(a: NDArray, b: NDArray) -> float:
+    """ Spearman (rank) correlation of two 1-D vectors, NaN-robust.
+
+    Spearman is Pearson computed on the ranks of the valid pairs; ties are
+    handled by :func:`scipy.stats.rankdata` (average ranks).
+    """
+    a = np.asarray(a, dtype=np.float64)
+    b = np.asarray(b, dtype=np.float64)
+    valid = np.isfinite(a) & np.isfinite(b)
+    a = a[valid]
+    b = b[valid]
+
+    if a.size < 2:
+
+        return np.nan
+
+    return _pearson_pair(rankdata(a), rankdata(b))
+
+
+_HANDLER = {
+    'pearson': _pearson_pair,
+    'spearman': _spearman_pair,
+}
+
+
+def information_coefficient(
+    pred: NDArray,
+    real: NDArray,
+    *,
+    method: str = 'spearman',
+    axis: int = 0,
+) -> Any:
+    r""" Information Coefficient between a prediction and a realized outcome.
+
+    The Information Coefficient (IC) is the correlation between a forecast and
+    what actually happened — a predict-then-rule guardrail measuring how much
+    signal a prediction carries. With ``method='spearman'`` (default) it is the
+    *rank-IC*: a rank correlation that rewards getting the ordering right while
+    ignoring the magnitude/shape of the relationship, which is the relevant
+    quantity when the prediction is used to rank assets. With
+    ``method='pearson'`` it is the ordinary linear correlation.
+
+    The two inputs must be aligned: ``pred[i]`` is the forecast for the outcome
+    ``real[i]``.
+
+    Notes
+    -----
+    For two aligned samples the IC is
+
+    .. math::
+
+        IC = corr(g(pred),\ g(real))
+
+    where :math:`g` is the identity for ``method='pearson'`` and the rank
+    transform for ``method='spearman'`` (Spearman = Pearson on ranks). Index
+    pairs where either side is NaN are dropped before the computation.
+
+    **Shape contract.** For 1-D inputs ``(T,)`` the IC is a scalar computed over
+    the whole sample. For 2-D panel inputs ``(T, N)`` the *default*
+    (``axis=0``) is the **cross-sectional IC per bar**: at each time step the
+    prediction is correlated against the realization *across the N assets*,
+    returning one IC per bar with shape ``(T,)``. This is the ranking
+    use-case — at each rebalancing bar, "did the assets I ranked highest
+    actually do best?". Pass ``axis=1`` to instead correlate along the time
+    axis per asset, returning shape ``(N,)`` (the per-asset time-series IC).
+
+    Parameters
+    ----------
+    pred : np.ndarray[dtype, ndim=1 or 2]
+        Predictions/forecasts (e.g. a model score). Same shape as ``real``.
+    real : np.ndarray[dtype, ndim=1 or 2]
+        Realized outcomes (e.g. forward returns). Same shape as ``pred``.
+    method : {'spearman', 'pearson'}, optional
+        ``'spearman'`` (default) for the rank-IC, ``'pearson'`` for the linear
+        IC.
+    axis : {0, 1}, optional
+        Axis indexing the samples to correlate *over*. For 2-D inputs,
+        ``axis=0`` correlates across the second dimension per row
+        (cross-sectional IC per bar, shape ``(T,)``) and ``axis=1`` correlates
+        across the first dimension per column (time-series IC per asset, shape
+        ``(N,)``). Ignored for 1-D inputs. Default is 0.
+
+    Returns
+    -------
+    float or np.ndarray[np.float64, ndim=1]
+        The IC. A scalar for 1-D inputs, a 1-D array for 2-D inputs. Entries
+        are ``np.nan`` (never an exception) where fewer than two valid pairs
+        remain or either side has zero variance.
+
+    References
+    ----------
+    .. [1] https://en.wikipedia.org/wiki/Information_coefficient
+
+    Examples
+    --------
+    A perfect monotonic prediction has a rank-IC of 1, even when the
+    relationship is non-linear (only the ordering matters):
+
+    >>> import numpy as np
+    >>> real = np.array([1., 2., 3., 4., 5.])
+    >>> pred = real ** 3
+    >>> float(information_coefficient(pred, real))
+    1.0
+    >>> round(float(information_coefficient(pred, real, method='pearson')), 4)
+    0.9431
+
+    A panel returns one cross-sectional IC per bar — here the ranking is
+    correct on the first bar and inverted on the second:
+
+    >>> pred = np.array([[1., 2., 3.], [1., 2., 3.]])
+    >>> real = np.array([[1., 2., 3.], [3., 2., 1.]])
+    >>> information_coefficient(pred, real)
+    array([ 1., -1.])
+
+    See Also
+    --------
+    sharpe, sortino
+
+    """
+    if method not in _HANDLER:
+
+        raise ValueError(
+            f"unknown method {method!r}, only 'spearman' and 'pearson' "
+            "are supported"
+        )
+
+    corr = _HANDLER[method]
+    pred = np.asarray(pred, dtype=np.float64)
+    real = np.asarray(real, dtype=np.float64)
+
+    if pred.shape != real.shape:
+
+        raise ValueError(
+            f"pred and real must have the same shape, got {pred.shape} and "
+            f"{real.shape}"
+        )
+
+    if pred.ndim == 1:
+
+        return corr(pred, real)
+
+    if pred.ndim != 2:
+
+        raise ValueError(
+            f"only 1-D and 2-D arrays are supported, got ndim={pred.ndim}"
+        )
+
+    if axis == 0:
+        # Cross-sectional IC per bar: correlate across the N assets within each
+        # time step, one value per row.
+        return np.array(
+            [corr(pred[t], real[t]) for t in range(pred.shape[0])],
+            dtype=np.float64,
+        )
+
+    elif axis == 1:
+        # Time-series IC per asset: correlate along time within each column.
+        return np.array(
+            [corr(pred[:, n], real[:, n]) for n in range(pred.shape[1])],
+            dtype=np.float64,
+        )
+
+    raise np.exceptions.AxisError(axis, pred.ndim)

--- a/fynance/tests/features/test_horizon.py
+++ b/fynance/tests/features/test_horizon.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Test forward horizon-return labels. """
+
+# Third-party packages
+import numpy as np
+import pytest
+
+# Local packages
+import fynance as fy
+from fynance.features import horizon_returns
+
+
+def test_non_overlapping_length_and_values():
+    # Constant 10% step => every 2-step forward return is 21%.
+    prices = 100. * 1.1 ** np.arange(7)  # length 7
+    out = horizon_returns(prices, 2)
+    # base indices 0, 2, 4 (t + h < T = 7) => length floor((7 - 1) / 2) = 3.
+    assert out.shape == (3,)
+    expected = prices[np.array([2, 4, 6])] / prices[np.array([0, 2, 4])] - 1.
+    assert out == pytest.approx(expected)
+    assert out == pytest.approx(np.full(3, 1.1 ** 2 - 1.))
+
+
+def test_overlapping_length_and_values():
+    prices = 100. * 1.1 ** np.arange(7)
+    out = horizon_returns(prices, 2, overlapping=True)
+    # base indices 0..4 => length T - h = 5.
+    assert out.shape == (5,)
+    base = np.arange(5)
+    expected = prices[base + 2] / prices[base] - 1.
+    assert out == pytest.approx(expected)
+
+
+def test_horizon_one_matches_simple_returns():
+    prices = np.array([100., 110., 99., 108.9, 130.68])
+    out = horizon_returns(prices, 1, overlapping=True)
+    expected = prices[1:] / prices[:-1] - 1.
+    assert out == pytest.approx(expected)
+
+
+def test_manual_computation():
+    prices = np.array([10., 12., 9., 18., 20., 15.])
+    out = horizon_returns(prices, 3)
+    # Non-overlapping: base indices 0, 3 (t + 3 < 6) => length floor(5 / 3) = 1.
+    # Only base index 0 keeps t + 3 = 3 < 6; index 3 would need t + 3 = 6.
+    assert out.shape == (1,)
+    assert out[0] == pytest.approx(18. / 10. - 1.)
+
+
+def test_leakage_probe_beyond_window_does_not_change_label():
+    # The label at t depends ONLY on the endpoints prices[t] and prices[t+h].
+    # Perturbing any price that is not an endpoint of label 0's window must not
+    # change label 0 (no leakage); perturbing label 1's forward endpoint must.
+    rng = np.random.default_rng(0)
+    prices = 100. * np.cumprod(1. + rng.standard_normal(20) * 0.01)
+    h = 4
+    base = horizon_returns(prices, h)  # base indices 0, 4, 8, 12 -> endpoints 4, 8, 12, 16
+    # Perturb prices[16], strictly beyond label 0's forward endpoint (index 4).
+    perturbed = prices.copy()
+    perturbed[16] *= 2.0
+    after = horizon_returns(perturbed, h)
+    # Label 0 (uses prices[0], prices[4]) is unchanged.
+    assert after[0] == pytest.approx(base[0])
+    # Label 3 (base index 12 -> uses prices[12], prices[16]) changes,
+    # confirming the probe actually moved an endpoint.
+    assert after[3] != pytest.approx(base[3])
+
+
+def test_panel_shape():
+    rng = np.random.default_rng(1)
+    prices = 100. * np.cumprod(1. + rng.standard_normal((30, 4)) * 0.01, axis=0)
+    out = horizon_returns(prices, 5)
+    # base indices 0, 5, ..., 25 (t + 5 < 30) => length floor(29 / 5) = 5.
+    assert out.shape == (5, 4)
+    base_idx = np.arange(0, 30 - 5, 5)
+    expected = prices[base_idx + 5] / prices[base_idx] - 1.
+    assert out == pytest.approx(expected)
+
+
+def test_strictly_causal_label_uses_future_only():
+    # Label at t equals prices[t+h]/prices[t]-1; it must not depend on prices
+    # strictly between t and t+h.
+    prices = np.array([1., 2., 4., 8., 16., 32.])
+    h = 3
+    out = horizon_returns(prices, h, overlapping=True)
+    # First label (t=0) = prices[3]/prices[0]-1 = 8/1-1 = 7.
+    assert out[0] == pytest.approx(7.0)
+    perturbed = prices.copy()
+    perturbed[1] = 999.  # strictly inside the (0, 3) window
+    perturbed[2] = -999.
+    out2 = horizon_returns(perturbed, h, overlapping=True)
+    assert out2[0] == pytest.approx(out[0])
+
+
+def test_invalid_horizon_raises():
+    prices = np.array([1., 2., 3.])
+    with pytest.raises(ValueError):
+        horizon_returns(prices, 0)
+    with pytest.raises(ValueError):
+        horizon_returns(prices, -1)
+
+
+def test_horizon_too_large_raises():
+    prices = np.array([1., 2., 3.])
+    with pytest.raises(ValueError):
+        horizon_returns(prices, 3)  # T == h, no label fits
+
+
+def test_exposed_on_top_level_package():
+    assert fy.horizon_returns is horizon_returns

--- a/fynance/tests/metrics/test_correlation.py
+++ b/fynance/tests/metrics/test_correlation.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Test the Information Coefficient / rank-IC metric. """
+
+# Third-party packages
+import numpy as np
+import pytest
+
+# Local packages
+import fynance as fy
+from fynance.metrics import information_coefficient
+
+
+def test_perfect_ic_is_one():
+    real = np.array([1., 2., 3., 4., 5., 6.])
+    pred = real.copy()
+    assert information_coefficient(pred, real, method='spearman') == pytest.approx(1.0)
+    assert information_coefficient(pred, real, method='pearson') == pytest.approx(1.0)
+
+
+def test_inverted_rank_ic_is_minus_one():
+    real = np.array([1., 2., 3., 4., 5., 6.])
+    pred = -real
+    assert information_coefficient(pred, real, method='spearman') == pytest.approx(-1.0)
+    assert information_coefficient(pred, real, method='pearson') == pytest.approx(-1.0)
+
+
+def test_monotone_nonlinear_rank_vs_level():
+    # A monotone non-linear map preserves the ordering (rank-IC == 1) but bends
+    # the line (pearson < 1): this proves spearman ranks rather than levels.
+    real = np.array([1., 2., 3., 4., 5., 6., 7., 8.])
+    pred = real ** 3
+    spearman = information_coefficient(pred, real, method='spearman')
+    pearson = information_coefficient(pred, real, method='pearson')
+    assert spearman == pytest.approx(1.0)
+    assert pearson < 1.0
+
+
+def test_pure_noise_ic_is_small():
+    rng = np.random.default_rng(0)
+    real = rng.standard_normal(2000)
+    pred = rng.standard_normal(2000)  # independent of real
+    ic = information_coefficient(pred, real, method='spearman')
+    assert abs(ic) < 0.1
+
+
+def test_zero_variance_returns_nan_not_exception():
+    real = np.array([1., 2., 3., 4., 5.])
+    flat = np.full(5, 7.0)  # zero variance prediction
+    assert np.isnan(information_coefficient(flat, real, method='pearson'))
+    assert np.isnan(information_coefficient(flat, real, method='spearman'))
+
+
+def test_fewer_than_two_valid_points_returns_nan():
+    # Only one finite pair survives the NaN drop -> nan, no exception.
+    pred = np.array([1.0, np.nan, np.nan])
+    real = np.array([1.0, 2.0, 3.0])
+    assert np.isnan(information_coefficient(pred, real, method='spearman'))
+    assert np.isnan(information_coefficient(pred, real, method='pearson'))
+
+
+def test_nan_pairs_are_dropped():
+    # Dropping the NaN pair leaves a perfectly ordered (pred, real) set.
+    real = np.array([1.0, 2.0, np.nan, 4.0, 5.0])
+    pred = np.array([10.0, 20.0, 99.0, 40.0, 50.0])
+    assert information_coefficient(pred, real, method='spearman') == pytest.approx(1.0)
+
+
+def test_panel_cross_sectional_ic_per_bar():
+    # Default axis=0 on a (T, N) panel returns one cross-sectional IC per bar.
+    pred = np.array([[1., 2., 3.],
+                     [1., 2., 3.],
+                     [1., 2., 3.]])
+    real = np.array([[1., 2., 3.],    # correct ranking
+                     [3., 2., 1.],    # inverted ranking
+                     [2., 3., 1.]])   # partial
+    ic = information_coefficient(pred, real, method='spearman')
+    assert ic.shape == (3,)
+    assert ic[0] == pytest.approx(1.0)
+    assert ic[1] == pytest.approx(-1.0)
+    # Hand-check the third bar: ranks of pred = [1, 2, 3], ranks of real =
+    # [2, 3, 1]; spearman == pearson on those ranks.
+    from scipy.stats import rankdata
+    rp = rankdata(pred[2])
+    rr = rankdata(real[2])
+    expected = np.corrcoef(rp, rr)[0, 1]
+    assert ic[2] == pytest.approx(expected)
+
+
+def test_panel_axis1_is_time_series_ic_per_asset():
+    # axis=1 correlates along time within each column -> one IC per asset.
+    real = np.array([[1., 5.],
+                     [2., 4.],
+                     [3., 3.],
+                     [4., 2.],
+                     [5., 1.]])
+    pred = real.copy()
+    ic = information_coefficient(pred, real, method='spearman', axis=1)
+    assert ic.shape == (2,)
+    assert ic == pytest.approx(np.array([1.0, 1.0]))
+
+
+def test_unknown_method_raises():
+    real = np.array([1., 2., 3.])
+    with pytest.raises(ValueError):
+        information_coefficient(real, real, method='kendall')
+
+
+def test_mismatched_shapes_raise():
+    with pytest.raises(ValueError):
+        information_coefficient(np.array([1., 2.]), np.array([1., 2., 3.]))
+
+
+def test_exposed_on_top_level_package():
+    assert fy.information_coefficient is information_coefficient
+
+
+def test_ic_decreases_with_noise():
+    # IC must decrease monotonically as more noise is mixed into the signal.
+    rng = np.random.default_rng(42)
+    real = rng.standard_normal(5000)
+    noise = rng.standard_normal(5000)
+    ics = [
+        information_coefficient(real + k * noise, real, method='spearman')
+        for k in (0.0, 0.5, 1.0, 2.0, 4.0)
+    ]
+    assert all(ics[i] > ics[i + 1] for i in range(len(ics) - 1))
+    assert ics[0] == pytest.approx(1.0)


### PR DESCRIPTION
## Summary

Adds a predict-then-rule guardrail metric plus the non-overlapping label helper it scores against. Pure metric work, independent of the rest of the panel epic.

- **`fynance/metrics/correlation.py`** — `information_coefficient(pred, real, *, method="spearman", axis=0)`. Rank-IC (Spearman = Pearson on ranks, via `scipy.stats.rankdata`) by default; `method="pearson"` for the linear IC. Handles 1-D `(T,)` and panel `(T, N)`: for 2-D the default `axis=0` is the **cross-sectional IC per bar** (rank across the N assets within each time step → shape `(T,)`), and `axis=1` gives the per-asset time-series IC → shape `(N,)`. Drops NaN pairs, handles ties, and returns `np.nan` (never raises) on zero variance or fewer than 2 valid points.
- **`fynance/features/horizon.py`** — `horizon_returns(prices, h, *, overlapping=False)`. Strictly-causal forward return `prices[t+h]/prices[t] - 1`; **non-overlapping by default** (one sample every `h` steps) so overlapping H-bar labels don't inflate the IC. Supports `(T,)` and `(T, N)`.
- Exported via each package's `__all__` (so reachable as `fy.information_coefficient` / `fy.horizon_returns`). `information_coefficient` is intentionally **not** added to the `METRICS` registry: that registry maps a name to a single-equity-curve callable (see `summary`), which a `(pred, real)` pair does not fit. Noted in `metrics/__init__.py`.

## Test plan

- `fynance/tests/metrics/test_correlation.py`: perfect IC == 1 (spearman + pearson); inverted == -1; monotone non-linear (`real**3`) ⇒ spearman == 1 but pearson < 1; pure noise ⇒ |IC| small; zero variance / <2 valid points ⇒ NaN (no exception); NaN-pair dropping; panel cross-sectional IC per bar matches a hand computation; `axis=1` per-asset IC; unknown method / shape mismatch raise; monotone IC decrease as noise grows.
- `fynance/tests/features/test_horizon.py`: non-overlapping & overlapping lengths and values vs manual computation; `h=1` matches simple returns; leakage probe (perturbing a non-endpoint leaves a label unchanged; perturbing a forward endpoint changes it); panel shape; strict causality; invalid/too-large `h` raise.

Gates: full `pytest` 820 passed / 1 skipped; targeted doctest gate green; `ruff check fynance/` clean; `mypy fynance/metrics/ fynance/features/` clean.

IC(k) verification (`pred = real + k*noise`, T=20000), monotonically decreasing:

| k | spearman | pearson |
|---|---|---|
| 0.00 | 1.0000 | 1.0000 |
| 0.50 | 0.8839 | 0.8927 |
| 1.00 | 0.6855 | 0.7025 |
| 2.00 | 0.4231 | 0.4405 |
| 4.00 | 0.2245 | 0.2355 |
| 16.00 | 0.0532 | 0.0560 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYiBP4z6rdZA1BHnEUqG4p
