### PR TITLE
docs: close out multi-asset/panel epic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Multi-asset / panel research harness.** `ObjectiveModel` trains a position
+  **book** `(T, N)` from a panel `X` `(T, N, M)` (or `(T, N·M)`) with a per-asset
+  target `y` `(T, N)`, scored on the aggregated book objective; `Strategy.run`/
+  `run_walk_forward` and `run_experiment` accept a `(T, N)` panel, stitch a
+  per-asset book and return a book equity with per-asset attribution
+  (`BacktestResult.asset_gross_returns`); the book tearsheet adds per-asset
+  **contribution** and **turnover** panels. The single-asset `N=1` path is
+  numerically unchanged throughout.
+- **`information_coefficient`** (rank-IC / Pearson; cross-sectional per bar or
+  per-asset time-series) and **`horizon_returns`** (non-overlapping forward
+  labels) — a predict-then-rule guardrail to gauge signal quality before trading.
+- **`RankingLoss`** — a differentiable cross-sectional long-short ranking loss.
+
 ### Changed
+
+- **Ratio losses are book-aware.** `SharpeLoss`/`SortinoLoss`/`CalmarLoss`/
+  `OmegaLoss` aggregate a 2-D `(T, N)` position book to the 1-D book return
+  (`Σ_i posᵢ·rᵢ`) before scoring; 1-D and `(T, 1)` inputs are numerically
+  unchanged.
 
 ### Fixed
 

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -72,6 +72,37 @@ Template:
 
 <!-- new entries below, newest first -->
 
