### PR TITLE
Release v2.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [2.11.1] - 2026-06-25
+
+### Added
+
 - **Tearsheet equity readability.** `plot_equity` / `tearsheet` gained two
   display-only options: `base` (rescale the curve to start at e.g. `100` for a
   base-100 reading) and `logy` (`"auto"` switches to a log y-axis on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Tearsheet equity readability.** `plot_equity` / `tearsheet` gained two
+  display-only options: `base` (rescale the curve to start at e.g. `100` for a
+  base-100 reading) and `logy` (`"auto"` switches to a log y-axis on
+  wide-amplitude curves — a x3-x30 trajectory stays readable and drawdowns stay
+  comparable across time — overridable with `True`/`False`).
+
 ### Changed
 
 ### Fixed

--- a/fynance/plot/equity.py
+++ b/fynance/plot/equity.py
@@ -8,17 +8,67 @@ from __future__ import annotations
 # Built-in packages
 from typing import Any
 
+# Third-party packages
+import numpy as np
+from numpy.typing import NDArray
+
 # Local packages
 from fynance.plot._helpers import as_equity, drawdown_curve
 
 __all__ = ['plot_equity', 'plot_drawdown']
 
+# Auto log-scale kicks in once the equity spans more than this multiplicative
+# range (max / min): a linear axis then crushes the early trajectory and makes
+# drawdowns visually incomparable across time.
+_LOG_Y_RATIO = 5.0
 
-def plot_equity(result: Any, ax: Any = None) -> Any:
-    """ Plot an equity curve. Returns the matplotlib ``Axes``. """
+
+def _use_log_y(equity: NDArray, logy: bool | str) -> bool:
+    """ Resolve the ``logy`` policy into a concrete log/linear choice. """
+    positive = bool(equity.size) and bool(np.all(equity > 0.0))
+
+    if logy == "auto":
+        if not positive:
+
+            return False
+
+        return float(equity.max() / equity.min()) > _LOG_Y_RATIO
+
+    return bool(logy) and positive
+
+
+def plot_equity(result: Any, ax: Any = None, *, base: float | None = None,
+                logy: bool | str = "auto") -> Any:
+    """ Plot an equity curve. Returns the matplotlib ``Axes``.
+
+    Parameters
+    ----------
+    result : BacktestResult, PriceSeries or array-like
+        The strategy result (or a raw equity curve).
+    ax : matplotlib.axes.Axes, optional
+        Axis to draw on; a new one is created when omitted.
+    base : float, optional
+        Rescale the curve to start at ``base`` (display only). The default
+        equity starts at the capital (``1.0``); ``base=100`` gives the familiar
+        base-100 reading without touching the underlying numbers.
+    logy : bool or {"auto"}, default "auto"
+        Use a logarithmic y-axis. ``"auto"`` switches to log only when the curve
+        spans more than a 5x range (and stays strictly positive), so a x3-x30
+        trajectory stays readable while a flat curve is left linear.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+
+    """
     import matplotlib.pyplot as plt
 
     equity, index = as_equity(result)
+
+    if (base is not None and equity.size and np.isfinite(equity[0])
+            and equity[0] != 0.0):
+        equity = equity * (base / equity[0])
+
     x = range(len(equity)) if index is None else index
 
     if ax is None:
@@ -26,8 +76,11 @@ def plot_equity(result: Any, ax: Any = None) -> Any:
 
     ax.plot(x, equity, color="#2c7fb8", lw=1.5)
     ax.set_title("Equity curve")
-    ax.set_ylabel("Equity")
+    ax.set_ylabel("Equity" if base is None else f"Equity (base {base:g})")
     ax.grid(alpha=0.3)
+
+    if _use_log_y(equity, logy):
+        ax.set_yscale("log")
 
     return ax
 

--- a/fynance/plot/tearsheet.py
+++ b/fynance/plot/tearsheet.py
@@ -33,7 +33,8 @@ def _summary(result: Any, period: int) -> dict[str, float]:
     return summary(equity, period=period)
 
 
-def tearsheet(result: Any, period: int = 252, figsize: tuple = (11, 7)) -> Any:
+def tearsheet(result: Any, period: int = 252, figsize: tuple = (11, 7), *,
+              base: float | None = None, logy: bool | str = "auto") -> Any:
     """ Build a full performance report figure.
 
     Composes the equity curve, drawdown, rolling Sharpe, return distribution
@@ -48,6 +49,12 @@ def tearsheet(result: Any, period: int = 252, figsize: tuple = (11, 7)) -> Any:
         Annualization factor.
     figsize : tuple
         Figure size.
+    base : float, optional
+        Rescale the equity panel to start at ``base`` (e.g. ``100`` for the
+        familiar base-100 reading); display only, see :func:`plot_equity`.
+    logy : bool or {"auto"}, default "auto"
+        Log y-axis policy for the equity panel; ``"auto"`` switches to log on
+        wide-amplitude curves, see :func:`plot_equity`.
 
     Returns
     -------
@@ -71,7 +78,7 @@ def tearsheet(result: Any, period: int = 252, figsize: tuple = (11, 7)) -> Any:
     fig = plt.figure(figsize=(figsize[0], figsize[1] * (1.4 if is_book else 1.0)))
     gs = fig.add_gridspec(n_rows, 2)
 
-    plot_equity(result, ax=fig.add_subplot(gs[0, 0]))
+    plot_equity(result, ax=fig.add_subplot(gs[0, 0]), base=base, logy=logy)
     plot_drawdown(result, ax=fig.add_subplot(gs[0, 1]))
     plot_rolling_sharpe(result, window=period, ax=fig.add_subplot(gs[1, 0]))
 

--- a/fynance/tests/plot/test_smoke.py
+++ b/fynance/tests/plot/test_smoke.py
@@ -53,3 +53,34 @@ def test_tearsheet_text_matches_summary():
     txt = tearsheet_text(res)
     assert "sharpe" in txt
     assert "max_drawdown" in txt
+
+
+def test_plot_equity_base_rescales_start():
+    # base=100 must rescale the displayed curve to start at 100 (display only).
+    res = _result()
+    ax = plot_equity(res, base=100.0)
+    ydata = ax.get_lines()[0].get_ydata()
+    assert abs(float(ydata[0]) - 100.0) < 1e-9
+    plt.close("all")
+
+
+def test_plot_equity_logy_auto_switches_on_wide_amplitude():
+    # A x20 ramp trips the auto log-scale; a near-flat curve stays linear.
+    ax = plot_equity(np.linspace(1.0, 20.0, 100))
+    assert ax.get_yscale() == "log"
+    plt.close("all")
+
+    ax = plot_equity(np.linspace(1.0, 1.2, 100))
+    assert ax.get_yscale() == "linear"
+    plt.close("all")
+
+
+def test_plot_equity_logy_explicit_overrides_auto():
+    # logy=False forces linear even when auto would have gone log.
+    ax = plot_equity(np.linspace(1.0, 20.0, 100), logy=False)
+    assert ax.get_yscale() == "linear"
+    plt.close("all")
+    # logy=True forces log even on a flat curve (still strictly positive).
+    ax = plot_equity(np.linspace(1.0, 1.2, 100), logy=True)
+    assert ax.get_yscale() == "log"
+    plt.close("all")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fynance"
-version = "2.11.0"
+version = "2.11.1"
 description = "Pure-Python (Numba-accelerated) machine learning, econometrics and statistical tools for financial analysis and backtesting"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
> This PR will be merged into `master` **after** `chore/release-2.11.1` (#224) lands in `develop`, then tagged `v2.11.1`.

## [2.11.1]

### Added

- **Tearsheet equity readability.** `plot_equity` / `tearsheet` gained two display-only options: `base` (rescale the curve to start at e.g. `100` for a base-100 reading) and `logy` (`"auto"` switches to a log y-axis on wide-amplitude curves — a ×3–×30 trajectory stays readable and drawdowns stay comparable across time — overridable with `True`/`False`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
