### PR TITLE
feat: book-aware losses + cross-sectional RankingLoss

### DIFF
--- a/fynance/models/loss/__init__.py
+++ b/fynance/models/loss/__init__.py
@@ -20,6 +20,8 @@ Main entry points
   maximum drawdown).
 - :class:`OmegaLoss` — negative Omega ratio (expected gains over
   expected losses relative to a threshold).
+- :class:`RankingLoss` — differentiable cross-sectional long-short
+  ranking objective for a panel of assets.
 - :class:`HybridLoss` — convex combination of two losses with a fixed or
   learnable weight.
 
@@ -40,8 +42,9 @@ from .calmar import CalmarLoss
 from .directional import DirectionalAccuracyLoss
 from .hybrid import HybridLoss
 from .omega import OmegaLoss
+from .ranking import RankingLoss
 from .sharpe import SharpeLoss
 from .sortino import SortinoLoss
 
 __all__ = ['BaseLoss', 'CalmarLoss', 'DirectionalAccuracyLoss', 'HybridLoss',
-           'OmegaLoss', 'SharpeLoss', 'SortinoLoss']
+           'OmegaLoss', 'RankingLoss', 'SharpeLoss', 'SortinoLoss']

--- a/fynance/models/loss/_base.py
+++ b/fynance/models/loss/_base.py
@@ -67,3 +67,20 @@ class BaseLoss(torch.nn.Module):
                 "Convert numpy arrays with torch.from_numpy() before passing "
                 "to this loss."
             )
+
+    @staticmethod
+    def _book_return(y_pred: torch.Tensor) -> torch.Tensor:
+        r""" Aggregate a position-book return ``(T, N)`` into a 1-D book return.
+
+        A 2-D ``y_pred`` is read as the per-asset net-of-cost returns of a
+        position book; the book return at each step is their sum across assets
+        (:math:`\sum_i pos_i \cdot r_i`), so the ratio losses score the
+        **portfolio** return rather than a pooled per-asset return. A 1-D
+        ``y_pred`` (single asset) is returned unchanged, and a ``(T, 1)`` book
+        reduces to the same series as the single-asset case.
+        """
+        if y_pred.dim() == 2:
+
+            return y_pred.sum(dim=1)
+
+        return y_pred

--- a/fynance/models/loss/calmar.py
+++ b/fynance/models/loss/calmar.py
@@ -52,6 +52,7 @@ class CalmarLoss(BaseLoss):
     ) -> torch.Tensor:
         """ Compute the negative Calmar ratio (scalar). """
         self._check_tensor(y_pred)
+        y_pred = self._book_return(y_pred)
         equity = torch.cumsum(y_pred, dim=0)
         running_max, _ = torch.cummax(equity, dim=0)
         max_drawdown = (running_max - equity).max()

--- a/fynance/models/loss/omega.py
+++ b/fynance/models/loss/omega.py
@@ -60,6 +60,7 @@ class OmegaLoss(BaseLoss):
     ) -> torch.Tensor:
         """ Compute the negative Omega ratio (scalar). """
         self._check_tensor(y_pred)
+        y_pred = self._book_return(y_pred)
         diff = y_pred - self.threshold
         gains = torch.relu(diff).mean()
         losses = torch.relu(-diff).mean()

