### PR TITLE
feat: multi-asset book report (per-asset contribution & turnover)

### DIFF
--- a/fynance/plot/__init__.py
+++ b/fynance/plot/__init__.py
@@ -12,6 +12,7 @@ API the notebook workflow and the optional Streamlit app both build on.
 """
 
 # Local packages
+from .attribution import plot_contribution, plot_turnover
 from .equity import plot_drawdown, plot_equity
 from .returns import plot_returns_hist, plot_rolling_sharpe
 from .tearsheet import tearsheet, tearsheet_text
@@ -21,6 +22,8 @@ __all__ = [
     'plot_drawdown',
     'plot_returns_hist',
     'plot_rolling_sharpe',
+    'plot_contribution',
+    'plot_turnover',
     'tearsheet',
     'tearsheet_text',
 ]

--- a/fynance/plot/attribution.py
+++ b/fynance/plot/attribution.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Per-asset attribution figures for a multi-asset book. """
+
+from __future__ import annotations
+
+# Built-in packages
+from typing import Any
+
+# Third-party packages
+import numpy as np
+
+__all__ = ['plot_contribution', 'plot_turnover']
+
+
+def _as_book(arr: Any) -> np.ndarray:
+    """ Coerce to a 2-D ``(T, N)`` book (a 1-D series becomes a single column). """
+    a = np.asarray(arr, dtype=np.float64)
+
+    return a if a.ndim == 2 else a.reshape(a.shape[0], -1)
+
+
+def plot_contribution(asset_returns: Any, index: Any = None, ax: Any = None) -> Any:
+    """ Plot the cumulative per-asset gross contribution of a book.
+
+    ``asset_returns`` is the per-asset gross return book ``(T, N)`` (each column
+    is one asset's contribution; together they sum to the book gross return). The
+    cumulative sum per asset shows how much each asset added to the book over
+    time. Returns the matplotlib ``Axes``.
+    """
+    import matplotlib.pyplot as plt
+
+    cum = np.cumsum(_as_book(asset_returns), axis=0)
+    x = range(cum.shape[0]) if index is None else index
+
+    if ax is None:
+        _, ax = plt.subplots()
+
+    for i in range(cum.shape[1]):
+        ax.plot(x, cum[:, i], lw=1.2, label=f"asset {i}")
+    ax.set_title("Per-asset contribution (cumulative gross)")
+    ax.set_ylabel("Cumulative return")
+    ax.grid(alpha=0.3)
+    ax.legend(loc="best", fontsize=8, ncol=2)
+
+    return ax
+
+
+def plot_turnover(positions: Any, index: Any = None, ax: Any = None) -> Any:
+    """ Plot the per-asset turnover ``|Δ position|`` of a book.
+
+    ``positions`` is the position book ``(T, N)``; the turnover at each step is
+    the absolute change in position per asset (the first step charges entry from
+    flat, matching the cost model). Returns the matplotlib ``Axes``.
+    """
+    import matplotlib.pyplot as plt
+
+    pos = _as_book(positions)
+    turn = np.abs(np.diff(pos, axis=0, prepend=np.zeros((1, pos.shape[1]))))
+    x = range(turn.shape[0]) if index is None else index
+
+    if ax is None:
+        _, ax = plt.subplots()
+
+    for i in range(turn.shape[1]):
+        ax.plot(x, turn[:, i], lw=1.0, label=f"asset {i}")
+    ax.set_title("Per-asset turnover")
+    ax.set_ylabel("|Δ position|")
+    ax.grid(alpha=0.3)
+    ax.legend(loc="best", fontsize=8, ncol=2)
+
+    return ax

--- a/fynance/plot/tearsheet.py
+++ b/fynance/plot/tearsheet.py
@@ -8,8 +8,12 @@ from __future__ import annotations
 # Built-in packages
 from typing import Any
 
+# Third-party packages
+import numpy as np
+
 # Local packages
 from fynance.plot._helpers import as_equity
+from fynance.plot.attribution import plot_contribution, plot_turnover
 from fynance.plot.equity import plot_drawdown, plot_equity
 from fynance.plot.returns import plot_rolling_sharpe
 
