### PR TITLE
feat: trade-profile metrics (sign changes / trades per year)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Trading-profile metrics.** `sign_changes` / `trades_per_year`
+  (`fynance.metrics`) count position direction flips (long↔flat↔short), total
+  and per-asset for a book — the round-trip churn a turnover-blind `total_cost`
+  hides. `BacktestResult.summary()` now reports `n_sign_changes` and
+  `trades_per_year`, so they flow into the research report automatically.
+
 ### Changed
 
 ### Fixed

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -42,3 +42,13 @@ Le harnais `fynance.research` est **livré** (S1–S3) : `Experiment`,
 
 - [ ] Explorateur **Streamlit** au-dessus du Ledger (parcourir / filtrer / comparer
   les runs persistés) — interactif, plus tardif.
+
+## 3. Métriques de profil de trading & coûts (signalé à l'usage par `fynance-research`)
+
+Métriques génériques utiles à tout report de stratégie (calculées à la main côté usage
+aujourd'hui ; remontables en librairie data-agnostique) :
+
+- [ ] **Décomposition des coûts dans le tearsheet** — un panneau « cumulative fees » ventilant
+  les composantes de coût (frais de transaction vs funding/borrow vs market-impact) en % du
+  capital. Aujourd'hui `BacktestResult` ne porte que le coût agrégé ; exposer les composantes
+  par pas (quand le `CostModel` en distingue) puis les empiler dans `write_report`.

--- a/fynance/backtest/result.py
+++ b/fynance/backtest/result.py
@@ -73,14 +73,20 @@ class BacktestResult:
         """ Standard performance summary.
 
         Delegates the risk-adjusted ratios and drawdown to
-        :func:`fynance.metrics.summary` (computed on the equity curve) and adds
-        the hit-rate and total transaction cost from the strategy's own data.
+        :func:`fynance.metrics.summary` (computed on the equity curve) and adds,
+        from the strategy's own data, the hit-rate, total transaction cost and
+        the trading-profile churn (``n_sign_changes`` / ``trades_per_year``,
+        summed over the book — see :func:`fynance.metrics.sign_changes`).
         """
         from fynance.metrics import summary as _metric_summary
+        from fynance.metrics.trading import sign_changes, trades_per_year
 
         out = _metric_summary(self.equity, period=period)
         r = self.returns[~np.isnan(self.returns)]
         out["hit_rate"] = float((r > 0).mean()) if r.size else 0.0
         out["total_cost"] = float(np.nansum(self.costs))
+        out["n_sign_changes"] = float(np.sum(sign_changes(self.positions)))
+        out["trades_per_year"] = float(
+            np.sum(trades_per_year(self.positions, period=period)))
 
         return out

--- a/fynance/metrics/__init__.py
+++ b/fynance/metrics/__init__.py
@@ -21,15 +21,18 @@ from .ratios import *
 from .returns import *
 from .returns import perf_strat, returns_strat  # noqa: F401
 from .summary import METRICS, summary  # noqa: F401
+from .trading import *
 
 # Aggregate __all__ via sys.modules (the star imports above rebind names that
 # collide with a submodule, e.g. the ``drawdown`` function vs the module).
-# ``information_coefficient`` is exported here but intentionally NOT added to the
+# ``information_coefficient`` and the trade-profile metrics (``sign_changes`` /
+# ``trades_per_year``) are exported here but intentionally NOT added to the
 # ``METRICS`` registry: that registry maps a name to a callable taking a single
 # equity/price curve (see ``summary``), whereas the IC takes an aligned
-# (pred, real) pair and so does not fit that single-series contract.
+# (pred, real) pair and the trade-profile metrics take a position series, so
+# neither fits that single-series contract.
 __all__ = []
-for _m in ("correlation", "returns", "ratios", "drawdown"):
+for _m in ("correlation", "returns", "ratios", "drawdown", "trading"):
     __all__ += _sys.modules[f"{__name__}.{_m}"].__all__
 __all__ += ['perf_strat', 'returns_strat', 'METRICS', 'summary']
 

--- a/fynance/metrics/trading.py
+++ b/fynance/metrics/trading.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Trading-profile metrics — churn of a position series or book.
+
+These describe *how* a strategy trades (turnover of direction) rather than how
+its equity curve performs, so — like :func:`information_coefficient` — they take
+a **position** series, not an equity curve, and are intentionally kept out of
+the ``METRICS`` registry.
+
+"""
+
+from __future__ import annotations
+
+# Third-party packages
+import numpy as np
+from numpy.typing import NDArray
+
+__all__ = ['sign_changes', 'trades_per_year']
+
+
+def sign_changes(positions: NDArray, *, axis: int = 0) -> NDArray | int:
+    r""" Number of position sign changes (long <-> flat <-> short).
+
+    Counts the steps where ``sign(pos_t) != sign(pos_{t-1})`` along the time
+    ``axis`` — the round-trip churn a turnover-blind ``total_cost`` hides. Flat
+    (``0``) is a distinct state, so ``long -> flat`` and ``flat -> short`` each
+    count as one change. Pairs straddling a ``NaN`` are not counted.
+
+    Parameters
+    ----------
+    positions : array_like
+        Position / weight series, shape ``(T,)`` or ``(T, n_assets)``.
+    axis : int, optional
+        Time axis. Default 0.
+
+    Returns
+    -------
+    int or numpy.ndarray
+        Total count for a 1-D series; a per-asset count vector for a 2-D book.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> sign_changes(np.array([1.0, 1.0, -1.0, -1.0, 0.0, 1.0]))
+    3
+    >>> sign_changes(np.array([[1.0, 0.0], [-1.0, 0.0], [-1.0, 1.0]]))
+    array([1, 1])
+
+    """
+    s = np.sign(np.asarray(positions, dtype=np.float64))
+    t = s.shape[axis]
+
+    if t < 2:
+
+        return 0 if s.ndim == 1 else np.zeros(s.shape[1 - axis], dtype=int)
+
+    prev = np.take(s, np.arange(t - 1), axis=axis)
+    cur = np.take(s, np.arange(1, t), axis=axis)
+    changed = (prev != cur) & ~(np.isnan(prev) | np.isnan(cur))
+    out = changed.sum(axis=axis)
+
+    return int(out) if np.ndim(out) == 0 else out.astype(int)
+
+
+def trades_per_year(positions: NDArray, period: int = 252, *,
+                    axis: int = 0) -> NDArray | float:
+    r""" Annualized number of position sign changes.
+
+    :func:`sign_changes` scaled to a yearly rate, ``n_changes / T * period``, so
+    two strategies sampled at different frequencies stay comparable.
+
+    Parameters
+    ----------
+    positions : array_like
+        Position / weight series, shape ``(T,)`` or ``(T, n_assets)``.
+    period : int, optional
+        Annualization factor (bars per year, 252 for daily). Default 252.
+    axis : int, optional
+        Time axis. Default 0.
+
+    Returns
+    -------
+    float or numpy.ndarray
+        Annualized rate for a 1-D series; a per-asset vector for a 2-D book.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> pos = np.array([1.0, -1.0, 1.0, -1.0])  # flips direction every bar
+    >>> float(trades_per_year(pos, period=252))
+    189.0
+
+    """
+    p = np.asarray(positions, dtype=np.float64)
+    t = p.shape[axis]
+    sc = sign_changes(p, axis=axis)
+
+    if t < 1:
+
+        return 0.0 if p.ndim == 1 else np.zeros(p.shape[1 - axis])
+
+    rate = np.asarray(sc, dtype=np.float64) / t * period
+
+    return float(rate) if np.ndim(rate) == 0 else rate

--- a/fynance/tests/backtest/test_result.py
+++ b/fynance/tests/backtest/test_result.py
@@ -18,9 +18,19 @@ def test_summary_keys_and_finiteness():
     res = backtest(returns, positions, shift=True)
     s = res.summary()
     for key in ("annual_return", "annual_volatility", "sharpe", "sortino",
-                "max_drawdown", "calmar", "hit_rate", "total_cost"):
+                "max_drawdown", "calmar", "hit_rate", "total_cost",
+                "n_sign_changes", "trades_per_year"):
         assert key in s
         assert np.isfinite(s[key])
+
+
+def test_summary_trade_profile_counts_sign_changes():
+    # Positions flip direction every bar -> a sign change at each step.
+    positions = np.array([1.0, -1.0, 1.0, -1.0, 1.0, -1.0])
+    res = backtest(np.zeros(6), positions, shift=False)
+    s = res.summary(period=252)
+    assert s["n_sign_changes"] == 5.0
+    assert np.isclose(s["trades_per_year"], 5.0 / 6.0 * 252.0)
 
 
 def test_to_price_series():

--- a/fynance/tests/metrics/test_trading.py
+++ b/fynance/tests/metrics/test_trading.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for the trading-profile metrics (sign-change churn). """
+
+# Third-party packages
+import numpy as np
+
+# Local packages
+from fynance.metrics import sign_changes, trades_per_year
+
+
+def test_sign_changes_counts_long_flat_short_transitions():
+    # 1 -> 1 (no), 1 -> -1 (yes), -1 -> -1 (no), -1 -> 0 (yes), 0 -> 1 (yes).
+    pos = np.array([1.0, 1.0, -1.0, -1.0, 0.0, 1.0])
+    assert sign_changes(pos) == 3
+
+
+def test_sign_changes_constant_position_is_zero():
+    assert sign_changes(np.ones(10)) == 0
+    assert sign_changes(np.zeros(10)) == 0
+
+
+def test_sign_changes_per_asset_book():
+    book = np.array([[1.0, 0.0], [-1.0, 0.0], [-1.0, 1.0]])
+    out = sign_changes(book)
+    assert out.shape == (2,)
+    assert list(out) == [1, 1]
+
+
+def test_sign_changes_ignores_nan_straddling_pairs():
+    # The pair (1.0, nan) and (nan, -1.0) straddle a NaN and are not counted;
+    # only the eventual -1 -> 1 would count, which is absent here.
+    pos = np.array([1.0, np.nan, -1.0])
+    assert sign_changes(pos) == 0
+
+
+def test_sign_changes_short_series():
+    assert sign_changes(np.array([1.0])) == 0
+    assert sign_changes(np.array([], dtype=float)) == 0
+
+
+def test_trades_per_year_annualizes():
+    pos = np.array([1.0, -1.0, 1.0, -1.0])  # 3 changes over 4 bars
+    assert np.isclose(trades_per_year(pos, period=252), 3.0 / 4.0 * 252.0)
+
+
+def test_trades_per_year_per_asset_book():
+    book = np.array([[1.0, 1.0], [-1.0, 1.0], [1.0, 1.0]])  # asset0: 2, asset1: 0
+    out = trades_per_year(book, period=252)
+    assert out.shape == (2,)
+    assert np.isclose(out[0], 2.0 / 3.0 * 252.0)
+    assert out[1] == 0.0


### PR DESCRIPTION
Roadmap §3, item 1 ("Fréquence de changements de signe / nombre de trades"). The remaining §3 item (cost decomposition) follows in a separate PR.

## What

New data-agnostic churn metrics in `fynance.metrics` (like `information_coefficient`, they take a **position** series — not an equity curve — so they're exported but intentionally kept out of the `METRICS` registry):

- **`sign_changes(positions, *, axis=0)`** — number of steps where `sign(posₜ) ≠ sign(posₜ₋₁)` (long↔flat↔short; flat is a distinct state). Total `int` for a 1-D series, per-asset vector for a `(T, N)` book. Pairs straddling a `NaN` are not counted.
- **`trades_per_year(positions, period=252, *, axis=0)`** — `sign_changes / T * period`, so different sampling frequencies stay comparable.

`BacktestResult.summary()` now reports **`n_sign_changes`** and **`trades_per_year`** (summed over the book), so they flow into the research `report.md` / tearsheet table automatically — the round-trip churn that the turnover-blind `total_cost` hides.

## Tests

- `fynance/tests/metrics/test_trading.py` — long/flat/short transitions, constant = 0, per-asset book, NaN-straddle skipped, short series, annualization; plus doctests.
- `test_result.py` — `summary()` carries the two new finite keys; a known flip-every-bar series yields the exact expected counts.

## Test plan

- `pytest` — **959 passed, 1 skipped**
- `ruff check fynance/` — clean
- `mypy` — clean
- `sphinx -W` (clean build) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
