### PR TITLE
feat: multi-asset panel walk-forward + per-asset attribution

### DIFF
--- a/fynance/backtest/engine.py
+++ b/fynance/backtest/engine.py
@@ -96,10 +96,12 @@ def backtest(
     else:
         pos_eff = pos
 
-    gross = pos_eff * returns
+    gross_book = pos_eff * returns
 
-    if gross.ndim == 2:
-        gross = gross.sum(axis=1)
+    # For a multi-asset book the per-asset gross contributions (which sum to the
+    # book gross return) are kept as attribution before aggregating to 1-D.
+    asset_gross_returns = gross_book if gross_book.ndim == 2 else None
+    gross = gross_book.sum(axis=1) if gross_book.ndim == 2 else gross_book
 
     costs = (
         np.asarray(cost(cost_book), dtype=np.float64)
@@ -115,4 +117,5 @@ def backtest(
         gross_returns=gross,
         positions=pos,
         costs=costs,
+        asset_gross_returns=asset_gross_returns,
     )

--- a/fynance/backtest/result.py
+++ b/fynance/backtest/result.py
@@ -41,6 +41,9 @@ class BacktestResult:
         Per-step transaction costs.
     index : numpy.ndarray, optional
         Temporal index carried from the input.
+    asset_gross_returns : numpy.ndarray, optional
+        Per-asset gross return contributions ``(T, N)`` for a multi-asset book
+        (they sum to :attr:`gross_returns`); ``None`` for a single-asset run.
 
     Methods
     -------
@@ -56,6 +59,7 @@ class BacktestResult:
     positions: NDArray
     costs: NDArray
     index: NDArray | None = None
+    asset_gross_returns: NDArray | None = None
 
     def to_numpy(self) -> NDArray:
         """ Return the equity curve as a numpy array. """

--- a/fynance/research/runner.py
+++ b/fynance/research/runner.py
@@ -28,11 +28,17 @@ __all__ = ['run_experiment']
 
 
 def _to_array(data: Any) -> NDArray[np.float64]:
-    """ Coerce a PriceSeries / array-like to a 1-D float64 array. """
+    """ Coerce a PriceSeries / array-like to a float64 array.
+
+    A 2-D ``(T, N)`` panel (multi-asset prices/returns) is preserved; anything
+    else is flattened to a 1-D series.
+    """
     if isinstance(data, PriceSeries):
         return data.to_numpy()
 
-    return np.asarray(data, dtype=np.float64).reshape(-1)
+    arr = np.asarray(data, dtype=np.float64)
+
+    return arr if arr.ndim == 2 else arr.reshape(-1)
 
 
 def _index_bound(data: Any, pos: int) -> Any:
@@ -197,6 +203,7 @@ def run_experiment(
     data_block: dict[str, Any] = {
         "kind": getattr(data, "name", None) or type(data).__name__,
         "n": int(n),
+        "n_assets": int(prices.shape[1]) if prices.ndim == 2 else 1,
         "start": _index_bound(data, 0),
         "end": _index_bound(data, -1),
         "desc": data_desc,
@@ -233,6 +240,11 @@ def run_experiment(
     date_index = _series_index(data, len(series["equity"]))
     if date_index is not None:
         series["index"] = date_index
+    # Persist per-asset gross contributions of a multi-asset book so the report
+    # can attribute the book return by asset; absent for a single-asset run.
+    asset_contrib = getattr(result, "asset_gross_returns", None)
+    if asset_contrib is not None:
+        series["asset_contrib"] = np.asarray(asset_contrib, dtype=float).tolist()
 
     experiment = Experiment(
         name=name,

--- a/fynance/strategy/strategy.py
+++ b/fynance/strategy/strategy.py
@@ -111,7 +111,20 @@ class Strategy:
         else:
             preds = feats
 
-        return np.asarray(self.signal(preds), dtype=np.float64).reshape(-1)
+        return self._signal_positions(preds)
+
+    def _signal_positions(self, preds: NDArray) -> NDArray:
+        """ Map predictions to positions, preserving a ``(T, N)`` book.
+
+        A genuine multi-asset book ``(T, N)`` is kept 2-D; only a trailing
+        singleton asset axis (the single-asset model output ``(T, 1)``) is
+        collapsed to 1-D so the single-asset path is unchanged.
+        """
+        pos = np.asarray(self.signal(preds), dtype=np.float64)
+        if pos.ndim == 2 and pos.shape[1] == 1:
+            pos = pos.reshape(-1)
+
+        return pos
 
     def run(self, data: Any, y: NDArray | None = None,
             X: NDArray | None = None) -> BacktestResult:
@@ -200,8 +213,8 @@ class Strategy:
         X_arr = None if X is None else np.asarray(X)  # preserve caller dtype
         n = prices.shape[0]
 
-        oos_pos: list[float] = []
-        oos_ret: list[float] = []
+        oos_pos: list[NDArray] = []
+        oos_ret: list[NDArray] = []
 
         for tr, te in walk_forward(n, train=train, test=test, step=step,
                                    purge=purge):
@@ -220,21 +233,24 @@ class Strategy:
             else:
                 preds = feats_te
 
-            pos = np.asarray(self.signal(preds), dtype=np.float64).reshape(-1)
+            pos = self._signal_positions(preds)
 
             # Return realized over each test step (causal: position at t earns
             # r_t within the OOS block; the engine applies the one-step shift).
             # The opening bar has no in-block prior price, so its return is
-            # discarded (NaN -> 0 below). See the method docstring note.
+            # discarded (NaN -> 0 below). For a panel the whole opening row is
+            # discarded. See the method docstring note.
             block = prices[te]
-            ret = np.empty(block.shape[0])
+            ret = np.empty_like(block, dtype=np.float64)
             ret[0] = np.nan
             ret[1:] = block[1:] / block[:-1] - 1.0
 
-            oos_pos.extend(pos.tolist())
-            oos_ret.extend(ret.tolist())
+            oos_pos.append(pos)
+            oos_ret.append(ret)
 
-        positions = np.asarray(oos_pos)
-        returns = np.nan_to_num(np.asarray(oos_ret), nan=0.0)
+        # Stitch the out-of-sample blocks: 1-D for a single asset, (T_oos, N)
+        # for a panel book.
+        positions = np.concatenate(oos_pos, axis=0)
+        returns = np.nan_to_num(np.concatenate(oos_ret, axis=0), nan=0.0)
 
         return backtest(returns, positions, cost=self.cost, shift=True)

--- a/fynance/tests/backtest/test_engine.py
+++ b/fynance/tests/backtest/test_engine.py
@@ -115,3 +115,23 @@ def test_prices_input_cost_preserves_no_lookahead():
     res = backtest(pert, positions, cost=cost,
                    returns_input=False, shift=True).equity
     assert np.allclose(base[:-1], res[:-1])
+
+
+def test_book_attribution_sums_to_gross():
+    # A 2-D position book yields per-asset gross contributions that sum to the
+    # aggregated book gross return.
+    rng = np.random.default_rng(0)
+    returns = rng.normal(0.0, 0.01, (50, 3))
+    positions = rng.choice([-1.0, 1.0], size=(50, 3))
+    res = backtest(returns, positions, shift=True)
+    assert res.asset_gross_returns is not None
+    assert res.asset_gross_returns.shape == (50, 3)
+    assert np.allclose(res.asset_gross_returns.sum(axis=1), res.gross_returns)
+
+
+def test_single_asset_has_no_attribution():
+    rng = np.random.default_rng(1)
+    returns = rng.normal(0.0, 0.01, 50)
+    res = backtest(returns, np.ones(50), shift=True)
+    assert res.asset_gross_returns is None
+    assert res.gross_returns.ndim == 1

--- a/fynance/tests/research/test_run_experiment.py
+++ b/fynance/tests/research/test_run_experiment.py
@@ -139,3 +139,28 @@ def test_non_datetime_index_yields_no_date_axis():
     exp = run_experiment(momentum(), gbm(200, seed=2), name="bars")
 
     assert "index" not in exp.series
+
+
+def test_run_experiment_panel(tmp_path):
+    # A 2-D (T, N) panel runs end to end: book equity, per-asset attribution
+    # persisted, and N recorded in the provenance.
+    rng = np.random.default_rng(4)
+    prices = 100.0 * np.cumprod(1.0 + rng.normal(0.0003, 0.01, (300, 3)), axis=0)
+
+    def panel_momentum(p):
+        r = np.zeros_like(p)
+        r[1:] = np.sign(p[1:] - p[:-1])
+        return r
+
+    strat = Strategy(features=panel_momentum, signal=lambda x: x)
+    exp = run_experiment(strat, prices, name="panel", output_dir=tmp_path)
+
+    assert exp.spec["data"]["n_assets"] == 3
+    assert "asset_contrib" in exp.series
+    assert exp.series["equity"]
+
+
+def test_run_experiment_single_asset_provenance():
+    exp = run_experiment(momentum(), gbm(200, seed=2), name="single")
+    assert exp.spec["data"]["n_assets"] == 1
+    assert "asset_contrib" not in exp.series

--- a/fynance/tests/strategy/test_strategy.py
+++ b/fynance/tests/strategy/test_strategy.py
@@ -168,3 +168,54 @@ def test_walk_forward_no_lookahead():
     prefix = cut - 100 - 40  # conservative: before any window touching the tail
     assert prefix > 0
     assert np.allclose(base.positions[:prefix], pert.positions[:prefix])
+
+
+def _panel_prices(n=300, n_assets=3, seed=0):
+    rng = np.random.default_rng(seed)
+    rets = rng.normal(0.0003, 0.01, (n, n_assets))
+    return 100.0 * np.cumprod(1.0 + rets, axis=0)
+
+
+def _panel_momentum(prices):
+    # Per-asset sign of the last price change -> a (T, N) position book.
+    r = np.zeros_like(prices)
+    r[1:] = np.sign(prices[1:] - prices[:-1])
+    return r
+
+
+def test_run_panel_book_attribution():
+    strat = Strategy(features=_panel_momentum, signal=lambda x: x)
+    res = strat.run(_panel_prices())
+    assert isinstance(res, BacktestResult)
+    assert res.asset_gross_returns is not None
+    assert res.asset_gross_returns.shape[1] == 3
+    assert np.allclose(res.asset_gross_returns.sum(axis=1), res.gross_returns)
+
+
+def test_run_single_asset_unchanged():
+    # The single-asset path keeps a 1-D book and carries no attribution.
+    def momentum(prices):
+        r = np.zeros_like(prices)
+        r[1:] = np.sign(prices[1:] - prices[:-1])
+        return r
+
+    res = Strategy(features=momentum, signal=lambda x: x).run(_prices())
+    assert res.asset_gross_returns is None
+    assert res.gross_returns.ndim == 1
+
+
+def test_walk_forward_panel_book_and_no_lookahead():
+    prices = _panel_prices(n=400, n_assets=3, seed=1)
+    strat = Strategy(features=_panel_momentum, signal=lambda x: x)
+    res = strat.run_walk_forward(prices, y=np.zeros(len(prices)), train=100, test=50)
+    assert res.asset_gross_returns is not None
+    assert res.asset_gross_returns.shape[1] == 3
+    assert np.allclose(res.asset_gross_returns.sum(axis=1), res.gross_returns)
+
+    # No lookahead: perturbing the tail leaves the earlier OOS prefix unchanged.
+    pert = prices.copy()
+    cut = int(len(prices) * 0.7)
+    pert[cut:] *= 1.05
+    res2 = strat.run_walk_forward(pert, y=np.zeros(len(pert)), train=100, test=50)
+    k = res.returns.shape[0] // 3
+    assert np.allclose(res.returns[:k], res2.returns[:k])


### PR DESCRIPTION
Leaf 04 of the multi-asset/panel epic (depends on #215, the panel `ObjectiveModel`).

## Summary
`Strategy.run` / `run_walk_forward` and `run_experiment` now accept a 2-D `(T, N)` panel (prices/returns) and stitch a per-asset **position book** through the already book-aware backtest engine (`engine.py:101`, `gross.sum(axis=1)`), returning an aggregated **book equity** plus **per-asset attribution**. The single-asset `(T,)` path is numerically unchanged (1-D book, no attribution).

- **engine** — keeps the per-asset gross contributions `(T, N)` (which sum to the book gross return) as `BacktestResult.asset_gross_returns`; `None` for a single-asset run. (Costs stay book-aggregated — `transaction_cost` already sums turnover across assets.)
- **`BacktestResult`** — new optional `asset_gross_returns` field.
- **`Strategy`** — `_signal_positions` preserves a genuine `(T, N)` book, collapsing only a trailing singleton asset axis (the single-asset model output `(T, 1)`); `run_walk_forward` stitches 2-D OOS blocks via `np.concatenate`.
- **`run_experiment`** — `_to_array` preserves a 2-D panel; records `n_assets` in the provenance; persists `asset_contrib` in the series so the report (leaf 05) can attribute the book return by asset.

## Test plan
- New tests: engine book attribution sums to `gross_returns` (and `None` for single-asset); `Strategy.run` panel attribution; single-asset path unchanged (1-D, no attribution); panel `run_walk_forward` book + a **no-lookahead** probe (perturbing the tail leaves the early OOS prefix identical); `run_experiment` panel (provenance `n_assets=3`, `asset_contrib` persisted) + single-asset provenance.
- Full suite: **941 passed, 1 skipped**; ruff + mypy clean; doctests pass.