@@ -52,8 +56,20 @@ def tearsheet(result: Any, period: int = 252, figsize: tuple = (11, 7)) -> Any:
     """
     import matplotlib.pyplot as plt
 
-    fig = plt.figure(figsize=figsize)
-    gs = fig.add_gridspec(2, 2)
+    # A multi-asset book carries per-asset attribution: add a contribution and a
+    # turnover panel below the core 2x2 report (single-asset stays a 2x2).
+    asset_gross = getattr(result, "asset_gross_returns", None)
+    positions = getattr(result, "positions", None)
+    index = getattr(result, "index", None)
+    is_book = (
+        asset_gross is not None
+        and np.asarray(asset_gross).ndim == 2
+        and np.asarray(asset_gross).shape[1] > 1
+    )
+
+    n_rows = 3 if is_book else 2
+    fig = plt.figure(figsize=(figsize[0], figsize[1] * (1.4 if is_book else 1.0)))
+    gs = fig.add_gridspec(n_rows, 2)
 
     plot_equity(result, ax=fig.add_subplot(gs[0, 0]))
     plot_drawdown(result, ax=fig.add_subplot(gs[0, 1]))
@@ -69,6 +85,11 @@ def tearsheet(result: Any, period: int = 252, figsize: tuple = (11, 7)) -> Any:
     table.set_fontsize(9)
     table.scale(1.0, 1.3)
     ax_table.set_title("Summary")
+
+    if is_book:
+        plot_contribution(asset_gross, index=index, ax=fig.add_subplot(gs[2, 0]))
+        if positions is not None and np.asarray(positions).ndim == 2:
+            plot_turnover(positions, index=index, ax=fig.add_subplot(gs[2, 1]))
 
     fig.tight_layout()
 

--- a/fynance/research/report.py
+++ b/fynance/research/report.py
@@ -55,7 +55,10 @@ def _provenance_table(spec: dict | None) -> str:
         span = ""
         if data.get("start") is not None or data.get("end") is not None:
             span = f" ({data.get('start')} → {data.get('end')})"
-        rows.append(("data", f"{data.get('kind')} · n={data.get('n')}{span}"))
+        n_assets = data.get("n_assets")
+        assets = f" · {n_assets} assets" if n_assets and n_assets > 1 else ""
+        rows.append(
+            ("data", f"{data.get('kind')} · n={data.get('n')}{assets}{span}"))
         if data.get("desc"):
             rows.append(("data desc", str(data["desc"])))
     elif data is not None:
@@ -97,15 +100,23 @@ def _write_png(experiment: Experiment, png_path: Path, period: int) -> bool:
     from fynance.plot import tearsheet
 
     equity = np.asarray(experiment.series["equity"], dtype=float)
-    # Duck-type a result carrying both the curve and its dates so the plot layer
-    # (via as_equity) draws against real dates; fall back to the bare curve (bar
-    # numbers) when the experiment has no datetime index.
-    result: Any = equity
+    # Duck-type a result carrying the curve, its dates and (for a multi-asset
+    # book) the per-asset attribution, so the plot layer draws against real dates
+    # and the tearsheet adds the book panels. Fall back to the bare curve (bar
+    # numbers, no book panels) when those are absent.
+    ns: dict[str, Any] = {"equity": equity}
     date_index = experiment.series.get("index")
     if date_index:
         index = np.asarray(date_index, dtype="datetime64[ns]")
         if index.shape[0] == equity.shape[0]:
-            result = SimpleNamespace(equity=equity, index=index)
+            ns["index"] = index
+    asset_contrib = experiment.series.get("asset_contrib")
+    if asset_contrib:
+        ns["asset_gross_returns"] = np.asarray(asset_contrib, dtype=float)
+    book_positions = experiment.series.get("positions")
+    if book_positions:
+        ns["positions"] = np.asarray(book_positions, dtype=float)
+    result: Any = SimpleNamespace(**ns) if len(ns) > 1 else equity
     fig = tearsheet(result, period=period)
     fig.savefig(png_path, dpi=110, bbox_inches="tight")
     plt.close(fig)

--- a/fynance/research/runner.py
+++ b/fynance/research/runner.py
@@ -245,6 +245,10 @@ def run_experiment(
     asset_contrib = getattr(result, "asset_gross_returns", None)
     if asset_contrib is not None:
         series["asset_contrib"] = np.asarray(asset_contrib, dtype=float).tolist()
+        # Persist the position book too so the report can show per-asset turnover.
+        book_positions = np.asarray(result.positions, dtype=float)
+        if book_positions.ndim == 2:
+            series["positions"] = book_positions.tolist()
 
     experiment = Experiment(
         name=name,

--- a/fynance/tests/plot/test_attribution.py
+++ b/fynance/tests/plot/test_attribution.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for per-asset attribution figures and the book tearsheet. """
+
+# Built-in packages
+from types import SimpleNamespace
+
+# Third-party packages
+import matplotlib
+import numpy as np
+
+matplotlib.use("Agg")
+
+# Local packages
+from fynance.plot import plot_contribution, plot_turnover, tearsheet
+
+
+def _book_result(n=120, n_assets=3, seed=0):
+    """ A duck-typed multi-asset BacktestResult-like object. """
+    rng = np.random.default_rng(seed)
+    asset_gross = rng.normal(0.0, 0.01, (n, n_assets))
+    gross = asset_gross.sum(axis=1)
+    equity = np.cumprod(1.0 + gross)
+    positions = rng.choice([-1.0, 0.0, 1.0], size=(n, n_assets))
+
+    return SimpleNamespace(
+        equity=equity, returns=gross, gross_returns=gross,
+        positions=positions, asset_gross_returns=asset_gross, index=None,
+    )
+
+
+def test_plot_contribution_is_cumulative_per_asset():
+    asset = np.array([[0.01, -0.02], [0.03, 0.01]])
+    ax = plot_contribution(asset)
+    lines = ax.get_lines()
+    assert len(lines) == 2
+    # The last cumulative value of each line is that asset's total contribution.
+    assert np.isclose(lines[0].get_ydata()[-1], asset[:, 0].sum())
+    assert np.isclose(lines[1].get_ydata()[-1], asset[:, 1].sum())
+
+
+def test_plot_turnover_charges_entry_from_flat():
+    pos = np.array([[1.0, 0.0], [1.0, 1.0], [0.0, 1.0]])
+    ax = plot_turnover(pos)
+    lines = ax.get_lines()
+    assert len(lines) == 2
+    # Asset 0: |1-0|, |1-1|, |0-1| = 1, 0, 1 (first step is entry from flat).
+    assert np.allclose(lines[0].get_ydata(), [1.0, 0.0, 1.0])
+
+
+def test_tearsheet_book_adds_attribution_panels():
+    fig = tearsheet(_book_result())
+    # 2x2 core report + contribution + turnover = 6 axes.
+    assert len(fig.axes) == 6
+    titles = " ".join(ax.get_title().lower() for ax in fig.axes)
+    assert "contribution" in titles
+    assert "turnover" in titles
+
+
+def test_tearsheet_single_asset_stays_2x2():
+    equity = np.cumprod(1.0 + np.random.default_rng(0).normal(0.0, 0.01, 100))
+    fig = tearsheet(equity)
+    assert len(fig.axes) == 4

