### PR TITLE
Release v2.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [2.11.0] - 2026-06-23
+
+### Breaking Changes
+
+### Added
+
 - **Multi-asset / panel research harness.** `ObjectiveModel` trains a position
   **book** `(T, N)` from a panel `X` `(T, N, M)` (or `(T, N·M)`) with a per-asset
   target `y` `(T, N)`, scored on the aggregated book objective; `Strategy.run`/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Multi-asset / panel research harness.** `ObjectiveModel` trains a position
+  **book** `(T, N)` from a panel `X` `(T, N, M)` (or `(T, N·M)`) with a per-asset
+  target `y` `(T, N)`, scored on the aggregated book objective; `Strategy.run`/
+  `run_walk_forward` and `run_experiment` accept a `(T, N)` panel, stitch a
+  per-asset book and return a book equity with per-asset attribution
+  (`BacktestResult.asset_gross_returns`); the book tearsheet adds per-asset
+  **contribution** and **turnover** panels. The single-asset `N=1` path is
+  numerically unchanged throughout.
+- **`information_coefficient`** (rank-IC / Pearson; cross-sectional per bar or
+  per-asset time-series) and **`horizon_returns`** (non-overlapping forward
+  labels) — a predict-then-rule guardrail to gauge signal quality before trading.
+- **`RankingLoss`** — a differentiable cross-sectional long-short ranking loss.
+
 ### Changed
+
+- **Ratio losses are book-aware.** `SharpeLoss`/`SortinoLoss`/`CalmarLoss`/
+  `OmegaLoss` aggregate a 2-D `(T, N)` position book to the 1-D book return
+  (`Σ_i posᵢ·rᵢ`) before scoring; 1-D and `(T, 1)` inputs are numerically
+  unchanged.
 
 ### Fixed
 

--- a/badges/interrogate_badge.svg
+++ b/badges/interrogate_badge.svg
@@ -1,5 +1,5 @@
 <svg width="140" height="20" viewBox="0 0 140 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <title>interrogate: 94.7%</title>
+    <title>interrogate: 94.8%</title>
     <g transform="matrix(1,0,0,1,22,0)">
         <g id="backgrounds" transform="matrix(1.32789,0,0,1,-22.3892,0)">
             <rect x="0" y="0" width="71" height="20" style="fill:rgb(85,85,85);"/>
@@ -12,8 +12,8 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
         <text x="590" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="610">interrogate</text>
         <text x="590" y="140" transform="scale(.1)" textLength="610">interrogate</text>
-        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">94.7%</text>
-        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">94.7%</text>
+        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">94.8%</text>
+        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">94.8%</text>
     </g>
     <g id="logo-shadow" serif:id="logo shadow" transform="matrix(0.854876,0,0,0.854876,-6.73514,1.732)">
         <g transform="matrix(0.299012,0,0,0.299012,9.70229,-6.68582)">

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -72,6 +72,37 @@ Template:
 
 <!-- new entries below, newest first -->
 
