### PR TITLE
chore: release v2.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [2.11.0] - 2026-06-23
+
+### Breaking Changes
+
+### Added
+
 - **Multi-asset / panel research harness.** `ObjectiveModel` trains a position
   **book** `(T, N)` from a panel `X` `(T, N, M)` (or `(T, N·M)`) with a per-asset
   target `y` `(T, N)`, scored on the aggregated book objective; `Strategy.run`/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fynance"
-version = "2.10.2"
+version = "2.11.0"
 description = "Pure-Python (Numba-accelerated) machine learning, econometrics and statistical tools for financial analysis and backtesting"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Release **v2.11.0** (minor — multi-asset / panel R&D harness epic).

### Added
- Multi-asset / panel research harness: panel `ObjectiveModel` (book `(T, N)`), panel `Strategy`/`run_experiment` with per-asset attribution, book tearsheet (contribution + turnover). (#215, #218, #219)
- `information_coefficient` (rank-IC) + `horizon_returns` predict-then-rule guardrail. (#216)
- `RankingLoss` differentiable cross-sectional long-short loss. (#217)

### Changed
- Ratio losses (`Sharpe`/`Sortino`/`Calmar`/`Omega`) are book-aware (aggregate a `(T, N)` book to the 1-D book return); 1-D / `(T, 1)` unchanged. (#217)

Single-asset `N=1` behaviour is numerically unchanged throughout.

## Test plan
CI green on all five leaves + closeout; 946 passed, 1 skipped; ruff + mypy + Sphinx -W clean.