--- a/fynance/tests/research/test_report.py
+++ b/fynance/tests/research/test_report.py
@@ -131,3 +131,32 @@ def test_tearsheet_plots_dates_for_indexed_curve():
 
     assert np.issubdtype(xdata.dtype, np.datetime64)
     assert isinstance(ax.xaxis.get_major_locator(), mdates.AutoDateLocator)
+
+
+@pytest.fixture
+def panel_experiment():
+    """ A real multi-asset (panel) experiment. """
+    rng = np.random.default_rng(7)
+    prices = 100.0 * np.cumprod(1.0 + rng.normal(0.0003, 0.01, (300, 3)), axis=0)
+
+    def panel_momentum(p):
+        r = np.zeros_like(p)
+        r[1:] = np.sign(p[1:] - p[:-1])
+        return r
+
+    strat = Strategy(features=panel_momentum, signal=lambda x: x)
+
+    return run_experiment(strat, prices, name="panel")
+
+
+def test_report_book_writes_attribution(tmp_path, panel_experiment):
+    # A panel experiment persists per-asset attribution; the tearsheet PNG is
+    # written and the provenance table records the asset count.
+    assert "asset_contrib" in panel_experiment.series
+
+    out = write_report(panel_experiment, tmp_path, notebook=False)
+    png = tmp_path / "panel" / "tearsheet.png"
+
+    assert out["png"] == png and png.is_file() and png.stat().st_size > 0
+    text = (tmp_path / "panel" / "report.md").read_text()
+    assert "3 assets" in text


### PR DESCRIPTION
Leaf 05 (final) of the multi-asset/panel epic (depends on #218, the panel walk-forward + attribution).

## Summary
A multi-asset run now gets a **book tearsheet**: the aggregated equity / drawdown / rolling-Sharpe panels plus two new **per-asset panels** — cumulative **contribution** (from `BacktestResult.asset_gross_returns`, which sum to the book gross return) and **turnover** (`|Δposition|` per asset). Single-asset reports are **unchanged** (2x2 grid, no book panels).

- **New `fynance/plot/attribution.py`** — `plot_contribution`, `plot_turnover` (matplotlib imported lazily inside the functions, so `import fynance` stays matplotlib-free).
- **`tearsheet()`** detects a book (`asset_gross_returns` present, `N > 1`) and adds a third panel row; otherwise the existing 2x2.
- **`write_report`** reconstructs the book from the persisted series (`asset_contrib` + `positions`) and shows the asset count in the provenance table.

## Test plan
- New tests: `plot_contribution` cumulative-per-asset, `plot_turnover` entry-from-flat, `tearsheet` book → 6 axes with contribution/turnover panels, single-asset → 4 axes; `write_report` on a panel experiment writes the PNG and the provenance shows "3 assets".
- `import fynance` stays matplotlib-free (existing test).
- Full suite: **946 passed, 1 skipped**; ruff + mypy clean; doctests pass.