+### 2026-06-23 — Multi-asset / panel R&D harness (PRs #215–#219, epic)  [accepted]
+
+Took the research harness from single-asset to **multi-pair**: a model predicts a
+position **book** `(T, N)`, a rule allocates, the book is backtested and reported
+with per-asset attribution. Five atomic leaves: #216 (IC), #215 (`ObjectiveModel`
+panel), #217 (book-aware losses), #218 (walk-forward + attribution), #219 (book
+report). Test count 946 (with doctests). Decisions worth recording:
+
+- **Book aggregation lives in the model *and* (additively) in the losses.**
+  `ObjectiveModel` sums the per-asset net returns to the 1-D book return before
+  the loss, so the existing 1-D losses keep working unchanged; the ratio losses
+  were *also* made book-aware (sum a `(T, N)` input across assets) so a custom
+  architecture can feed per-asset returns directly. Both reduce to the same
+  scalar, and `(T, 1)`/1-D are bit-identical to before (verified: `N=1`
+  max-abs-diff `0.0`).
+- **A 3-D panel `X (T, N, M)` is flattened to `(T, N·M)`** for the default dense
+  net, with `N` remembered for the `Linear(dim, N)` head; a custom `net=` receives
+  the flattened matrix (3-D pass-through to a custom net is deferred).
+- **Per-asset attribution is gross-contribution only.** `BacktestResult`
+  carries an optional `asset_gross_returns` `(T, N)` (summing to the book gross
+  return); the cost model already returns book-aggregated turnover, so per-asset
+  *net* costs are not split — turnover is shown per asset from the position book.
+  `None` for a single-asset run (strict back-compat).
+- **IC defaults to cross-sectional-per-bar** for a `(T, N)` panel (the ranking
+  use-case; `axis=1` gives the per-asset time-series IC), and **horizon labels are
+  non-overlapping by default** (overlapping H-bar labels inflate the IC).
+- **Rejected alternatives**: re-touching `ObjectiveModel` to pass per-asset returns
+  to the loss (kept the model's pre-aggregation, made losses additively book-aware
+  instead); extending `BacktestResult` with per-asset *net* costs (out of scope —
+  the cost model is book-level).
+
 ### 2026-06-22 — Audit round 2: regression + residual bugs (PRs #201–#207, v2.10.1)  [accepted]
 
 A second audit pass after v2.10.0 caught **one regression** the first remediation

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -23,7 +23,14 @@ so an agent doesn't re-investigate settled ground or assume a known stub is a bu
   management (`iso_vol`), feature engineering (multi-resolution, Granger,
   incremental moments) and k-means market-regime detection.
 - **Metrics**: `fynance.metrics` (Sharpe/Sortino/Calmar/diversified-ratio,
-  annual return/vol, drawdown/mdd, perf_*, roll_*) + one-call `summary`.
+  annual return/vol, drawdown/mdd, perf_*, roll_*, **`information_coefficient`**
+  rank-IC) + one-call `summary`.
+- **Multi-asset / panel harness**: `ObjectiveModel` trains a position book
+  `(T, N)` from a panel `X`; book-aware ratio losses + `RankingLoss`;
+  `Strategy`/`run_walk_forward`/`run_experiment` accept a `(T, N)` panel and return
+  a book equity with per-asset attribution (`BacktestResult.asset_gross_returns`);
+  `horizon_returns` non-overlapping labels; book tearsheet (per-asset contribution
+  + turnover). The single-asset `N=1` path is unchanged.
 - **Models**: econometric (ARMA/GARCH) + neural (MLP, RNN/GRU/LSTM, attention,
   TCN, Transformer) on PyTorch; `StackingEnsemble` (direction+magnitude OOF
   meta-model); **`RegimeMoE`** (regime-conditioned mixture-of-experts — an

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -12,14 +12,18 @@ shipped, `03-decisions.md` for *why*. Keep it short and true.
 > Loop : `/pick-task` → `/plan` (arbre dans `plans/`) → `/execute-leaf` →
 > `/finish-task`. Release : `/release` quand `[Unreleased]` est suffisamment rempli.
 
-> **fynance 2.x livré** (v2.9.0 sur `master`/PyPI). Le refactor en couches, le port
+> **fynance 2.x livré** (v2.10.2 sur `master`/PyPI). Le refactor en couches, le port
 > Cython→Numba (build pure-Python), le harnais R&D `fynance.research` (S1–S3), la
 > brique d'entraînement aligné-objectif (`ObjectiveModel`) et les **bricks de
 > librairie** (conteneur `OHLCV` + indicateurs ATR/ADX/Williams %R/OBV/VWAP, feature
 > GARCH causale, `RegimeMoE`, fenêtres adaptatives, coût market-impact non-linéaire)
 > sont **terminés** — voir `CHANGELOG.md` / `03-decisions.md`. Deux passages d'audit (2026-06-22) ont été **entièrement remédiés** : 9 PR
 > (#188–#196, v2.10.0) puis 7 PR (#201–#207, v2.10.1, dont une régression KPI).
-> Voir `CHANGELOG.md` / `03-decisions.md`. Il ne reste que l'item optionnel ci-dessous.
+> Voir `CHANGELOG.md` / `03-decisions.md`. L'épic **harnais R&D multi-actifs /
+> panel** (2026-06-23) est **livré** : 5 PR (#215–#219) — `ObjectiveModel` panel,
+> losses book-aware + `RankingLoss`, `information_coefficient`/`horizon_returns`,
+> walk-forward + attribution par actif, report de book. Il ne reste que l'item
+> optionnel ci-dessous.
 
 > ⚠️ **Hors scope ici** : la recherche de stratégie sur **vraie data** (benchmarks
 > empiriques loss / architecture / normalisation, évaluation Sharpe out-of-sample,
@@ -38,49 +42,3 @@ Le harnais `fynance.research` est **livré** (S1–S3) : `Experiment`,
 
 - [ ] Explorateur **Streamlit** au-dessus du Ledger (parcourir / filtrer / comparer
   les runs persistés) — interactif, plus tardif.
-
-## 3. Harnais R&D multi-actifs / panel (signalé à l'usage par `fynance-research`)
-
-`fynance-research` passe du mono-actif (ETH/BTC) à des stratégies **multi-pair** : un
-modèle qui voit `N` paires × `M` features, prédit **signal + magnitude par paire à `H`
-horizons**, puis une **règle** (allocation / ranking) décide quoi long/short. Audit du
-harnais : le **moteur de backtest gère déjà un book** `(T, N)` (`backtest/engine.py`,
-`gross.sum(axis=1)`) et l'**allocation** est livrée (`portfolio.allocation` :
-`ERC/HRP/IVP/MVP/MDP` + `rolling_allocation` ; `portfolio.sizing` : `vol_target`,
-`kelly_fraction`). **Mais toute la couche R&D au-dessus est câblée mono-actif** — c'est le
-blocage. Tâches ordonnées par dépendance ; rétro-compat mono-actif (`N=1`) à préserver.
-
-- [ ] **`ObjectiveModel` — entraînement panel (le cœur de l'enabler).** Aujourd'hui
-  `fit(X (T,F), y (T,))`, `out = net(X).reshape(-1)`, `predict → (-1, 1)` : une seule
-  colonne de position. Le rendre capable de consommer `X` panel `(T, N, M)` (ou `(T, N·M)`)
-  et de sortir un **book de positions** `(T, N)`, avec cible `y` panel `(T, N)` voire
-  multi-horizon `(T, N, H)`. Sans ça, aucun modèle cross-actifs n'est entraînable.
-- [ ] **Losses book-aware (objectif = portefeuille).** Les `*Loss` (`SharpeLoss`,
-  `Sortino`, `Calmar`, …) sont calculées sur un return 1-D. Les rendre capables d'agréger
-  le **return du book** `Σ_i pos_i·r_i − coût` avant de scorer, pour qu'on entraîne sur la
-  perf du portefeuille et non d'un actif. Ajouter (optionnel) une **loss cross-sectionnelle
-  / ranking** différentiable (long top-k vs bottom-k) pour la tête de prédiction. Dépend du
-  1er item.
-- [ ] **Walk-forward + `run_experiment` multi-actifs.** `Strategy.run` /
-  `run_walk_forward(data, y, …)` et `run_experiment` supposent une série de prix unique
-  (`n = prices.shape[0]`, une equity, un tearsheet). Accepter `data` **panel** `(T, N)`
-  (returns/prix), stitcher un **book OOS**, backtester via le moteur book (déjà OK) et
-  renvoyer une **equity de book + attribution par actif**. `run_experiment` : chemin panel
-  + provenance (X 3-D, `N` actifs). Dépend du 1er item.
-- [ ] **Métrique Information Coefficient / rank-IC + cible multi-horizon.** `fynance.metrics`
-  n'a aucune corrélation prédiction↔réalisé. Ajouter `information_coefficient` (Spearman de
-  rang, **par horizon**) en évaluation **non-chevauchante** (les labels à `H` barres se
-  chevauchent → sinon la skill est surestimée). C'est le **garde-fou predict-then-rule** :
-  mesurer la qualité du signal OOS *avant* tout trade, pour distinguer « signal mort »
-  (IC≈0) de « signal vivant mangé par les frais / la règle » (IC>0, PnL<0). Optionnel :
-  helper `horizon_returns` panel côté `research` / `features`. Indépendant (métrique pure).
-- [ ] **Report / tearsheet de book.** Étendre `write_report` + tearsheet (l'axe temporel en
-  dates vient d'atterrir, `feat/tearsheet-date-axis`) pour un run multi-actifs : equity
-  agrégée + contribution & turnover **par actif**. Dépend du walk-forward panel.
-
-> **Reste côté `fynance-research` (thin, pas ici).** Le réseau bespoke (transformer axial :
-> attention temporelle causale + attention cross-actifs) vit dans
-> `fynance-research/strategies/nets.py` et ne consomme que le harnais ci-dessus ; les règles
-> A/B/C (trend diversifié, cross-sectionnel, stat-arb cointégration) sont des modules
-> stratégie. *Si* la brique d'attention cross-sectionnelle s'avère réutilisable et
-> data-agnostique, elle pourra remonter en modèle de librairie — à trancher à l'usage.

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -38,3 +38,49 @@ Le harnais `fynance.research` est **livré** (S1–S3) : `Experiment`,
 
 - [ ] Explorateur **Streamlit** au-dessus du Ledger (parcourir / filtrer / comparer
   les runs persistés) — interactif, plus tardif.
+
+## 3. Harnais R&D multi-actifs / panel (signalé à l'usage par `fynance-research`)
+
+`fynance-research` passe du mono-actif (ETH/BTC) à des stratégies **multi-pair** : un
+modèle qui voit `N` paires × `M` features, prédit **signal + magnitude par paire à `H`
+horizons**, puis une **règle** (allocation / ranking) décide quoi long/short. Audit du
+harnais : le **moteur de backtest gère déjà un book** `(T, N)` (`backtest/engine.py`,
+`gross.sum(axis=1)`) et l'**allocation** est livrée (`portfolio.allocation` :
+`ERC/HRP/IVP/MVP/MDP` + `rolling_allocation` ; `portfolio.sizing` : `vol_target`,
+`kelly_fraction`). **Mais toute la couche R&D au-dessus est câblée mono-actif** — c'est le
+blocage. Tâches ordonnées par dépendance ; rétro-compat mono-actif (`N=1`) à préserver.
+
+- [ ] **`ObjectiveModel` — entraînement panel (le cœur de l'enabler).** Aujourd'hui
+  `fit(X (T,F), y (T,))`, `out = net(X).reshape(-1)`, `predict → (-1, 1)` : une seule
+  colonne de position. Le rendre capable de consommer `X` panel `(T, N, M)` (ou `(T, N·M)`)
+  et de sortir un **book de positions** `(T, N)`, avec cible `y` panel `(T, N)` voire
+  multi-horizon `(T, N, H)`. Sans ça, aucun modèle cross-actifs n'est entraînable.
+- [ ] **Losses book-aware (objectif = portefeuille).** Les `*Loss` (`SharpeLoss`,
+  `Sortino`, `Calmar`, …) sont calculées sur un return 1-D. Les rendre capables d'agréger
+  le **return du book** `Σ_i pos_i·r_i − coût` avant de scorer, pour qu'on entraîne sur la
+  perf du portefeuille et non d'un actif. Ajouter (optionnel) une **loss cross-sectionnelle
+  / ranking** différentiable (long top-k vs bottom-k) pour la tête de prédiction. Dépend du
+  1er item.
+- [ ] **Walk-forward + `run_experiment` multi-actifs.** `Strategy.run` /
+  `run_walk_forward(data, y, …)` et `run_experiment` supposent une série de prix unique
+  (`n = prices.shape[0]`, une equity, un tearsheet). Accepter `data` **panel** `(T, N)`
+  (returns/prix), stitcher un **book OOS**, backtester via le moteur book (déjà OK) et
+  renvoyer une **equity de book + attribution par actif**. `run_experiment` : chemin panel
+  + provenance (X 3-D, `N` actifs). Dépend du 1er item.
+- [ ] **Métrique Information Coefficient / rank-IC + cible multi-horizon.** `fynance.metrics`
+  n'a aucune corrélation prédiction↔réalisé. Ajouter `information_coefficient` (Spearman de
+  rang, **par horizon**) en évaluation **non-chevauchante** (les labels à `H` barres se
+  chevauchent → sinon la skill est surestimée). C'est le **garde-fou predict-then-rule** :
+  mesurer la qualité du signal OOS *avant* tout trade, pour distinguer « signal mort »
+  (IC≈0) de « signal vivant mangé par les frais / la règle » (IC>0, PnL<0). Optionnel :
+  helper `horizon_returns` panel côté `research` / `features`. Indépendant (métrique pure).
+- [ ] **Report / tearsheet de book.** Étendre `write_report` + tearsheet (l'axe temporel en
+  dates vient d'atterrir, `feat/tearsheet-date-axis`) pour un run multi-actifs : equity
+  agrégée + contribution & turnover **par actif**. Dépend du walk-forward panel.
+
+> **Reste côté `fynance-research` (thin, pas ici).** Le réseau bespoke (transformer axial :
+> attention temporelle causale + attention cross-actifs) vit dans
+> `fynance-research/strategies/nets.py` et ne consomme que le harnais ci-dessus ; les règles
+> A/B/C (trend diversifié, cross-sectionnel, stat-arb cointégration) sont des modules
+> stratégie. *Si* la brique d'attention cross-sectionnelle s'avère réutilisable et
+> data-agnostique, elle pourra remonter en modèle de librairie — à trancher à l'usage.

--- a/fynance/backtest/engine.py
+++ b/fynance/backtest/engine.py
@@ -96,10 +96,12 @@ def backtest(
     else:
         pos_eff = pos
 
-    gross = pos_eff * returns
+    gross_book = pos_eff * returns
 
-    if gross.ndim == 2:
-        gross = gross.sum(axis=1)
+    # For a multi-asset book the per-asset gross contributions (which sum to the
+    # book gross return) are kept as attribution before aggregating to 1-D.
+    asset_gross_returns = gross_book if gross_book.ndim == 2 else None
+    gross = gross_book.sum(axis=1) if gross_book.ndim == 2 else gross_book
 
     costs = (
         np.asarray(cost(cost_book), dtype=np.float64)
@@ -115,4 +117,5 @@ def backtest(
         gross_returns=gross,
         positions=pos,
         costs=costs,
+        asset_gross_returns=asset_gross_returns,
     )

--- a/fynance/backtest/result.py
+++ b/fynance/backtest/result.py
@@ -41,6 +41,9 @@ class BacktestResult:
         Per-step transaction costs.
     index : numpy.ndarray, optional
         Temporal index carried from the input.
+    asset_gross_returns : numpy.ndarray, optional
+        Per-asset gross return contributions ``(T, N)`` for a multi-asset book
+        (they sum to :attr:`gross_returns`); ``None`` for a single-asset run.
 
     Methods
     -------
@@ -56,6 +59,7 @@ class BacktestResult:
     positions: NDArray
     costs: NDArray
     index: NDArray | None = None
+    asset_gross_returns: NDArray | None = None
 
     def to_numpy(self) -> NDArray:
         """ Return the equity curve as a numpy array. """

--- a/fynance/features/__init__.py
+++ b/fynance/features/__init__.py
@@ -29,6 +29,7 @@ from . import (
     engineering,
     filters,
     garch,
+    horizon,
     indicators,
     momentums,
     money_management,
@@ -41,6 +42,7 @@ from . import (
 from .engineering import *
 from .filters import *
 from .garch import *
+from .horizon import *
 from .indicators import *
 from .momentums import *
 from .money_management import *
@@ -54,6 +56,7 @@ __all__ = engineering.__all__
 __all__ += regime.__all__
 __all__ += filters.__all__
 __all__ += garch.__all__
+__all__ += horizon.__all__
 __all__ += momentums.__all__
 __all__ += indicators.__all__
 __all__ += money_management.__all__

--- a/fynance/features/horizon.py
+++ b/fynance/features/horizon.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Forward horizon-return labels.
+
+Helpers to turn a price series into forward (look-ahead) return labels over a
+fixed horizon ``h``. These are the *targets* an Information Coefficient
+(:func:`fynance.metrics.information_coefficient`) is computed against. The
+non-overlapping variant (the default) is the safe choice for IC estimation:
+overlapping H-bar labels share data and inflate the apparent correlation.
+
+"""
+
+from __future__ import annotations
+
+# Built-in packages
+# Third-party packages
+import numpy as np
+from numpy.typing import NDArray
+
+# Local packages
+
+__all__ = ['horizon_returns']
+
+
+def horizon_returns(
+    prices: NDArray,
+    h: int,
+    *,
+    overlapping: bool = False,
+) -> NDArray:
+    r""" Forward return over a fixed horizon ``h``, strictly causal.
+
+    The label at time ``t`` is the simple return realized over the next ``h``
+    steps, :math:`prices_{t+h} / prices_t - 1`. It looks *forward* (the label
+    at ``t`` is only known at ``t + h``), so it is a prediction *target*, not a
+    feature — never feed it back into the model as an input at time ``t``.
+
+    By default the labels are **non-overlapping**: one sample every ``h`` steps
+    (``t = 0, h, 2h, ...``), so no two labels share any underlying price move.
+    This matters for Information Coefficient estimation — overlapping H-bar
+    labels are autocorrelated by construction and inflate the apparent IC. Set
+    ``overlapping=True`` to get one label per bar (``t = 0, 1, 2, ...``) when
+    that autocorrelation is acceptable.
+
+    Notes
+    -----
+    With :math:`T` observations and horizon :math:`h`, the forward return is
+
+    .. math::
+
+        r^{(h)}_t = \frac{prices_{t+h}}{prices_t} - 1
+
+    defined for :math:`t + h < T`. The non-overlapping output keeps
+    :math:`t \in \{0, h, 2h, \dots\}` and has length
+    :math:`\lfloor (T - 1) / h \rfloor`; the overlapping output keeps every
+    :math:`t \in \{0, 1, \dots\}` and has length :math:`T - h`.
+
+    Parameters
+    ----------
+    prices : np.ndarray[dtype, ndim=1 or 2]
+        Time-series of prices indexed by time on the first axis. For a 2-D
+        ``(T, N)`` panel each column is an independent series.
+    h : int
+        Forward horizon in number of steps, must be a positive integer.
+    overlapping : bool, optional
+        If ``False`` (default), keep one label every ``h`` steps
+        (non-overlapping). If ``True``, keep one label per bar (overlapping).
+
+    Returns
+    -------
+    np.ndarray[np.float64, ndim=1 or 2]
+        Forward horizon returns. A 1-D input of length ``T`` yields a 1-D
+        output; a 2-D ``(T, N)`` input yields a ``(K, N)`` output where ``K`` is
+        the number of retained labels.
+
+    References
+    ----------
+    .. [1] https://en.wikipedia.org/wiki/Rate_of_return
+
+    Examples
+    --------
+    Non-overlapping 2-step forward returns (one label every 2 bars):
+
+    >>> import numpy as np
+    >>> prices = np.array([100., 110., 121., 133.1, 146.41, 161.051])
+    >>> horizon_returns(prices, 2)
+    array([0.21, 0.21])
+
+    Overlapping labels keep one per bar:
+
+    >>> horizon_returns(prices, 2, overlapping=True)
+    array([0.21, 0.21, 0.21, 0.21])
+
+    See Also
+    --------
+    fynance.metrics.information_coefficient
+
+    """
+    if not isinstance(h, (int, np.integer)) or h <= 0:
+
+        raise ValueError(f"h must be a positive integer, got {h!r}")
+
+    prices = np.asarray(prices, dtype=np.float64)
+
+    if prices.ndim not in (1, 2):
+
+        raise ValueError(
+            f"only 1-D and 2-D arrays are supported, got ndim={prices.ndim}"
+        )
+
+    T = prices.shape[0]
+
+    if T <= h:
+
+        raise ValueError(
+            f"prices must have more than h={h} observations on axis 0, got {T}"
+        )
+
+    step = h if not overlapping else 1
+    base_idx = np.arange(0, T - h, step)
+    fwd = prices[base_idx + h] / prices[base_idx] - 1.
+
+    return fwd

--- a/fynance/metrics/__init__.py
+++ b/fynance/metrics/__init__.py
@@ -15,6 +15,7 @@ Risk-adjusted ratios, return and drawdown metrics for evaluating a strategy
 import sys as _sys
 
 # Local packages
+from .correlation import *
 from .drawdown import *
 from .ratios import *
 from .returns import *
@@ -23,8 +24,12 @@ from .summary import METRICS, summary  # noqa: F401
 
 # Aggregate __all__ via sys.modules (the star imports above rebind names that
 # collide with a submodule, e.g. the ``drawdown`` function vs the module).
+# ``information_coefficient`` is exported here but intentionally NOT added to the
+# ``METRICS`` registry: that registry maps a name to a callable taking a single
+# equity/price curve (see ``summary``), whereas the IC takes an aligned
+# (pred, real) pair and so does not fit that single-series contract.
 __all__ = []
-for _m in ("returns", "ratios", "drawdown"):
+for _m in ("correlation", "returns", "ratios", "drawdown"):
     __all__ += _sys.modules[f"{__name__}.{_m}"].__all__
 __all__ += ['perf_strat', 'returns_strat', 'METRICS', 'summary']
 

--- a/fynance/metrics/correlation.py
+++ b/fynance/metrics/correlation.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Predict-vs-realize correlation metrics (Information Coefficient).
+
+The Information Coefficient (IC) is a predict-then-rule guardrail: it scores how
+well a *prediction* lines up with the *realized* outcome. Unlike the risk-adjusted
+ratios in :mod:`fynance.metrics.ratios`, which evaluate a single equity curve, the
+IC takes two aligned series (a prediction and a realization) and returns their
+correlation along the time axis.
+
+"""
+
+from __future__ import annotations
+
+# Built-in packages
+from typing import Any
+
+# Third-party packages
+import numpy as np
+from numpy.typing import NDArray
+from scipy.stats import rankdata
+
+# Local packages
+
+__all__ = ['information_coefficient']
+
+
+def _pearson_pair(a: NDArray, b: NDArray) -> float:
+    """ Pearson correlation of two 1-D vectors, NaN-robust.
+
+    Drops index pairs where either side is NaN, and returns ``np.nan`` when
+    fewer than two valid pairs remain or either side has zero variance.
+    """
+    a = np.asarray(a, dtype=np.float64)
+    b = np.asarray(b, dtype=np.float64)
+    valid = np.isfinite(a) & np.isfinite(b)
+    a = a[valid]
+    b = b[valid]
+
+    if a.size < 2:
+
+        return np.nan
+
+    a = a - a.mean()
+    b = b - b.mean()
+    denom = np.sqrt(np.sum(a * a) * np.sum(b * b))
+
+    if denom == 0.:
+
+        return np.nan
+
+    return float(np.sum(a * b) / denom)
+
+
+def _spearman_pair(a: NDArray, b: NDArray) -> float:
+    """ Spearman (rank) correlation of two 1-D vectors, NaN-robust.
+
+    Spearman is Pearson computed on the ranks of the valid pairs; ties are
+    handled by :func:`scipy.stats.rankdata` (average ranks).
+    """
+    a = np.asarray(a, dtype=np.float64)
+    b = np.asarray(b, dtype=np.float64)
+    valid = np.isfinite(a) & np.isfinite(b)
+    a = a[valid]
+    b = b[valid]
+
+    if a.size < 2:
+
+        return np.nan
+
+    return _pearson_pair(rankdata(a), rankdata(b))
+
+
+_HANDLER = {
+    'pearson': _pearson_pair,
+    'spearman': _spearman_pair,
+}
+
+
+def information_coefficient(
+    pred: NDArray,
+    real: NDArray,
+    *,
+    method: str = 'spearman',
+    axis: int = 0,
+) -> Any:
+    r""" Information Coefficient between a prediction and a realized outcome.
+
+    The Information Coefficient (IC) is the correlation between a forecast and
+    what actually happened — a predict-then-rule guardrail measuring how much
+    signal a prediction carries. With ``method='spearman'`` (default) it is the
+    *rank-IC*: a rank correlation that rewards getting the ordering right while
+    ignoring the magnitude/shape of the relationship, which is the relevant
+    quantity when the prediction is used to rank assets. With
+    ``method='pearson'`` it is the ordinary linear correlation.
+
+    The two inputs must be aligned: ``pred[i]`` is the forecast for the outcome
+    ``real[i]``.
+
+    Notes
+    -----
+    For two aligned samples the IC is
+
+    .. math::
+
+        IC = corr(g(pred),\ g(real))
+
+    where :math:`g` is the identity for ``method='pearson'`` and the rank
+    transform for ``method='spearman'`` (Spearman = Pearson on ranks). Index
+    pairs where either side is NaN are dropped before the computation.
+
+    **Shape contract.** For 1-D inputs ``(T,)`` the IC is a scalar computed over
+    the whole sample. For 2-D panel inputs ``(T, N)`` the *default*
+    (``axis=0``) is the **cross-sectional IC per bar**: at each time step the
+    prediction is correlated against the realization *across the N assets*,
+    returning one IC per bar with shape ``(T,)``. This is the ranking
+    use-case — at each rebalancing bar, "did the assets I ranked highest
+    actually do best?". Pass ``axis=1`` to instead correlate along the time
+    axis per asset, returning shape ``(N,)`` (the per-asset time-series IC).
+
+    Parameters
+    ----------
+    pred : np.ndarray[dtype, ndim=1 or 2]
+        Predictions/forecasts (e.g. a model score). Same shape as ``real``.
+    real : np.ndarray[dtype, ndim=1 or 2]
+        Realized outcomes (e.g. forward returns). Same shape as ``pred``.
+    method : {'spearman', 'pearson'}, optional
+        ``'spearman'`` (default) for the rank-IC, ``'pearson'`` for the linear
+        IC.
+    axis : {0, 1}, optional
+        Axis indexing the samples to correlate *over*. For 2-D inputs,
+        ``axis=0`` correlates across the second dimension per row
+        (cross-sectional IC per bar, shape ``(T,)``) and ``axis=1`` correlates
+        across the first dimension per column (time-series IC per asset, shape
+        ``(N,)``). Ignored for 1-D inputs. Default is 0.
+
+    Returns
+    -------
+    float or np.ndarray[np.float64, ndim=1]
+        The IC. A scalar for 1-D inputs, a 1-D array for 2-D inputs. Entries
+        are ``np.nan`` (never an exception) where fewer than two valid pairs
+        remain or either side has zero variance.
+
+    References
+    ----------
+    .. [1] https://en.wikipedia.org/wiki/Information_coefficient
+
+    Examples
+    --------
+    A perfect monotonic prediction has a rank-IC of 1, even when the
+    relationship is non-linear (only the ordering matters):
+
+    >>> import numpy as np
+    >>> real = np.array([1., 2., 3., 4., 5.])
+    >>> pred = real ** 3
+    >>> float(information_coefficient(pred, real))
+    1.0
+    >>> round(float(information_coefficient(pred, real, method='pearson')), 4)
+    0.9431
+
+    A panel returns one cross-sectional IC per bar — here the ranking is
+    correct on the first bar and inverted on the second:
+
+    >>> pred = np.array([[1., 2., 3.], [1., 2., 3.]])
+    >>> real = np.array([[1., 2., 3.], [3., 2., 1.]])
+    >>> information_coefficient(pred, real)
+    array([ 1., -1.])
+
+    See Also
+    --------
+    sharpe, sortino
+
+    """
+    if method not in _HANDLER:
+
+        raise ValueError(
+            f"unknown method {method!r}, only 'spearman' and 'pearson' "
+            "are supported"
+        )
+
+    corr = _HANDLER[method]
+    pred = np.asarray(pred, dtype=np.float64)
+    real = np.asarray(real, dtype=np.float64)
+
+    if pred.shape != real.shape:
+
+        raise ValueError(
+            f"pred and real must have the same shape, got {pred.shape} and "
+            f"{real.shape}"
+        )
+
+    if pred.ndim == 1:
+
+        return corr(pred, real)
+
+    if pred.ndim != 2:
+
+        raise ValueError(
+            f"only 1-D and 2-D arrays are supported, got ndim={pred.ndim}"
+        )
+
+    if axis == 0:
+        # Cross-sectional IC per bar: correlate across the N assets within each
+        # time step, one value per row.
+        return np.array(
+            [corr(pred[t], real[t]) for t in range(pred.shape[0])],
+            dtype=np.float64,
+        )
+
+    elif axis == 1:
+        # Time-series IC per asset: correlate along time within each column.
+        return np.array(
+            [corr(pred[:, n], real[:, n]) for n in range(pred.shape[1])],
+            dtype=np.float64,
+        )
+
+    raise np.exceptions.AxisError(axis, pred.ndim)

--- a/fynance/models/loss/__init__.py
+++ b/fynance/models/loss/__init__.py
@@ -20,6 +20,8 @@ Main entry points
   maximum drawdown).
 - :class:`OmegaLoss` — negative Omega ratio (expected gains over
   expected losses relative to a threshold).
+- :class:`RankingLoss` — differentiable cross-sectional long-short
+  ranking objective for a panel of assets.
 - :class:`HybridLoss` — convex combination of two losses with a fixed or
   learnable weight.
 
@@ -40,8 +42,9 @@ from .calmar import CalmarLoss
 from .directional import DirectionalAccuracyLoss
 from .hybrid import HybridLoss
 from .omega import OmegaLoss
+from .ranking import RankingLoss
 from .sharpe import SharpeLoss
 from .sortino import SortinoLoss
 
 __all__ = ['BaseLoss', 'CalmarLoss', 'DirectionalAccuracyLoss', 'HybridLoss',
-           'OmegaLoss', 'SharpeLoss', 'SortinoLoss']
+           'OmegaLoss', 'RankingLoss', 'SharpeLoss', 'SortinoLoss']

--- a/fynance/models/loss/_base.py
+++ b/fynance/models/loss/_base.py
@@ -67,3 +67,20 @@ class BaseLoss(torch.nn.Module):
                 "Convert numpy arrays with torch.from_numpy() before passing "
                 "to this loss."
             )
+
+    @staticmethod
+    def _book_return(y_pred: torch.Tensor) -> torch.Tensor:
+        r""" Aggregate a position-book return ``(T, N)`` into a 1-D book return.
+
+        A 2-D ``y_pred`` is read as the per-asset net-of-cost returns of a
+        position book; the book return at each step is their sum across assets
+        (:math:`\sum_i pos_i \cdot r_i`), so the ratio losses score the
+        **portfolio** return rather than a pooled per-asset return. A 1-D
+        ``y_pred`` (single asset) is returned unchanged, and a ``(T, 1)`` book
+        reduces to the same series as the single-asset case.
+        """
+        if y_pred.dim() == 2:
+
+            return y_pred.sum(dim=1)
+
+        return y_pred

--- a/fynance/models/loss/calmar.py
+++ b/fynance/models/loss/calmar.py
@@ -52,6 +52,7 @@ class CalmarLoss(BaseLoss):
     ) -> torch.Tensor:
         """ Compute the negative Calmar ratio (scalar). """
         self._check_tensor(y_pred)
+        y_pred = self._book_return(y_pred)
         equity = torch.cumsum(y_pred, dim=0)
         running_max, _ = torch.cummax(equity, dim=0)
         max_drawdown = (running_max - equity).max()

--- a/fynance/models/loss/omega.py
+++ b/fynance/models/loss/omega.py
@@ -60,6 +60,7 @@ class OmegaLoss(BaseLoss):
     ) -> torch.Tensor:
         """ Compute the negative Omega ratio (scalar). """
         self._check_tensor(y_pred)
+        y_pred = self._book_return(y_pred)
         diff = y_pred - self.threshold
         gains = torch.relu(diff).mean()
         losses = torch.relu(-diff).mean()

--- a/fynance/models/loss/ranking.py
+++ b/fynance/models/loss/ranking.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Differentiable cross-sectional ranking loss. """
+
+from __future__ import annotations
+
+# Third-party packages
+import torch
+
+# Local packages
+from ._base import BaseLoss
+
+__all__ = ['RankingLoss']
+
+
+class RankingLoss(BaseLoss):
+    r""" Differentiable cross-sectional long-short ranking loss.
+
+    A *predict-then-rank* objective for a panel of assets: it rewards a score
+    that ranks assets by their realized cross-sectional outcome. At each time
+    step the per-asset scores are turned into a softmax **long** book and a
+    softmax **short** book (a smooth, differentiable relaxation of "long the
+    top names, short the bottom names"); the loss is the negative mean
+    long-short **spread return**
+
+    .. math::
+
+        \mathcal{L} = -\frac{1}{T} \sum_t \sum_i
+            \big(w^{+}_{t,i} - w^{-}_{t,i}\big)\, r_{t,i},
+        \qquad
+        w^{\pm}_{t} = \mathrm{softmax}(\pm\,\tau\, s_t)
+
+    where :math:`s` is ``y_pred`` (the per-asset scores), :math:`r` is
+    ``y_true`` (the realized per-asset returns) and :math:`\tau` is
+    ``temperature`` (higher = sharper, closer to a hard top/bottom selection).
+    Minimizing the loss maximizes the spread: it pushes high scores onto the
+    cross-sectional winners and low scores onto the losers.
+
+    Unlike the ratio losses, this one is **inherently cross-sectional**: it
+    needs a 2-D ``(T, N)`` panel (``N >= 2`` assets) and a realized target.
+
+    Parameters
+    ----------
+    temperature : float, optional
+        Softmax sharpness :math:`\tau`. Higher pushes the soft long/short books
+        toward a hard top/bottom selection. Default is 1.0.
+    **kwargs
+        Forwarded to :class:`BaseLoss` (``rf``, ``period``, ``eps``).
+
+    Examples
+    --------
+    >>> import torch
+    >>> from fynance.models.loss import RankingLoss
+    >>> scores = torch.tensor([[3., 2., 1.], [1., 2., 3.]])
+    >>> real = torch.tensor([[0.03, 0.0, -0.03], [-0.03, 0.0, 0.03]])
+    >>> loss_fn = RankingLoss()
+    >>> aligned = loss_fn(scores, real)
+    >>> inverted = loss_fn(-scores, real)
+    >>> bool(aligned < inverted)        # scoring the winners high ranks best
+    True
+
+    See Also
+    --------
+    SharpeLoss, SortinoLoss
+
+    """
+
+    def __init__(self, temperature: float = 1.0, **kwargs):
+        super().__init__(**kwargs)
+        self.temperature = temperature
+
+    def forward(
+        self, y_pred: torch.Tensor, y_true: torch.Tensor,
+    ) -> torch.Tensor:
+        """ Compute the negative mean cross-sectional long-short spread.
+
+        Parameters
+        ----------
+        y_pred : torch.Tensor
+            Per-asset scores, shape ``(T, N)`` with ``N >= 2``.
+        y_true : torch.Tensor
+            Realized per-asset returns, same shape as ``y_pred``.
+
+        Returns
+        -------
+        torch.Tensor
+            Scalar loss (negative mean long-short spread return).
+
+        Raises
+        ------
+        TypeError
+            If ``y_pred`` or ``y_true`` is not a :class:`torch.Tensor`.
+        ValueError
+            If the inputs are not matching-shape 2-D panels with ``N >= 2``.
+
+        """
+        self._check_tensor(y_pred)
+        self._check_tensor(y_true)
+
+        if y_pred.dim() != 2 or y_pred.shape[1] < 2:
+
+            raise ValueError(
+                "RankingLoss needs a 2-D (T, N) panel with N >= 2 assets, got "
+                f"shape {tuple(y_pred.shape)}"
+            )
+
+        if y_pred.shape != y_true.shape:
+
+            raise ValueError(
+                "y_pred and y_true must have the same shape, got "
+                f"{tuple(y_pred.shape)} and {tuple(y_true.shape)}"
+            )
+
+        w_long = torch.softmax(self.temperature * y_pred, dim=1)
+        w_short = torch.softmax(-self.temperature * y_pred, dim=1)
+        spread = ((w_long - w_short) * y_true).sum(dim=1)
+
+        return -spread.mean()

--- a/fynance/models/loss/sharpe.py
+++ b/fynance/models/loss/sharpe.py
@@ -88,7 +88,8 @@ class SharpeLoss(BaseLoss):
         Parameters
         ----------
         y_pred : torch.Tensor
-            Predicted return series, shape ``(T,)`` or ``(T, M)``.
+            Predicted return series ``(T,)``. A 2-D ``(T, N)`` position book is
+            aggregated to the book return (sum across assets) before scoring.
         y_true : torch.Tensor, optional
             Not used; accepted for API compatibility with PyTorch criterions.
 
@@ -104,5 +105,6 @@ class SharpeLoss(BaseLoss):
 
         """
         self._check_tensor(y_pred)
+        y_pred = self._book_return(y_pred)
         excess = y_pred - self._rf_per_period
         return -(excess.mean() / (excess.std(correction=0) + self.eps))

--- a/fynance/models/loss/sortino.py
+++ b/fynance/models/loss/sortino.py
@@ -92,7 +92,8 @@ class SortinoLoss(BaseLoss):
         Parameters
         ----------
         y_pred : torch.Tensor
-            Predicted return series, shape ``(T,)`` or ``(T, M)``.
+            Predicted return series ``(T,)``. A 2-D ``(T, N)`` position book is
+            aggregated to the book return (sum across assets) before scoring.
         y_true : torch.Tensor, optional
             Not used; accepted for API compatibility with PyTorch criterions.
 
@@ -108,6 +109,7 @@ class SortinoLoss(BaseLoss):
 
         """
         self._check_tensor(y_pred)
+        y_pred = self._book_return(y_pred)
         excess = y_pred - self._rf_per_period
         downside = torch.sqrt(torch.mean(F.relu(-excess) ** 2))
         # Floor the downside relative to the return scale: a fixed absolute eps

--- a/fynance/models/objective.py
+++ b/fynance/models/objective.py
@@ -22,6 +22,21 @@ protocol (``fit``/``predict``), so it drops into the harness via the precomputed
 (``tanh``) these are bounded in ``[-1, 1]``; a custom ``position_fn`` may be
 unbounded.
 
+**Single-asset and panel.** With ``N`` assets the net outputs a **position
+book** ``(T, N)`` — one column per asset — and is trained on the objective of
+the **aggregated book return** ``(positions * returns).sum(axis=1)``. The
+single-asset path (``N == 1``) is unchanged: ``X`` of shape ``(T, F)`` with a
+1-D ``y`` of shape ``(T,)`` still trains exactly as before and ``predict``
+returns ``(T, 1)``. For a panel, pass either a 3-D ``X`` of shape
+``(T, N, M)`` (``M`` features per asset, flattened internally to ``(T, N*M)``
+for the default dense net) or a pre-flattened 2-D ``X`` of shape ``(T, N*M)``
+together with a 2-D ``y`` of shape ``(T, N)`` (the per-asset returns)::
+
+    # N = 3 assets, M = 4 features each
+    model = ObjectiveModel(n_assets=3, loss=SharpeLoss(), epochs=80)
+    model.fit(X, y)            # X (T, 3, 4) or (T, 12); y (T, 3)
+    book = model.predict(X)    # positions, shape (T, 3)
+
 """
 
 # Built-in
@@ -40,14 +55,20 @@ from fynance.models.loss import SharpeLoss
 __all__ = ['ObjectiveModel']
 
 
-def _default_net(n_features: int, layers: tuple[int, ...]) -> torch.nn.Module:
-    """ A plain feed-forward net with ReLU hidden layers and a linear head. """
+def _default_net(
+    n_features: int, layers: tuple[int, ...], n_assets: int = 1,
+) -> torch.nn.Module:
+    """ A plain feed-forward net with ReLU hidden layers and a linear head.
+
+    The head is ``Linear(dim, n_assets)`` so the net outputs one position per
+    asset; ``n_assets == 1`` reproduces the original single-asset head exactly.
+    """
     mods: list[torch.nn.Module] = []
     dim = n_features
     for h in layers:
         mods += [torch.nn.Linear(dim, h), torch.nn.ReLU()]
         dim = h
-    mods += [torch.nn.Linear(dim, 1)]  # linear position head
+    mods += [torch.nn.Linear(dim, n_assets)]  # linear position-book head
 
     return torch.nn.Sequential(*mods)
 
@@ -58,9 +79,17 @@ class ObjectiveModel:
     Parameters
     ----------
     net : torch.nn.Module, optional
-        Architecture mapping a feature matrix ``(T, F)`` to ``(T, 1)``. Defaults
-        to an MLP built lazily on the first :meth:`fit` (so it learns ``F``). Pass
-        any ``nn.Module`` (e.g. a TCN/LSTM) to use a custom architecture.
+        Architecture mapping a feature matrix ``(T, F)`` to a position book
+        ``(T, N)`` (``N`` = number of assets; ``(T, 1)`` for the single-asset
+        case). Defaults to an MLP built lazily on the first :meth:`fit` (so it
+        learns ``F`` and ``N``). Pass any ``nn.Module`` (e.g. a TCN/LSTM) to use
+        a custom architecture; a custom net receives ``X`` as the 2-D matrix
+        ``(T, F)`` (a 3-D panel ``(T, N, M)`` is flattened to ``(T, N*M)`` first).
+    n_assets : int, optional
+        Number of assets ``N`` in the position book. ``None`` (default) infers
+        it at :meth:`fit`: from the 2nd dimension of a 2-D ``y`` ``(T, N)``, or
+        from the 2nd dimension of a 3-D ``X`` ``(T, N, M)``, falling back to
+        ``1`` for a 1-D ``y`` (the single-asset case).
     layers : tuple of int
         Hidden sizes of the default MLP (ignored when ``net`` is given).
     loss : BaseLoss, optional
@@ -108,6 +137,7 @@ class ObjectiveModel:
         self,
         net: torch.nn.Module | None = None,
         *,
+        n_assets: int | None = None,
         layers: tuple[int, ...] = (16, 8),
         loss: Any = None,
         optimizer: type[torch.optim.Optimizer] = torch.optim.Adam,
@@ -120,6 +150,7 @@ class ObjectiveModel:
         seed: int = 0,
     ):
         self.net = net
+        self.n_assets = n_assets
         self.layers = tuple(layers)
         self.loss = loss if loss is not None else SharpeLoss()
         self.optimizer_cls = optimizer
@@ -135,24 +166,37 @@ class ObjectiveModel:
     def _ensure_net(self, n_features: int) -> None:
         if self.net is None:
             torch.manual_seed(self.seed)
-            self.net = _default_net(n_features, self.layers)
+            self.net = _default_net(n_features, self.layers, self.n_assets or 1)
         if self._optim is None:
             self._optim = self.optimizer_cls(
                 self.net.parameters(), lr=self.lr,  # type: ignore[call-arg]
             )
 
     def _positions(self, X: torch.Tensor) -> torch.Tensor:
-        out = self.net(X).reshape(-1)  # type: ignore[misc]
+        """ Position book ``(T, N)`` for the feature matrix ``X`` ``(T, F)``.
+
+        ``N`` is :attr:`n_assets` (``1`` for the single-asset case). The net
+        output is reshaped to ``(T, N)`` before ``position_fn`` so a single-asset
+        run yields the same numbers as the original flat ``(T,)`` path.
+        """
+        n = self.n_assets or 1
+        out = self.net(X).reshape(-1, n)  # type: ignore[misc]
 
         return self.position_fn(out)
 
     def _strat_return(self, pos: torch.Tensor, ret: torch.Tensor,
                       prev: torch.Tensor | None) -> torch.Tensor:
-        """ Net-of-cost strategy return ``pos*ret - cost*|Δpos|`` for a chunk.
+        """ Net-of-cost **book** return for a chunk, as a 1-D series ``(T,)``.
 
-        ``prev`` is the (detached) last position of the previous contiguous chunk
-        so the turnover at the chunk boundary is charged correctly; ``None`` (or a
-        shuffled chunk) charges entry from flat on the first bar.
+        ``pos`` and ``ret`` are ``(T, N)`` (a single-asset run uses ``N == 1``).
+        The per-asset net-of-cost return is ``pos*ret - cost*|Δpos|`` and the
+        book return aggregates across assets (sum over the asset axis), so the
+        1-D series handed to the (1-D) loss is the aggregated book return.
+
+        ``prev`` is the (detached) last position book of the previous contiguous
+        chunk so the turnover at the chunk boundary is charged correctly per
+        asset; ``None`` (or a shuffled chunk) charges entry from flat on the
+        first bar.
         """
         strat = pos * ret
         if self.cost:
@@ -160,17 +204,22 @@ class ObjectiveModel:
             turnover = torch.cat([first, torch.abs(pos[1:] - pos[:-1])])
             strat = strat - self.cost * turnover
 
-        return strat
+        # Aggregate the per-asset net-of-cost returns into the book return.
+        return strat.sum(dim=1)
 
     def fit(self, X: NDArray, y: NDArray) -> ObjectiveModel:
         """ Train the net to maximize the objective of the net-of-cost return.
 
         Parameters
         ----------
-        X : array-like, shape (T, F)
-            Feature matrix.
-        y : array-like, shape (T,)
-            Realized per-bar returns aligned with ``X`` (not a supervised label).
+        X : array-like, shape (T, F) or (T, N, M)
+            Feature matrix. A 3-D panel ``(T, N, M)`` (``N`` assets, ``M``
+            features each) is flattened to ``(T, N*M)`` for the default dense
+            net.
+        y : array-like, shape (T,) or (T, N)
+            Realized per-bar returns aligned with ``X`` (not a supervised
+            label). A 2-D ``y`` carries the per-asset returns of the position
+            book; a 1-D ``y`` is the single-asset case (``N == 1``).
 
         Returns
         -------
@@ -178,8 +227,25 @@ class ObjectiveModel:
             ``self``.
 
         """
-        Xt = torch.as_tensor(np.asarray(X, dtype=np.float32))
-        rt = torch.as_tensor(np.asarray(y, dtype=np.float32).reshape(-1))
+        Xa = np.asarray(X, dtype=np.float32)
+        ya = np.asarray(y, dtype=np.float32)
+
+        # Infer the number of assets N (constructor value wins), then align the
+        # feature matrix to 2-D (T, F) and the returns to (T, N).
+        n = self.n_assets
+        if n is None:
+            if ya.ndim == 2:
+                n = ya.shape[1]
+            elif Xa.ndim == 3:
+                n = Xa.shape[1]
+            else:
+                n = 1
+            self.n_assets = n
+
+        if Xa.ndim == 3:  # (T, N, M) panel -> (T, N*M) for the dense net
+            Xa = Xa.reshape(Xa.shape[0], -1)
+        Xt = torch.as_tensor(Xa)
+        rt = torch.as_tensor(ya.reshape(ya.shape[0], n))
         self._ensure_net(Xt.shape[1])
 
         T = Xt.shape[0]
@@ -211,12 +277,18 @@ class ObjectiveModel:
 
     @torch.no_grad()
     def predict(self, X: NDArray) -> NDArray:
-        """ Return a position for each row of ``X``.
+        """ Return the position book for ``X``, shape ``(T, N)``.
 
-        With the default ``position_fn`` (``tanh``) positions are bounded in
-        ``[-1, 1]``; a custom ``position_fn`` may produce unbounded values.
+        Accepts a 2-D ``X`` ``(T, F)`` or a 3-D panel ``(T, N, M)`` (flattened
+        to ``(T, N*M)`` for the default net). The output is a position book with
+        one column per asset (``(T, 1)`` in the single-asset case). With the
+        default ``position_fn`` (``tanh``) positions are bounded in ``[-1, 1]``;
+        a custom ``position_fn`` may produce unbounded values.
         """
         self.net.eval()  # type: ignore[union-attr]
-        Xt = torch.as_tensor(np.asarray(X, dtype=np.float32))
+        Xa = np.asarray(X, dtype=np.float32)
+        if Xa.ndim == 3:  # (T, N, M) panel -> (T, N*M) for the dense net
+            Xa = Xa.reshape(Xa.shape[0], -1)
+        Xt = torch.as_tensor(Xa)
 
-        return self._positions(Xt).reshape(-1, 1).cpu().numpy()
+        return self._positions(Xt).cpu().numpy()

--- a/fynance/plot/__init__.py
+++ b/fynance/plot/__init__.py
@@ -12,6 +12,7 @@ API the notebook workflow and the optional Streamlit app both build on.
 """
 
 # Local packages
+from .attribution import plot_contribution, plot_turnover
 from .equity import plot_drawdown, plot_equity
 from .returns import plot_returns_hist, plot_rolling_sharpe
 from .tearsheet import tearsheet, tearsheet_text
@@ -21,6 +22,8 @@ __all__ = [
     'plot_drawdown',
     'plot_returns_hist',
     'plot_rolling_sharpe',
+    'plot_contribution',
+    'plot_turnover',
     'tearsheet',
     'tearsheet_text',
 ]

--- a/fynance/plot/attribution.py
+++ b/fynance/plot/attribution.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Per-asset attribution figures for a multi-asset book. """
+
+from __future__ import annotations
+
+# Built-in packages
+from typing import Any
+
+# Third-party packages
+import numpy as np
+
+__all__ = ['plot_contribution', 'plot_turnover']
+
+
+def _as_book(arr: Any) -> np.ndarray:
+    """ Coerce to a 2-D ``(T, N)`` book (a 1-D series becomes a single column). """
+    a = np.asarray(arr, dtype=np.float64)
+
+    return a if a.ndim == 2 else a.reshape(a.shape[0], -1)
+
+
+def plot_contribution(asset_returns: Any, index: Any = None, ax: Any = None) -> Any:
+    """ Plot the cumulative per-asset gross contribution of a book.
+
+    ``asset_returns`` is the per-asset gross return book ``(T, N)`` (each column
+    is one asset's contribution; together they sum to the book gross return). The
+    cumulative sum per asset shows how much each asset added to the book over
+    time. Returns the matplotlib ``Axes``.
+    """
+    import matplotlib.pyplot as plt
+
+    cum = np.cumsum(_as_book(asset_returns), axis=0)
+    x = range(cum.shape[0]) if index is None else index
+
+    if ax is None:
+        _, ax = plt.subplots()
+
+    for i in range(cum.shape[1]):
+        ax.plot(x, cum[:, i], lw=1.2, label=f"asset {i}")
+    ax.set_title("Per-asset contribution (cumulative gross)")
+    ax.set_ylabel("Cumulative return")
+    ax.grid(alpha=0.3)
+    ax.legend(loc="best", fontsize=8, ncol=2)
+
+    return ax
+
+
+def plot_turnover(positions: Any, index: Any = None, ax: Any = None) -> Any:
+    """ Plot the per-asset turnover ``|Δ position|`` of a book.
+
+    ``positions`` is the position book ``(T, N)``; the turnover at each step is
+    the absolute change in position per asset (the first step charges entry from
+    flat, matching the cost model). Returns the matplotlib ``Axes``.
+    """
+    import matplotlib.pyplot as plt
+
+    pos = _as_book(positions)
+    turn = np.abs(np.diff(pos, axis=0, prepend=np.zeros((1, pos.shape[1]))))
+    x = range(turn.shape[0]) if index is None else index
+
+    if ax is None:
+        _, ax = plt.subplots()
+
+    for i in range(turn.shape[1]):
+        ax.plot(x, turn[:, i], lw=1.0, label=f"asset {i}")
+    ax.set_title("Per-asset turnover")
+    ax.set_ylabel("|Δ position|")
+    ax.grid(alpha=0.3)
+    ax.legend(loc="best", fontsize=8, ncol=2)
+
+    return ax

--- a/fynance/plot/tearsheet.py
+++ b/fynance/plot/tearsheet.py
@@ -8,8 +8,12 @@ from __future__ import annotations
 # Built-in packages
 from typing import Any
 
+# Third-party packages
+import numpy as np
+
 # Local packages
 from fynance.plot._helpers import as_equity
+from fynance.plot.attribution import plot_contribution, plot_turnover
 from fynance.plot.equity import plot_drawdown, plot_equity
 from fynance.plot.returns import plot_rolling_sharpe
 
@@ -52,8 +56,20 @@ def tearsheet(result: Any, period: int = 252, figsize: tuple = (11, 7)) -> Any:
     """
     import matplotlib.pyplot as plt
 
-    fig = plt.figure(figsize=figsize)
-    gs = fig.add_gridspec(2, 2)
+    # A multi-asset book carries per-asset attribution: add a contribution and a
+    # turnover panel below the core 2x2 report (single-asset stays a 2x2).
+    asset_gross = getattr(result, "asset_gross_returns", None)
+    positions = getattr(result, "positions", None)
+    index = getattr(result, "index", None)
+    is_book = (
+        asset_gross is not None
+        and np.asarray(asset_gross).ndim == 2
+        and np.asarray(asset_gross).shape[1] > 1
+    )
+
+    n_rows = 3 if is_book else 2
+    fig = plt.figure(figsize=(figsize[0], figsize[1] * (1.4 if is_book else 1.0)))
+    gs = fig.add_gridspec(n_rows, 2)
 
     plot_equity(result, ax=fig.add_subplot(gs[0, 0]))
     plot_drawdown(result, ax=fig.add_subplot(gs[0, 1]))
@@ -69,6 +85,11 @@ def tearsheet(result: Any, period: int = 252, figsize: tuple = (11, 7)) -> Any:
     table.set_fontsize(9)
     table.scale(1.0, 1.3)
     ax_table.set_title("Summary")
+
+    if is_book:
+        plot_contribution(asset_gross, index=index, ax=fig.add_subplot(gs[2, 0]))
+        if positions is not None and np.asarray(positions).ndim == 2:
+            plot_turnover(positions, index=index, ax=fig.add_subplot(gs[2, 1]))
 
     fig.tight_layout()
 

--- a/fynance/research/report.py
+++ b/fynance/research/report.py
@@ -55,7 +55,10 @@ def _provenance_table(spec: dict | None) -> str:
         span = ""
         if data.get("start") is not None or data.get("end") is not None:
             span = f" ({data.get('start')} → {data.get('end')})"
-        rows.append(("data", f"{data.get('kind')} · n={data.get('n')}{span}"))
+        n_assets = data.get("n_assets")
+        assets = f" · {n_assets} assets" if n_assets and n_assets > 1 else ""
+        rows.append(
+            ("data", f"{data.get('kind')} · n={data.get('n')}{assets}{span}"))
         if data.get("desc"):
             rows.append(("data desc", str(data["desc"])))
     elif data is not None:
@@ -97,15 +100,23 @@ def _write_png(experiment: Experiment, png_path: Path, period: int) -> bool:
     from fynance.plot import tearsheet
 
     equity = np.asarray(experiment.series["equity"], dtype=float)
-    # Duck-type a result carrying both the curve and its dates so the plot layer
-    # (via as_equity) draws against real dates; fall back to the bare curve (bar
-    # numbers) when the experiment has no datetime index.
-    result: Any = equity
+    # Duck-type a result carrying the curve, its dates and (for a multi-asset
+    # book) the per-asset attribution, so the plot layer draws against real dates
+    # and the tearsheet adds the book panels. Fall back to the bare curve (bar
+    # numbers, no book panels) when those are absent.
+    ns: dict[str, Any] = {"equity": equity}
     date_index = experiment.series.get("index")
     if date_index:
         index = np.asarray(date_index, dtype="datetime64[ns]")
         if index.shape[0] == equity.shape[0]:
-            result = SimpleNamespace(equity=equity, index=index)
+            ns["index"] = index
+    asset_contrib = experiment.series.get("asset_contrib")
+    if asset_contrib:
+        ns["asset_gross_returns"] = np.asarray(asset_contrib, dtype=float)
+    book_positions = experiment.series.get("positions")
+    if book_positions:
+        ns["positions"] = np.asarray(book_positions, dtype=float)
+    result: Any = SimpleNamespace(**ns) if len(ns) > 1 else equity
     fig = tearsheet(result, period=period)
     fig.savefig(png_path, dpi=110, bbox_inches="tight")
     plt.close(fig)

--- a/fynance/research/runner.py
+++ b/fynance/research/runner.py
@@ -245,6 +245,10 @@ def run_experiment(
     asset_contrib = getattr(result, "asset_gross_returns", None)
     if asset_contrib is not None:
         series["asset_contrib"] = np.asarray(asset_contrib, dtype=float).tolist()
+        # Persist the position book too so the report can show per-asset turnover.
+        book_positions = np.asarray(result.positions, dtype=float)
+        if book_positions.ndim == 2:
+            series["positions"] = book_positions.tolist()
 
     experiment = Experiment(
         name=name,

--- a/fynance/research/runner.py
+++ b/fynance/research/runner.py
@@ -28,11 +28,17 @@ __all__ = ['run_experiment']
 
 
 def _to_array(data: Any) -> NDArray[np.float64]:
-    """ Coerce a PriceSeries / array-like to a 1-D float64 array. """
+    """ Coerce a PriceSeries / array-like to a float64 array.
+
+    A 2-D ``(T, N)`` panel (multi-asset prices/returns) is preserved; anything
+    else is flattened to a 1-D series.
+    """
     if isinstance(data, PriceSeries):
         return data.to_numpy()
 
-    return np.asarray(data, dtype=np.float64).reshape(-1)
+    arr = np.asarray(data, dtype=np.float64)
+
+    return arr if arr.ndim == 2 else arr.reshape(-1)
 
 
 def _index_bound(data: Any, pos: int) -> Any:
@@ -197,6 +203,7 @@ def run_experiment(
     data_block: dict[str, Any] = {
         "kind": getattr(data, "name", None) or type(data).__name__,
         "n": int(n),
+        "n_assets": int(prices.shape[1]) if prices.ndim == 2 else 1,
         "start": _index_bound(data, 0),
         "end": _index_bound(data, -1),
         "desc": data_desc,
@@ -233,6 +240,11 @@ def run_experiment(
     date_index = _series_index(data, len(series["equity"]))
     if date_index is not None:
         series["index"] = date_index
+    # Persist per-asset gross contributions of a multi-asset book so the report
+    # can attribute the book return by asset; absent for a single-asset run.
+    asset_contrib = getattr(result, "asset_gross_returns", None)
+    if asset_contrib is not None:
+        series["asset_contrib"] = np.asarray(asset_contrib, dtype=float).tolist()
 
     experiment = Experiment(
         name=name,

--- a/fynance/strategy/strategy.py
+++ b/fynance/strategy/strategy.py
@@ -111,7 +111,20 @@ class Strategy:
         else:
             preds = feats
 
-        return np.asarray(self.signal(preds), dtype=np.float64).reshape(-1)
+        return self._signal_positions(preds)
+
+    def _signal_positions(self, preds: NDArray) -> NDArray:
+        """ Map predictions to positions, preserving a ``(T, N)`` book.
+
+        A genuine multi-asset book ``(T, N)`` is kept 2-D; only a trailing
+        singleton asset axis (the single-asset model output ``(T, 1)``) is
+        collapsed to 1-D so the single-asset path is unchanged.
+        """
+        pos = np.asarray(self.signal(preds), dtype=np.float64)
+        if pos.ndim == 2 and pos.shape[1] == 1:
+            pos = pos.reshape(-1)
+
+        return pos
 
     def run(self, data: Any, y: NDArray | None = None,
             X: NDArray | None = None) -> BacktestResult:
@@ -200,8 +213,8 @@ class Strategy:
         X_arr = None if X is None else np.asarray(X)  # preserve caller dtype
         n = prices.shape[0]
 
-        oos_pos: list[float] = []
-        oos_ret: list[float] = []
+        oos_pos: list[NDArray] = []
+        oos_ret: list[NDArray] = []
 
         for tr, te in walk_forward(n, train=train, test=test, step=step,
                                    purge=purge):
@@ -220,21 +233,24 @@ class Strategy:
             else:
                 preds = feats_te
 
-            pos = np.asarray(self.signal(preds), dtype=np.float64).reshape(-1)
+            pos = self._signal_positions(preds)
 
             # Return realized over each test step (causal: position at t earns
             # r_t within the OOS block; the engine applies the one-step shift).
             # The opening bar has no in-block prior price, so its return is
-            # discarded (NaN -> 0 below). See the method docstring note.
+            # discarded (NaN -> 0 below). For a panel the whole opening row is
+            # discarded. See the method docstring note.
             block = prices[te]
-            ret = np.empty(block.shape[0])
+            ret = np.empty_like(block, dtype=np.float64)
             ret[0] = np.nan
             ret[1:] = block[1:] / block[:-1] - 1.0
 
-            oos_pos.extend(pos.tolist())
-            oos_ret.extend(ret.tolist())
+            oos_pos.append(pos)
+            oos_ret.append(ret)
 
-        positions = np.asarray(oos_pos)
-        returns = np.nan_to_num(np.asarray(oos_ret), nan=0.0)
+        # Stitch the out-of-sample blocks: 1-D for a single asset, (T_oos, N)
+        # for a panel book.
+        positions = np.concatenate(oos_pos, axis=0)
+        returns = np.nan_to_num(np.concatenate(oos_ret, axis=0), nan=0.0)
 
         return backtest(returns, positions, cost=self.cost, shift=True)

--- a/fynance/tests/backtest/test_engine.py
+++ b/fynance/tests/backtest/test_engine.py
@@ -115,3 +115,23 @@ def test_prices_input_cost_preserves_no_lookahead():
     res = backtest(pert, positions, cost=cost,
                    returns_input=False, shift=True).equity
     assert np.allclose(base[:-1], res[:-1])
+
+
+def test_book_attribution_sums_to_gross():
+    # A 2-D position book yields per-asset gross contributions that sum to the
+    # aggregated book gross return.
+    rng = np.random.default_rng(0)
+    returns = rng.normal(0.0, 0.01, (50, 3))
+    positions = rng.choice([-1.0, 1.0], size=(50, 3))
+    res = backtest(returns, positions, shift=True)
+    assert res.asset_gross_returns is not None
+    assert res.asset_gross_returns.shape == (50, 3)
+    assert np.allclose(res.asset_gross_returns.sum(axis=1), res.gross_returns)
+
+
+def test_single_asset_has_no_attribution():
+    rng = np.random.default_rng(1)
+    returns = rng.normal(0.0, 0.01, 50)
+    res = backtest(returns, np.ones(50), shift=True)
+    assert res.asset_gross_returns is None
+    assert res.gross_returns.ndim == 1

--- a/fynance/tests/features/test_horizon.py
+++ b/fynance/tests/features/test_horizon.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Test forward horizon-return labels. """
+
+# Third-party packages
+import numpy as np
+import pytest
+
+# Local packages
+import fynance as fy
+from fynance.features import horizon_returns
+
+
+def test_non_overlapping_length_and_values():
+    # Constant 10% step => every 2-step forward return is 21%.
+    prices = 100. * 1.1 ** np.arange(7)  # length 7
+    out = horizon_returns(prices, 2)
+    # base indices 0, 2, 4 (t + h < T = 7) => length floor((7 - 1) / 2) = 3.
+    assert out.shape == (3,)
+    expected = prices[np.array([2, 4, 6])] / prices[np.array([0, 2, 4])] - 1.
+    assert out == pytest.approx(expected)
+    assert out == pytest.approx(np.full(3, 1.1 ** 2 - 1.))
+
+
+def test_overlapping_length_and_values():
+    prices = 100. * 1.1 ** np.arange(7)
+    out = horizon_returns(prices, 2, overlapping=True)
+    # base indices 0..4 => length T - h = 5.
+    assert out.shape == (5,)
+    base = np.arange(5)
+    expected = prices[base + 2] / prices[base] - 1.
+    assert out == pytest.approx(expected)
+
+
+def test_horizon_one_matches_simple_returns():
+    prices = np.array([100., 110., 99., 108.9, 130.68])
+    out = horizon_returns(prices, 1, overlapping=True)
+    expected = prices[1:] / prices[:-1] - 1.
+    assert out == pytest.approx(expected)
+
+
+def test_manual_computation():
+    prices = np.array([10., 12., 9., 18., 20., 15.])
+    out = horizon_returns(prices, 3)
+    # Non-overlapping: base indices 0, 3 (t + 3 < 6) => length floor(5 / 3) = 1.
+    # Only base index 0 keeps t + 3 = 3 < 6; index 3 would need t + 3 = 6.
+    assert out.shape == (1,)
+    assert out[0] == pytest.approx(18. / 10. - 1.)
+
+
+def test_leakage_probe_beyond_window_does_not_change_label():
+    # The label at t depends ONLY on the endpoints prices[t] and prices[t+h].
+    # Perturbing any price that is not an endpoint of label 0's window must not
+    # change label 0 (no leakage); perturbing label 1's forward endpoint must.
+    rng = np.random.default_rng(0)
+    prices = 100. * np.cumprod(1. + rng.standard_normal(20) * 0.01)
+    h = 4
+    base = horizon_returns(prices, h)  # base indices 0, 4, 8, 12 -> endpoints 4, 8, 12, 16
+    # Perturb prices[16], strictly beyond label 0's forward endpoint (index 4).
+    perturbed = prices.copy()
+    perturbed[16] *= 2.0
+    after = horizon_returns(perturbed, h)
+    # Label 0 (uses prices[0], prices[4]) is unchanged.
+    assert after[0] == pytest.approx(base[0])
+    # Label 3 (base index 12 -> uses prices[12], prices[16]) changes,
+    # confirming the probe actually moved an endpoint.
+    assert after[3] != pytest.approx(base[3])
+
+
+def test_panel_shape():
+    rng = np.random.default_rng(1)
+    prices = 100. * np.cumprod(1. + rng.standard_normal((30, 4)) * 0.01, axis=0)
+    out = horizon_returns(prices, 5)
+    # base indices 0, 5, ..., 25 (t + 5 < 30) => length floor(29 / 5) = 5.
+    assert out.shape == (5, 4)
+    base_idx = np.arange(0, 30 - 5, 5)
+    expected = prices[base_idx + 5] / prices[base_idx] - 1.
+    assert out == pytest.approx(expected)
+
+
+def test_strictly_causal_label_uses_future_only():
+    # Label at t equals prices[t+h]/prices[t]-1; it must not depend on prices
+    # strictly between t and t+h.
+    prices = np.array([1., 2., 4., 8., 16., 32.])
+    h = 3
+    out = horizon_returns(prices, h, overlapping=True)
+    # First label (t=0) = prices[3]/prices[0]-1 = 8/1-1 = 7.
+    assert out[0] == pytest.approx(7.0)
+    perturbed = prices.copy()
+    perturbed[1] = 999.  # strictly inside the (0, 3) window
+    perturbed[2] = -999.
+    out2 = horizon_returns(perturbed, h, overlapping=True)
+    assert out2[0] == pytest.approx(out[0])
+
+
+def test_invalid_horizon_raises():
+    prices = np.array([1., 2., 3.])
+    with pytest.raises(ValueError):
+        horizon_returns(prices, 0)
+    with pytest.raises(ValueError):
+        horizon_returns(prices, -1)
+
+
+def test_horizon_too_large_raises():
+    prices = np.array([1., 2., 3.])
+    with pytest.raises(ValueError):
+        horizon_returns(prices, 3)  # T == h, no label fits
+
+
+def test_exposed_on_top_level_package():
+    assert fy.horizon_returns is horizon_returns

--- a/fynance/tests/metrics/test_correlation.py
+++ b/fynance/tests/metrics/test_correlation.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Test the Information Coefficient / rank-IC metric. """
+
+# Third-party packages
+import numpy as np
+import pytest
+
+# Local packages
+import fynance as fy
+from fynance.metrics import information_coefficient
+
+
+def test_perfect_ic_is_one():
+    real = np.array([1., 2., 3., 4., 5., 6.])
+    pred = real.copy()
+    assert information_coefficient(pred, real, method='spearman') == pytest.approx(1.0)
+    assert information_coefficient(pred, real, method='pearson') == pytest.approx(1.0)
+
+
+def test_inverted_rank_ic_is_minus_one():
+    real = np.array([1., 2., 3., 4., 5., 6.])
+    pred = -real
+    assert information_coefficient(pred, real, method='spearman') == pytest.approx(-1.0)
+    assert information_coefficient(pred, real, method='pearson') == pytest.approx(-1.0)
+
+
+def test_monotone_nonlinear_rank_vs_level():
+    # A monotone non-linear map preserves the ordering (rank-IC == 1) but bends
+    # the line (pearson < 1): this proves spearman ranks rather than levels.
+    real = np.array([1., 2., 3., 4., 5., 6., 7., 8.])
+    pred = real ** 3
+    spearman = information_coefficient(pred, real, method='spearman')
+    pearson = information_coefficient(pred, real, method='pearson')
+    assert spearman == pytest.approx(1.0)
+    assert pearson < 1.0
+
+
+def test_pure_noise_ic_is_small():
+    rng = np.random.default_rng(0)
+    real = rng.standard_normal(2000)
+    pred = rng.standard_normal(2000)  # independent of real
+    ic = information_coefficient(pred, real, method='spearman')
+    assert abs(ic) < 0.1
+
+
+def test_zero_variance_returns_nan_not_exception():
+    real = np.array([1., 2., 3., 4., 5.])
+    flat = np.full(5, 7.0)  # zero variance prediction
+    assert np.isnan(information_coefficient(flat, real, method='pearson'))
+    assert np.isnan(information_coefficient(flat, real, method='spearman'))
+
+
+def test_fewer_than_two_valid_points_returns_nan():
+    # Only one finite pair survives the NaN drop -> nan, no exception.
+    pred = np.array([1.0, np.nan, np.nan])
+    real = np.array([1.0, 2.0, 3.0])
+    assert np.isnan(information_coefficient(pred, real, method='spearman'))
+    assert np.isnan(information_coefficient(pred, real, method='pearson'))
+
+
+def test_nan_pairs_are_dropped():
+    # Dropping the NaN pair leaves a perfectly ordered (pred, real) set.
+    real = np.array([1.0, 2.0, np.nan, 4.0, 5.0])
+    pred = np.array([10.0, 20.0, 99.0, 40.0, 50.0])
+    assert information_coefficient(pred, real, method='spearman') == pytest.approx(1.0)
+
+
+def test_panel_cross_sectional_ic_per_bar():
+    # Default axis=0 on a (T, N) panel returns one cross-sectional IC per bar.
+    pred = np.array([[1., 2., 3.],
+                     [1., 2., 3.],
+                     [1., 2., 3.]])
+    real = np.array([[1., 2., 3.],    # correct ranking
+                     [3., 2., 1.],    # inverted ranking
+                     [2., 3., 1.]])   # partial
+    ic = information_coefficient(pred, real, method='spearman')
+    assert ic.shape == (3,)
+    assert ic[0] == pytest.approx(1.0)
+    assert ic[1] == pytest.approx(-1.0)
+    # Hand-check the third bar: ranks of pred = [1, 2, 3], ranks of real =
+    # [2, 3, 1]; spearman == pearson on those ranks.
+    from scipy.stats import rankdata
+    rp = rankdata(pred[2])
+    rr = rankdata(real[2])
+    expected = np.corrcoef(rp, rr)[0, 1]
+    assert ic[2] == pytest.approx(expected)
+
+
+def test_panel_axis1_is_time_series_ic_per_asset():
+    # axis=1 correlates along time within each column -> one IC per asset.
+    real = np.array([[1., 5.],
+                     [2., 4.],
+                     [3., 3.],
+                     [4., 2.],
+                     [5., 1.]])
+    pred = real.copy()
+    ic = information_coefficient(pred, real, method='spearman', axis=1)
+    assert ic.shape == (2,)
+    assert ic == pytest.approx(np.array([1.0, 1.0]))
+
+
+def test_unknown_method_raises():
+    real = np.array([1., 2., 3.])
+    with pytest.raises(ValueError):
+        information_coefficient(real, real, method='kendall')
+
+
+def test_mismatched_shapes_raise():
+    with pytest.raises(ValueError):
+        information_coefficient(np.array([1., 2.]), np.array([1., 2., 3.]))
+
+
+def test_exposed_on_top_level_package():
+    assert fy.information_coefficient is information_coefficient
+
+
+def test_ic_decreases_with_noise():
+    # IC must decrease monotonically as more noise is mixed into the signal.
+    rng = np.random.default_rng(42)
+    real = rng.standard_normal(5000)
+    noise = rng.standard_normal(5000)
+    ics = [
+        information_coefficient(real + k * noise, real, method='spearman')
+        for k in (0.0, 0.5, 1.0, 2.0, 4.0)
+    ]
+    assert all(ics[i] > ics[i + 1] for i in range(len(ics) - 1))
+    assert ics[0] == pytest.approx(1.0)

--- a/fynance/tests/models/test_loss.py
+++ b/fynance/tests/models/test_loss.py
@@ -12,7 +12,10 @@ import torch
 
 # Local packages
 from fynance.models.loss import (
+    CalmarLoss,
     DirectionalAccuracyLoss,
+    OmegaLoss,
+    RankingLoss,
     SharpeLoss,
     SortinoLoss,
 )
@@ -356,3 +359,88 @@ def test_train_model_with_calmar_loss():
     model.set_optimizer(CalmarLoss, torch.optim.Adam, lr=1e-2)
     loss = model.train_on(model.X, model.y)
     assert torch.isfinite(loss)
+
+
+# Book-aware aggregation: a 2-D (T, N) position book is summed across assets
+# into the 1-D book return before the ratio is scored. ObjectiveModel already
+# pre-aggregates, so this is additive; it must leave 1-D / (T, 1) unchanged.
+_RATIO_LOSSES = [SharpeLoss, SortinoLoss, CalmarLoss, OmegaLoss]
+
+
+class TestBookAwareLosses:
+    @pytest.mark.parametrize("loss_cls", _RATIO_LOSSES)
+    def test_book_equals_summed_book_return(self, loss_cls):
+        # loss((T, N)) == loss(book.sum(axis=1)) for every ratio loss.
+        book = torch.from_numpy(
+            RNG.standard_normal((T, 3)).astype(np.float32) * 0.01)
+        loss_fn = loss_cls()
+        assert torch.allclose(loss_fn(book), loss_fn(book.sum(dim=1)))
+
+    @pytest.mark.parametrize("loss_cls", _RATIO_LOSSES)
+    def test_single_column_matches_1d(self, loss_cls):
+        # A (T, 1) book reduces to exactly the single-asset 1-D series (no
+        # behaviour change for the existing single-asset path).
+        r = torch.from_numpy(RNG.standard_normal(T).astype(np.float32) * 0.01)
+        loss_fn = loss_cls()
+        assert torch.allclose(loss_fn(r), loss_fn(r.reshape(T, 1)))
+
+    @pytest.mark.parametrize("loss_cls", _RATIO_LOSSES)
+    def test_book_gradient_finite_and_nonzero(self, loss_cls):
+        # The book objective stays differentiable: a finite, non-zero gradient
+        # flows back to every per-asset return on a normal panel batch.
+        book = torch.from_numpy(
+            RNG.standard_normal((T, 3)).astype(np.float32) * 0.01
+        ).requires_grad_(True)
+        loss = loss_cls()(book)
+        loss.backward()
+        assert book.grad is not None
+        assert torch.isfinite(book.grad).all()
+        assert book.grad.abs().sum() > 0
+
+
+class TestRankingLoss:
+    def _panel(self, n_assets=4):
+        scores = torch.from_numpy(
+            RNG.standard_normal((T, n_assets)).astype(np.float32))
+        real = scores * 0.01  # returns aligned with the scores' ranking
+        return scores, real
+
+    def test_aligned_beats_inverted(self):
+        scores, real = self._panel()
+        loss_fn = RankingLoss()
+        aligned = loss_fn(scores, real)
+        inverted = loss_fn(-scores, real)
+        assert aligned.shape == torch.Size([])
+        assert aligned.item() < inverted.item()
+
+    def test_aligned_beats_random(self):
+        scores, real = self._panel()
+        random_scores = torch.from_numpy(
+            RNG.standard_normal((T, scores.shape[1])).astype(np.float32))
+        loss_fn = RankingLoss()
+        assert loss_fn(scores, real).item() < loss_fn(random_scores, real).item()
+
+    def test_gradient_finite_and_nonzero(self):
+        scores, real = self._panel()
+        scores = scores.requires_grad_(True)
+        loss = RankingLoss()(scores, real)
+        loss.backward()
+        assert scores.grad is not None
+        assert torch.isfinite(scores.grad).all()
+        assert scores.grad.abs().sum() > 0
+
+    def test_requires_2d_panel(self):
+        with pytest.raises(ValueError):
+            RankingLoss()(torch.randn(T), torch.randn(T))
+
+    def test_requires_at_least_two_assets(self):
+        with pytest.raises(ValueError):
+            RankingLoss()(torch.randn(T, 1), torch.randn(T, 1))
+
+    def test_shape_mismatch_raises(self):
+        with pytest.raises(ValueError):
+            RankingLoss()(torch.randn(T, 3), torch.randn(T, 4))
+
+    def test_non_tensor_raises(self):
+        with pytest.raises(TypeError):
+            RankingLoss()(np.zeros((T, 3)), np.zeros((T, 3)))

--- a/fynance/tests/models/test_objective.py
+++ b/fynance/tests/models/test_objective.py
@@ -79,6 +79,107 @@ def test_accepts_custom_net_and_loss():
     assert np.asarray(model.predict(X)).shape == (300, 1)
 
 
+def _panel_edge(n=1500, n_assets=3, m_features=2, seed=0):
+    """ A learnable panel edge: each asset's own feature predicts its return.
+
+    Returns ``X`` of shape ``(n, n_assets, m_features)`` (the first feature of
+    each asset is its sign signal, the rest are noise) and ``y`` of shape
+    ``(n, n_assets)`` (each asset's realized per-bar return).
+    """
+    rng = np.random.default_rng(seed)
+    feats, rets = [], []
+    for _ in range(n_assets):
+        s = rng.choice([-1.0, 1.0], size=n)
+        r = (s * 0.01 + rng.standard_normal(n) * 0.01).astype(np.float32)
+        cols = [s] + [rng.standard_normal(n) for _ in range(m_features - 1)]
+        feats.append(np.column_stack(cols).astype(np.float32))
+        rets.append(r)
+    X = np.stack(feats, axis=1)                     # (n, n_assets, m_features)
+    y = np.column_stack(rets).astype(np.float32)    # (n, n_assets)
+
+    return X, y
+
+
+def _book_turnover(pos):
+    """ Mean per-bar turnover aggregated across the book's asset columns. """
+    pos = np.asarray(pos)
+    return float(np.abs(np.diff(pos, axis=0, prepend=0.0)).sum(axis=1).mean())
+
+
+def test_panel_predict_shape_3d_and_flat():
+    # A 3-D panel (T, N, M) and its pre-flattened (T, N*M) form must both be
+    # accepted and yield the *same* position book of shape (T, N).
+    X, y = _panel_edge(n=300, n_assets=3, m_features=2)
+    model = ObjectiveModel(layers=(8,), epochs=20, lr=5e-3, seed=0).fit(X, y)
+    pos = np.asarray(model.predict(X))
+    assert pos.shape == (300, 3)
+    assert model.n_assets == 3
+
+    Xflat = X.reshape(X.shape[0], -1)
+    model2 = ObjectiveModel(n_assets=3, layers=(8,), epochs=20, lr=5e-3,
+                            seed=0).fit(Xflat, y)
+    pos2 = np.asarray(model2.predict(Xflat))
+    assert pos2.shape == (300, 3)
+    assert np.allclose(pos, pos2)
+
+
+def test_panel_positions_are_bounded():
+    # With tanh, each per-asset position stays within [-1, 1].
+    X, y = _panel_edge(n=300, n_assets=3)
+    pos = np.asarray(ObjectiveModel(epochs=10, seed=0).fit(X, y).predict(X))
+    assert pos.shape == (300, 3)
+    assert np.all(np.abs(pos) <= 1.0 + 1e-6)
+
+
+def test_panel_book_learns_a_known_edge():
+    # Each of the N=3 assets has its own learnable edge; the aggregated book
+    # return should achieve a clearly positive Sharpe.
+    X, y = _panel_edge(n_assets=3, seed=0)
+    model = ObjectiveModel(layers=(8,), epochs=150, lr=5e-3, seed=0).fit(X, y)
+    pos = np.asarray(model.predict(X))
+    assert pos.shape == (1500, 3)
+
+    book_ret = (pos * y).sum(axis=1)
+    assert sharpe(np.cumprod(1 + book_ret), period=252) > 1.0
+
+
+def test_panel_cost_reduces_book_turnover():
+    # On a fast-flipping panel, the turnover-penalized book churns less than the
+    # cost-free one (aggregated across asset columns).
+    s = np.where(np.arange(1500) % 2 == 0, 1.0, -1.0)
+    rng = np.random.default_rng(0)
+    feats, rets = [], []
+    for _ in range(3):
+        r = (s * 0.01 + rng.standard_normal(1500) * 0.005).astype(np.float32)
+        feats.append(np.column_stack([s, rng.standard_normal(1500)]
+                                     ).astype(np.float32))
+        rets.append(r)
+    X = np.stack(feats, axis=1)
+    y = np.column_stack(rets).astype(np.float32)
+
+    free = ObjectiveModel(layers=(8,), epochs=200, lr=5e-3, seed=0).fit(X, y)
+    pricey = ObjectiveModel(layers=(8,), epochs=200, lr=5e-3, cost=0.1,
+                            seed=0).fit(X, y)
+
+    assert _book_turnover(pricey.predict(X)) < _book_turnover(free.predict(X))
+
+
+def test_n1_explicit_matches_inferred():
+    # Strict N=1 non-regression: an explicit n_assets=1 run, the inferred path
+    # from a 1-D y, and a 2-D (T, 1) y must all give identical positions, with a
+    # (T, 1) shape -- the single-asset behaviour is unchanged.
+    X, returns = _edge_data(n=400)
+    inferred = ObjectiveModel(epochs=20, seed=42).fit(X, returns).predict(X)
+    explicit = ObjectiveModel(n_assets=1, epochs=20,
+                              seed=42).fit(X, returns).predict(X)
+    twod_y = ObjectiveModel(epochs=20, seed=42).fit(
+        X, returns.reshape(-1, 1)).predict(X)
+
+    assert inferred.shape == (400, 1)
+    assert np.array_equal(inferred, explicit)
+    assert np.array_equal(inferred, twod_y)
+
+
 def _alternating_edge(n=1500, seed=0):
     """ Sign flips every bar: the no-cost optimum churns (turnover ~2/bar). """
     s = np.where(np.arange(n) % 2 == 0, 1.0, -1.0)

--- a/fynance/tests/plot/test_attribution.py
+++ b/fynance/tests/plot/test_attribution.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for per-asset attribution figures and the book tearsheet. """
+
+# Built-in packages
+from types import SimpleNamespace
+
+# Third-party packages
+import matplotlib
+import numpy as np
+
+matplotlib.use("Agg")
+
+# Local packages
+from fynance.plot import plot_contribution, plot_turnover, tearsheet
+
+
+def _book_result(n=120, n_assets=3, seed=0):
+    """ A duck-typed multi-asset BacktestResult-like object. """
+    rng = np.random.default_rng(seed)
+    asset_gross = rng.normal(0.0, 0.01, (n, n_assets))
+    gross = asset_gross.sum(axis=1)
+    equity = np.cumprod(1.0 + gross)
+    positions = rng.choice([-1.0, 0.0, 1.0], size=(n, n_assets))
+
+    return SimpleNamespace(
+        equity=equity, returns=gross, gross_returns=gross,
+        positions=positions, asset_gross_returns=asset_gross, index=None,
+    )
+
+
+def test_plot_contribution_is_cumulative_per_asset():
+    asset = np.array([[0.01, -0.02], [0.03, 0.01]])
+    ax = plot_contribution(asset)
+    lines = ax.get_lines()
+    assert len(lines) == 2
+    # The last cumulative value of each line is that asset's total contribution.
+    assert np.isclose(lines[0].get_ydata()[-1], asset[:, 0].sum())
+    assert np.isclose(lines[1].get_ydata()[-1], asset[:, 1].sum())
+
+
+def test_plot_turnover_charges_entry_from_flat():
+    pos = np.array([[1.0, 0.0], [1.0, 1.0], [0.0, 1.0]])
+    ax = plot_turnover(pos)
+    lines = ax.get_lines()
+    assert len(lines) == 2
+    # Asset 0: |1-0|, |1-1|, |0-1| = 1, 0, 1 (first step is entry from flat).
+    assert np.allclose(lines[0].get_ydata(), [1.0, 0.0, 1.0])
+
+
+def test_tearsheet_book_adds_attribution_panels():
+    fig = tearsheet(_book_result())
+    # 2x2 core report + contribution + turnover = 6 axes.
+    assert len(fig.axes) == 6
+    titles = " ".join(ax.get_title().lower() for ax in fig.axes)
+    assert "contribution" in titles
+    assert "turnover" in titles
+
+
+def test_tearsheet_single_asset_stays_2x2():
+    equity = np.cumprod(1.0 + np.random.default_rng(0).normal(0.0, 0.01, 100))
+    fig = tearsheet(equity)
+    assert len(fig.axes) == 4

--- a/fynance/tests/research/test_report.py
+++ b/fynance/tests/research/test_report.py
@@ -131,3 +131,32 @@ def test_tearsheet_plots_dates_for_indexed_curve():
 
     assert np.issubdtype(xdata.dtype, np.datetime64)
     assert isinstance(ax.xaxis.get_major_locator(), mdates.AutoDateLocator)
+
+
+@pytest.fixture
+def panel_experiment():
+    """ A real multi-asset (panel) experiment. """
+    rng = np.random.default_rng(7)
+    prices = 100.0 * np.cumprod(1.0 + rng.normal(0.0003, 0.01, (300, 3)), axis=0)
+
+    def panel_momentum(p):
+        r = np.zeros_like(p)
+        r[1:] = np.sign(p[1:] - p[:-1])
+        return r
+
+    strat = Strategy(features=panel_momentum, signal=lambda x: x)
+
+    return run_experiment(strat, prices, name="panel")
+
+
+def test_report_book_writes_attribution(tmp_path, panel_experiment):
+    # A panel experiment persists per-asset attribution; the tearsheet PNG is
+    # written and the provenance table records the asset count.
+    assert "asset_contrib" in panel_experiment.series
+
+    out = write_report(panel_experiment, tmp_path, notebook=False)
+    png = tmp_path / "panel" / "tearsheet.png"
+
+    assert out["png"] == png and png.is_file() and png.stat().st_size > 0
+    text = (tmp_path / "panel" / "report.md").read_text()
+    assert "3 assets" in text

--- a/fynance/tests/research/test_run_experiment.py
+++ b/fynance/tests/research/test_run_experiment.py
@@ -139,3 +139,28 @@ def test_non_datetime_index_yields_no_date_axis():
     exp = run_experiment(momentum(), gbm(200, seed=2), name="bars")
 
     assert "index" not in exp.series
+
+
+def test_run_experiment_panel(tmp_path):
+    # A 2-D (T, N) panel runs end to end: book equity, per-asset attribution
+    # persisted, and N recorded in the provenance.
+    rng = np.random.default_rng(4)
+    prices = 100.0 * np.cumprod(1.0 + rng.normal(0.0003, 0.01, (300, 3)), axis=0)
+
+    def panel_momentum(p):
+        r = np.zeros_like(p)
+        r[1:] = np.sign(p[1:] - p[:-1])
+        return r
+
+    strat = Strategy(features=panel_momentum, signal=lambda x: x)
+    exp = run_experiment(strat, prices, name="panel", output_dir=tmp_path)
+
+    assert exp.spec["data"]["n_assets"] == 3
+    assert "asset_contrib" in exp.series
+    assert exp.series["equity"]
+
+
+def test_run_experiment_single_asset_provenance():
+    exp = run_experiment(momentum(), gbm(200, seed=2), name="single")
+    assert exp.spec["data"]["n_assets"] == 1
+    assert "asset_contrib" not in exp.series

--- a/fynance/tests/strategy/test_strategy.py
+++ b/fynance/tests/strategy/test_strategy.py
@@ -168,3 +168,54 @@ def test_walk_forward_no_lookahead():
     prefix = cut - 100 - 40  # conservative: before any window touching the tail
     assert prefix > 0
     assert np.allclose(base.positions[:prefix], pert.positions[:prefix])
+
+
+def _panel_prices(n=300, n_assets=3, seed=0):
+    rng = np.random.default_rng(seed)
+    rets = rng.normal(0.0003, 0.01, (n, n_assets))
+    return 100.0 * np.cumprod(1.0 + rets, axis=0)
+
+
+def _panel_momentum(prices):
+    # Per-asset sign of the last price change -> a (T, N) position book.
+    r = np.zeros_like(prices)
+    r[1:] = np.sign(prices[1:] - prices[:-1])
+    return r
+
+
+def test_run_panel_book_attribution():
+    strat = Strategy(features=_panel_momentum, signal=lambda x: x)
+    res = strat.run(_panel_prices())
+    assert isinstance(res, BacktestResult)
+    assert res.asset_gross_returns is not None
+    assert res.asset_gross_returns.shape[1] == 3
+    assert np.allclose(res.asset_gross_returns.sum(axis=1), res.gross_returns)
+
+
+def test_run_single_asset_unchanged():
+    # The single-asset path keeps a 1-D book and carries no attribution.
+    def momentum(prices):
+        r = np.zeros_like(prices)
+        r[1:] = np.sign(prices[1:] - prices[:-1])
+        return r
+
+    res = Strategy(features=momentum, signal=lambda x: x).run(_prices())
+    assert res.asset_gross_returns is None
+    assert res.gross_returns.ndim == 1
+
+
+def test_walk_forward_panel_book_and_no_lookahead():
+    prices = _panel_prices(n=400, n_assets=3, seed=1)
+    strat = Strategy(features=_panel_momentum, signal=lambda x: x)
+    res = strat.run_walk_forward(prices, y=np.zeros(len(prices)), train=100, test=50)
+    assert res.asset_gross_returns is not None
+    assert res.asset_gross_returns.shape[1] == 3
+    assert np.allclose(res.asset_gross_returns.sum(axis=1), res.gross_returns)
+
+    # No lookahead: perturbing the tail leaves the earlier OOS prefix unchanged.
+    pert = prices.copy()
+    cut = int(len(prices) * 0.7)
+    pert[cut:] *= 1.05
+    res2 = strat.run_walk_forward(pert, y=np.zeros(len(pert)), train=100, test=50)
+    k = res.returns.shape[0] // 3
+    assert np.allclose(res.returns[:k], res2.returns[:k])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fynance"
-version = "2.10.2"
+version = "2.11.0"
 description = "Pure-Python (Numba-accelerated) machine learning, econometrics and statistical tools for financial analysis and backtesting"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Release **v2.11.0** (minor — multi-asset / panel R&D harness).

### Added
- Multi-asset / panel harness: panel `ObjectiveModel` (book `(T, N)`), panel `Strategy`/`run_experiment` + per-asset attribution, book tearsheet. (#215, #218, #219)
- `information_coefficient` (rank-IC) + `horizon_returns`. (#216)
- `RankingLoss`. (#217)

### Changed
- Book-aware ratio losses. (#217)

Single-asset `N=1` unchanged. Merged after `chore/release-2.11.0` (#221) landed in `develop`.