+### 2026-06-23 — Multi-asset / panel R&D harness (PRs #215–#219, epic)  [accepted]
+
+Took the research harness from single-asset to **multi-pair**: a model predicts a
+position **book** `(T, N)`, a rule allocates, the book is backtested and reported
+with per-asset attribution. Five atomic leaves: #216 (IC), #215 (`ObjectiveModel`
+panel), #217 (book-aware losses), #218 (walk-forward + attribution), #219 (book
+report). Test count 946 (with doctests). Decisions worth recording:
+
+- **Book aggregation lives in the model *and* (additively) in the losses.**
+  `ObjectiveModel` sums the per-asset net returns to the 1-D book return before
+  the loss, so the existing 1-D losses keep working unchanged; the ratio losses
+  were *also* made book-aware (sum a `(T, N)` input across assets) so a custom
+  architecture can feed per-asset returns directly. Both reduce to the same
+  scalar, and `(T, 1)`/1-D are bit-identical to before (verified: `N=1`
+  max-abs-diff `0.0`).
+- **A 3-D panel `X (T, N, M)` is flattened to `(T, N·M)`** for the default dense
+  net, with `N` remembered for the `Linear(dim, N)` head; a custom `net=` receives
+  the flattened matrix (3-D pass-through to a custom net is deferred).
+- **Per-asset attribution is gross-contribution only.** `BacktestResult`
+  carries an optional `asset_gross_returns` `(T, N)` (summing to the book gross
+  return); the cost model already returns book-aggregated turnover, so per-asset
+  *net* costs are not split — turnover is shown per asset from the position book.
+  `None` for a single-asset run (strict back-compat).
+- **IC defaults to cross-sectional-per-bar** for a `(T, N)` panel (the ranking
+  use-case; `axis=1` gives the per-asset time-series IC), and **horizon labels are
+  non-overlapping by default** (overlapping H-bar labels inflate the IC).
+- **Rejected alternatives**: re-touching `ObjectiveModel` to pass per-asset returns
+  to the loss (kept the model's pre-aggregation, made losses additively book-aware
+  instead); extending `BacktestResult` with per-asset *net* costs (out of scope —
+  the cost model is book-level).
+
 ### 2026-06-22 — Audit round 2: regression + residual bugs (PRs #201–#207, v2.10.1)  [accepted]
 
 A second audit pass after v2.10.0 caught **one regression** the first remediation

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -23,7 +23,14 @@ so an agent doesn't re-investigate settled ground or assume a known stub is a bu
   management (`iso_vol`), feature engineering (multi-resolution, Granger,
   incremental moments) and k-means market-regime detection.
 - **Metrics**: `fynance.metrics` (Sharpe/Sortino/Calmar/diversified-ratio,
-  annual return/vol, drawdown/mdd, perf_*, roll_*) + one-call `summary`.
+  annual return/vol, drawdown/mdd, perf_*, roll_*, **`information_coefficient`**
+  rank-IC) + one-call `summary`.
+- **Multi-asset / panel harness**: `ObjectiveModel` trains a position book
+  `(T, N)` from a panel `X`; book-aware ratio losses + `RankingLoss`;
+  `Strategy`/`run_walk_forward`/`run_experiment` accept a `(T, N)` panel and return
+  a book equity with per-asset attribution (`BacktestResult.asset_gross_returns`);
+  `horizon_returns` non-overlapping labels; book tearsheet (per-asset contribution
+  + turnover). The single-asset `N=1` path is unchanged.
 - **Models**: econometric (ARMA/GARCH) + neural (MLP, RNN/GRU/LSTM, attention,
   TCN, Transformer) on PyTorch; `StackingEnsemble` (direction+magnitude OOF
   meta-model); **`RegimeMoE`** (regime-conditioned mixture-of-experts — an

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -12,14 +12,18 @@ shipped, `03-decisions.md` for *why*. Keep it short and true.
 > Loop : `/pick-task` → `/plan` (arbre dans `plans/`) → `/execute-leaf` →
 > `/finish-task`. Release : `/release` quand `[Unreleased]` est suffisamment rempli.
 
-> **fynance 2.x livré** (v2.9.0 sur `master`/PyPI). Le refactor en couches, le port
+> **fynance 2.x livré** (v2.10.2 sur `master`/PyPI). Le refactor en couches, le port
 > Cython→Numba (build pure-Python), le harnais R&D `fynance.research` (S1–S3), la
 > brique d'entraînement aligné-objectif (`ObjectiveModel`) et les **bricks de
 > librairie** (conteneur `OHLCV` + indicateurs ATR/ADX/Williams %R/OBV/VWAP, feature
 > GARCH causale, `RegimeMoE`, fenêtres adaptatives, coût market-impact non-linéaire)
 > sont **terminés** — voir `CHANGELOG.md` / `03-decisions.md`. Deux passages d'audit (2026-06-22) ont été **entièrement remédiés** : 9 PR
 > (#188–#196, v2.10.0) puis 7 PR (#201–#207, v2.10.1, dont une régression KPI).
-> Voir `CHANGELOG.md` / `03-decisions.md`. Il ne reste que l'item optionnel ci-dessous.
+> Voir `CHANGELOG.md` / `03-decisions.md`. L'épic **harnais R&D multi-actifs /
+> panel** (2026-06-23) est **livré** : 5 PR (#215–#219) — `ObjectiveModel` panel,
+> losses book-aware + `RankingLoss`, `information_coefficient`/`horizon_returns`,
+> walk-forward + attribution par actif, report de book. Il ne reste que l'item
+> optionnel ci-dessous.
 
 > ⚠️ **Hors scope ici** : la recherche de stratégie sur **vraie data** (benchmarks
 > empiriques loss / architecture / normalisation, évaluation Sharpe out-of-sample,
@@ -38,49 +42,3 @@ Le harnais `fynance.research` est **livré** (S1–S3) : `Experiment`,
 
 - [ ] Explorateur **Streamlit** au-dessus du Ledger (parcourir / filtrer / comparer
   les runs persistés) — interactif, plus tardif.
-
-## 3. Harnais R&D multi-actifs / panel (signalé à l'usage par `fynance-research`)
-
-`fynance-research` passe du mono-actif (ETH/BTC) à des stratégies **multi-pair** : un
-modèle qui voit `N` paires × `M` features, prédit **signal + magnitude par paire à `H`
-horizons**, puis une **règle** (allocation / ranking) décide quoi long/short. Audit du
-harnais : le **moteur de backtest gère déjà un book** `(T, N)` (`backtest/engine.py`,
-`gross.sum(axis=1)`) et l'**allocation** est livrée (`portfolio.allocation` :
-`ERC/HRP/IVP/MVP/MDP` + `rolling_allocation` ; `portfolio.sizing` : `vol_target`,
-`kelly_fraction`). **Mais toute la couche R&D au-dessus est câblée mono-actif** — c'est le
-blocage. Tâches ordonnées par dépendance ; rétro-compat mono-actif (`N=1`) à préserver.
-
-- [ ] **`ObjectiveModel` — entraînement panel (le cœur de l'enabler).** Aujourd'hui
-  `fit(X (T,F), y (T,))`, `out = net(X).reshape(-1)`, `predict → (-1, 1)` : une seule
-  colonne de position. Le rendre capable de consommer `X` panel `(T, N, M)` (ou `(T, N·M)`)
-  et de sortir un **book de positions** `(T, N)`, avec cible `y` panel `(T, N)` voire
-  multi-horizon `(T, N, H)`. Sans ça, aucun modèle cross-actifs n'est entraînable.
-- [ ] **Losses book-aware (objectif = portefeuille).** Les `*Loss` (`SharpeLoss`,
-  `Sortino`, `Calmar`, …) sont calculées sur un return 1-D. Les rendre capables d'agréger
-  le **return du book** `Σ_i pos_i·r_i − coût` avant de scorer, pour qu'on entraîne sur la
-  perf du portefeuille et non d'un actif. Ajouter (optionnel) une **loss cross-sectionnelle
-  / ranking** différentiable (long top-k vs bottom-k) pour la tête de prédiction. Dépend du
-  1er item.
-- [ ] **Walk-forward + `run_experiment` multi-actifs.** `Strategy.run` /
-  `run_walk_forward(data, y, …)` et `run_experiment` supposent une série de prix unique
-  (`n = prices.shape[0]`, une equity, un tearsheet). Accepter `data` **panel** `(T, N)`
-  (returns/prix), stitcher un **book OOS**, backtester via le moteur book (déjà OK) et
-  renvoyer une **equity de book + attribution par actif**. `run_experiment` : chemin panel
-  + provenance (X 3-D, `N` actifs). Dépend du 1er item.
-- [ ] **Métrique Information Coefficient / rank-IC + cible multi-horizon.** `fynance.metrics`
-  n'a aucune corrélation prédiction↔réalisé. Ajouter `information_coefficient` (Spearman de
-  rang, **par horizon**) en évaluation **non-chevauchante** (les labels à `H` barres se
-  chevauchent → sinon la skill est surestimée). C'est le **garde-fou predict-then-rule** :
-  mesurer la qualité du signal OOS *avant* tout trade, pour distinguer « signal mort »
-  (IC≈0) de « signal vivant mangé par les frais / la règle » (IC>0, PnL<0). Optionnel :
-  helper `horizon_returns` panel côté `research` / `features`. Indépendant (métrique pure).
-- [ ] **Report / tearsheet de book.** Étendre `write_report` + tearsheet (l'axe temporel en
-  dates vient d'atterrir, `feat/tearsheet-date-axis`) pour un run multi-actifs : equity
-  agrégée + contribution & turnover **par actif**. Dépend du walk-forward panel.
-
-> **Reste côté `fynance-research` (thin, pas ici).** Le réseau bespoke (transformer axial :
-> attention temporelle causale + attention cross-actifs) vit dans
-> `fynance-research/strategies/nets.py` et ne consomme que le harnais ci-dessus ; les règles
-> A/B/C (trend diversifié, cross-sectionnel, stat-arb cointégration) sont des modules
-> stratégie. *Si* la brique d'attention cross-sectionnelle s'avère réutilisable et
-> data-agnostique, elle pourra remonter en modèle de librairie — à trancher à l'usage.


### PR DESCRIPTION
Central closeout for the **multi-asset / panel** epic (leaves #215–#219, all merged).

- **CHANGELOG** `[Unreleased]` filled: panel `ObjectiveModel`/`Strategy`/`run_experiment` + per-asset attribution + book tearsheet (Added), `information_coefficient`/`horizon_returns`/`RankingLoss` (Added), book-aware ratio losses (Changed).
- **ADR** (`03-decisions.md`): records the epic's decisions — book aggregation in model *and* losses, `X` flattening, gross-only attribution, IC cross-sectional default, `N=1` bit-identity.
- **Roadmap**: §3 dropped (shipped); intro note updated.
- **Status**: panel harness + `information_coefficient` added to "Done".
- Local plan tree archived.

## Test plan
Docs-only. The epic's code (all green across #215–#219) is already on `develop`: 946 passed, 1 skipped; ruff + mypy + Sphinx -W clean.