### PR TITLE
chore: release v2.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [2.11.1] - 2026-06-25
+
+### Added
+
 - **Tearsheet equity readability.** `plot_equity` / `tearsheet` gained two
   display-only options: `base` (rescale the curve to start at e.g. `100` for a
   base-100 reading) and `logy` (`"auto"` switches to a log y-axis on

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fynance"
-version = "2.11.0"
+version = "2.11.1"
 description = "Pure-Python (Numba-accelerated) machine learning, econometrics and statistical tools for financial analysis and backtesting"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Release **v2.11.1** — patch (tearsheet readability, display-only, backward-compatible).

## [2.11.1]

### Added

- **Tearsheet equity readability.** `plot_equity` / `tearsheet` gained two display-only options: `base` (rescale the curve to start at e.g. `100` for a base-100 reading) and `logy` (`"auto"` switches to a log y-axis on wide-amplitude curves — a ×3–×30 trajectory stays readable and drawdowns stay comparable across time — overridable with `True`/`False`).

## Test plan

- `pytest` — 949 passed, 1 skipped
- `ruff check fynance/` — clean
- `mypy` — clean
- `sphinx -W` (clean build) — clean
- CI green on develop (PR #223)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