--- a/fynance/models/loss/ranking.py
+++ b/fynance/models/loss/ranking.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Differentiable cross-sectional ranking loss. """
+
+from __future__ import annotations
+
+# Third-party packages
+import torch
+
+# Local packages
+from ._base import BaseLoss
+
+__all__ = ['RankingLoss']
+
+
+class RankingLoss(BaseLoss):
+    r""" Differentiable cross-sectional long-short ranking loss.
+
+    A *predict-then-rank* objective for a panel of assets: it rewards a score
+    that ranks assets by their realized cross-sectional outcome. At each time
+    step the per-asset scores are turned into a softmax **long** book and a
+    softmax **short** book (a smooth, differentiable relaxation of "long the
+    top names, short the bottom names"); the loss is the negative mean
+    long-short **spread return**
+
+    .. math::
+
+        \mathcal{L} = -\frac{1}{T} \sum_t \sum_i
+            \big(w^{+}_{t,i} - w^{-}_{t,i}\big)\, r_{t,i},
+        \qquad
+        w^{\pm}_{t} = \mathrm{softmax}(\pm\,\tau\, s_t)
+
+    where :math:`s` is ``y_pred`` (the per-asset scores), :math:`r` is
+    ``y_true`` (the realized per-asset returns) and :math:`\tau` is
+    ``temperature`` (higher = sharper, closer to a hard top/bottom selection).
+    Minimizing the loss maximizes the spread: it pushes high scores onto the
+    cross-sectional winners and low scores onto the losers.
+
+    Unlike the ratio losses, this one is **inherently cross-sectional**: it
+    needs a 2-D ``(T, N)`` panel (``N >= 2`` assets) and a realized target.
+
+    Parameters
+    ----------
+    temperature : float, optional
+        Softmax sharpness :math:`\tau`. Higher pushes the soft long/short books
+        toward a hard top/bottom selection. Default is 1.0.
+    **kwargs
+        Forwarded to :class:`BaseLoss` (``rf``, ``period``, ``eps``).
+
+    Examples
+    --------
+    >>> import torch
+    >>> from fynance.models.loss import RankingLoss
+    >>> scores = torch.tensor([[3., 2., 1.], [1., 2., 3.]])
+    >>> real = torch.tensor([[0.03, 0.0, -0.03], [-0.03, 0.0, 0.03]])
+    >>> loss_fn = RankingLoss()
+    >>> aligned = loss_fn(scores, real)
+    >>> inverted = loss_fn(-scores, real)
+    >>> bool(aligned < inverted)        # scoring the winners high ranks best
+    True
+
+    See Also
+    --------
+    SharpeLoss, SortinoLoss
+
+    """
+
+    def __init__(self, temperature: float = 1.0, **kwargs):
+        super().__init__(**kwargs)
+        self.temperature = temperature
+
+    def forward(
+        self, y_pred: torch.Tensor, y_true: torch.Tensor,
+    ) -> torch.Tensor:
+        """ Compute the negative mean cross-sectional long-short spread.
+
+        Parameters
+        ----------
+        y_pred : torch.Tensor
+            Per-asset scores, shape ``(T, N)`` with ``N >= 2``.
+        y_true : torch.Tensor
+            Realized per-asset returns, same shape as ``y_pred``.
+
+        Returns
+        -------
+        torch.Tensor
+            Scalar loss (negative mean long-short spread return).
+
+        Raises
+        ------
+        TypeError
+            If ``y_pred`` or ``y_true`` is not a :class:`torch.Tensor`.
+        ValueError
+            If the inputs are not matching-shape 2-D panels with ``N >= 2``.
+
+        """
+        self._check_tensor(y_pred)
+        self._check_tensor(y_true)
+
+        if y_pred.dim() != 2 or y_pred.shape[1] < 2:
+
+            raise ValueError(
+                "RankingLoss needs a 2-D (T, N) panel with N >= 2 assets, got "
+                f"shape {tuple(y_pred.shape)}"
+            )
+
+        if y_pred.shape != y_true.shape:
+
+            raise ValueError(
+                "y_pred and y_true must have the same shape, got "
+                f"{tuple(y_pred.shape)} and {tuple(y_true.shape)}"
+            )
+
+        w_long = torch.softmax(self.temperature * y_pred, dim=1)
+        w_short = torch.softmax(-self.temperature * y_pred, dim=1)
+        spread = ((w_long - w_short) * y_true).sum(dim=1)
+
+        return -spread.mean()

--- a/fynance/models/loss/sharpe.py
+++ b/fynance/models/loss/sharpe.py
@@ -88,7 +88,8 @@ class SharpeLoss(BaseLoss):
         Parameters
         ----------
         y_pred : torch.Tensor
-            Predicted return series, shape ``(T,)`` or ``(T, M)``.
+            Predicted return series ``(T,)``. A 2-D ``(T, N)`` position book is
+            aggregated to the book return (sum across assets) before scoring.
         y_true : torch.Tensor, optional
             Not used; accepted for API compatibility with PyTorch criterions.
 
@@ -104,5 +105,6 @@ class SharpeLoss(BaseLoss):
 
         """
         self._check_tensor(y_pred)
+        y_pred = self._book_return(y_pred)
         excess = y_pred - self._rf_per_period
         return -(excess.mean() / (excess.std(correction=0) + self.eps))

--- a/fynance/models/loss/sortino.py
+++ b/fynance/models/loss/sortino.py
@@ -92,7 +92,8 @@ class SortinoLoss(BaseLoss):
         Parameters
         ----------
         y_pred : torch.Tensor
-            Predicted return series, shape ``(T,)`` or ``(T, M)``.
+            Predicted return series ``(T,)``. A 2-D ``(T, N)`` position book is
+            aggregated to the book return (sum across assets) before scoring.
         y_true : torch.Tensor, optional
             Not used; accepted for API compatibility with PyTorch criterions.
 
@@ -108,6 +109,7 @@ class SortinoLoss(BaseLoss):
 
         """
         self._check_tensor(y_pred)
+        y_pred = self._book_return(y_pred)
         excess = y_pred - self._rf_per_period
         downside = torch.sqrt(torch.mean(F.relu(-excess) ** 2))
         # Floor the downside relative to the return scale: a fixed absolute eps

--- a/fynance/tests/models/test_loss.py
+++ b/fynance/tests/models/test_loss.py
@@ -12,7 +12,10 @@ import torch
 
 # Local packages
 from fynance.models.loss import (
+    CalmarLoss,
     DirectionalAccuracyLoss,
+    OmegaLoss,
+    RankingLoss,
     SharpeLoss,
     SortinoLoss,
 )
@@ -356,3 +359,88 @@ def test_train_model_with_calmar_loss():
     model.set_optimizer(CalmarLoss, torch.optim.Adam, lr=1e-2)
     loss = model.train_on(model.X, model.y)
     assert torch.isfinite(loss)
+
+
+# Book-aware aggregation: a 2-D (T, N) position book is summed across assets
+# into the 1-D book return before the ratio is scored. ObjectiveModel already
+# pre-aggregates, so this is additive; it must leave 1-D / (T, 1) unchanged.
+_RATIO_LOSSES = [SharpeLoss, SortinoLoss, CalmarLoss, OmegaLoss]
+
+
+class TestBookAwareLosses:
+    @pytest.mark.parametrize("loss_cls", _RATIO_LOSSES)
+    def test_book_equals_summed_book_return(self, loss_cls):
+        # loss((T, N)) == loss(book.sum(axis=1)) for every ratio loss.
+        book = torch.from_numpy(
+            RNG.standard_normal((T, 3)).astype(np.float32) * 0.01)
+        loss_fn = loss_cls()
+        assert torch.allclose(loss_fn(book), loss_fn(book.sum(dim=1)))
+
+    @pytest.mark.parametrize("loss_cls", _RATIO_LOSSES)
+    def test_single_column_matches_1d(self, loss_cls):
+        # A (T, 1) book reduces to exactly the single-asset 1-D series (no
+        # behaviour change for the existing single-asset path).
+        r = torch.from_numpy(RNG.standard_normal(T).astype(np.float32) * 0.01)
+        loss_fn = loss_cls()
+        assert torch.allclose(loss_fn(r), loss_fn(r.reshape(T, 1)))
+
+    @pytest.mark.parametrize("loss_cls", _RATIO_LOSSES)
+    def test_book_gradient_finite_and_nonzero(self, loss_cls):
+        # The book objective stays differentiable: a finite, non-zero gradient
+        # flows back to every per-asset return on a normal panel batch.
+        book = torch.from_numpy(
+            RNG.standard_normal((T, 3)).astype(np.float32) * 0.01
+        ).requires_grad_(True)
+        loss = loss_cls()(book)
+        loss.backward()
+        assert book.grad is not None
+        assert torch.isfinite(book.grad).all()
+        assert book.grad.abs().sum() > 0
+
+
+class TestRankingLoss:
+    def _panel(self, n_assets=4):
+        scores = torch.from_numpy(
+            RNG.standard_normal((T, n_assets)).astype(np.float32))
+        real = scores * 0.01  # returns aligned with the scores' ranking
+        return scores, real
+
+    def test_aligned_beats_inverted(self):
+        scores, real = self._panel()
+        loss_fn = RankingLoss()
+        aligned = loss_fn(scores, real)
+        inverted = loss_fn(-scores, real)
+        assert aligned.shape == torch.Size([])
+        assert aligned.item() < inverted.item()
+
+    def test_aligned_beats_random(self):
+        scores, real = self._panel()
+        random_scores = torch.from_numpy(
+            RNG.standard_normal((T, scores.shape[1])).astype(np.float32))
+        loss_fn = RankingLoss()
+        assert loss_fn(scores, real).item() < loss_fn(random_scores, real).item()
+
+    def test_gradient_finite_and_nonzero(self):
+        scores, real = self._panel()
+        scores = scores.requires_grad_(True)
+        loss = RankingLoss()(scores, real)
+        loss.backward()
+        assert scores.grad is not None
+        assert torch.isfinite(scores.grad).all()
+        assert scores.grad.abs().sum() > 0
+
+    def test_requires_2d_panel(self):
+        with pytest.raises(ValueError):
+            RankingLoss()(torch.randn(T), torch.randn(T))
+
+    def test_requires_at_least_two_assets(self):
+        with pytest.raises(ValueError):
+            RankingLoss()(torch.randn(T, 1), torch.randn(T, 1))
+
+    def test_shape_mismatch_raises(self):
+        with pytest.raises(ValueError):
+            RankingLoss()(torch.randn(T, 3), torch.randn(T, 4))
+
+    def test_non_tensor_raises(self):
+        with pytest.raises(TypeError):
+            RankingLoss()(np.zeros((T, 3)), np.zeros((T, 3)))


### PR DESCRIPTION
Leaf 03 of the multi-asset/panel epic (depends on #215, the panel `ObjectiveModel`).

## Summary
- **Ratio losses are book-aware.** `SharpeLoss`/`SortinoLoss`/`CalmarLoss`/`OmegaLoss` now read a 2-D `(T, N)` `y_pred` as a **position book** and aggregate it to the 1-D book return `Σ_i posᵢ·rᵢ` (sum across assets) via a shared `BaseLoss._book_return` helper, so they score the **portfolio** return instead of a pooled per-asset return. 1-D `(T,)` and `(T, 1)` inputs are numerically **unchanged** (single-asset path preserved; `ObjectiveModel` already pre-aggregates, so this is additive).
- **New `RankingLoss`** — a differentiable cross-sectional long-short objective (per-bar softmax long/short books → negative mean spread return), the predict-then-rank training counterpart to the `information_coefficient` evaluation guardrail (#216).

## Test plan
- New tests: book-equivalence (`loss((T,N)) == loss(book.sum(axis=1))`) for all 4 ratio losses; `(T,1)`-equals-1-D non-regression; finite/non-zero gradient on a panel batch; `RankingLoss` aligned<inverted, aligned<random, gradient, and shape/type guards.
- Full suite: **934 passed, 1 skipped**; ruff + mypy clean; doctests pass.