### PR TITLE
feat: transaction-cost decomposition in tearsheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and per-asset for a book — the round-trip churn a turnover-blind `total_cost`
   hides. `BacktestResult.summary()` now reports `n_sign_changes` and
   `trades_per_year`, so they flow into the research report automatically.
+- **Cost decomposition.** Cost models may expose an optional
+  `components(weights)` breakdown (`ProportionalCost` → `transaction`;
+  `MarketImpactCost` → `transaction` + `market_impact`); the engine carries it
+  on `BacktestResult.cost_components`, the research runner persists it, and the
+  tearsheet stacks a full-width **cumulative-fees** panel (cost in % of capital
+  by source) via the new `plot_cost_decomposition`.
 
 ### Changed
 

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -42,13 +42,3 @@ Le harnais `fynance.research` est **livré** (S1–S3) : `Experiment`,
 
 - [ ] Explorateur **Streamlit** au-dessus du Ledger (parcourir / filtrer / comparer
   les runs persistés) — interactif, plus tardif.
-
-## 3. Métriques de profil de trading & coûts (signalé à l'usage par `fynance-research`)
-
-Métriques génériques utiles à tout report de stratégie (calculées à la main côté usage
-aujourd'hui ; remontables en librairie data-agnostique) :
-
-- [ ] **Décomposition des coûts dans le tearsheet** — un panneau « cumulative fees » ventilant
-  les composantes de coût (frais de transaction vs funding/borrow vs market-impact) en % du
-  capital. Aujourd'hui `BacktestResult` ne porte que le coût agrégé ; exposer les composantes
-  par pas (quand le `CostModel` en distingue) puis les empiler dans `write_report`.

--- a/fynance/backtest/cost.py
+++ b/fynance/backtest/cost.py
@@ -61,6 +61,15 @@ class ProportionalCost:
 
         return transaction_cost(weights, fee=rate)
 
+    def components(self, weights: NDArray) -> dict[str, NDArray[np.float64]]:
+        """ Per-step cost broken down by component (here a single one).
+
+        Returns ``{"transaction": fee+slippage turnover cost}``; the values sum
+        to :meth:`__call__`. The optional ``components`` convention lets the
+        engine carry a cost breakdown for the tearsheet's cumulative-fees panel.
+        """
+        return {"transaction": self(weights)}
+
 
 class MarketImpactCost:
     """ Non-linear market-impact cost: linear fee + convex impact term.
@@ -120,3 +129,18 @@ class MarketImpactCost:
         turnover = transaction_cost(weights, fee=1.0)
 
         return self.fee * turnover + self.impact * turnover ** self.exponent
+
+    def components(self, weights: NDArray) -> dict[str, NDArray[np.float64]]:
+        """ Per-step cost split into its linear and convex parts.
+
+        Returns ``{"transaction": fee turnover, "market_impact": convex term}``;
+        the values sum to :meth:`__call__`. The optional ``components``
+        convention lets the engine carry a cost breakdown for the tearsheet's
+        cumulative-fees panel.
+        """
+        turnover = transaction_cost(weights, fee=1.0)
+
+        return {
+            "transaction": self.fee * turnover,
+            "market_impact": self.impact * turnover ** self.exponent,
+        }

--- a/fynance/backtest/engine.py
+++ b/fynance/backtest/engine.py
@@ -108,6 +108,18 @@ def backtest(
         if cost is not None
         else np.zeros(returns.shape[0], dtype=np.float64)
     )
+
+    # When the cost model exposes a per-step breakdown (optional ``components``
+    # convention), carry it through so the report can stack a cumulative-fees
+    # panel. The components sum to ``costs`` by the model's own contract.
+    cost_components = None
+    if cost is not None and hasattr(cost, "components"):
+        comps = cost.components(cost_book)
+        if comps:
+            cost_components = {
+                str(k): np.asarray(v, dtype=np.float64) for k, v in comps.items()
+            }
+
     net = gross - costs
     equity = capital * np.cumprod(1.0 + net)
 
@@ -118,4 +130,5 @@ def backtest(
         positions=pos,
         costs=costs,
         asset_gross_returns=asset_gross_returns,
+        cost_components=cost_components,
     )

--- a/fynance/backtest/result.py
+++ b/fynance/backtest/result.py
@@ -44,6 +44,10 @@ class BacktestResult:
     asset_gross_returns : numpy.ndarray, optional
         Per-asset gross return contributions ``(T, N)`` for a multi-asset book
         (they sum to :attr:`gross_returns`); ``None`` for a single-asset run.
+    cost_components : dict of str to numpy.ndarray, optional
+        Per-step cost broken down by component (e.g. ``transaction`` vs
+        ``market_impact``); the values sum to :attr:`costs`. Populated when the
+        cost model exposes the optional ``components`` convention, else ``None``.
 
     Methods
     -------
@@ -60,6 +64,7 @@ class BacktestResult:
     costs: NDArray
     index: NDArray | None = None
     asset_gross_returns: NDArray | None = None
+    cost_components: dict[str, NDArray] | None = None
 
     def to_numpy(self) -> NDArray:
         """ Return the equity curve as a numpy array. """

--- a/fynance/core/protocols.py
+++ b/fynance/core/protocols.py
@@ -92,7 +92,12 @@ class Allocator(Protocol):
 class CostModel(Protocol):
     """ Map a weight book to per-step transaction costs.
 
-    Concrete models live in :mod:`fynance.backtest.cost`.
+    Concrete models live in :mod:`fynance.backtest.cost`. A model *may* also
+    expose an optional ``components(weights) -> dict[str, NDArray]`` returning a
+    per-step breakdown whose values sum to ``__call__`` (e.g. ``transaction`` vs
+    ``market_impact``); the engine carries it through to the tearsheet's
+    cumulative-fees panel when present. It is not part of the required
+    interface — only ``__call__`` is.
     """
 
     def __call__(self, weights: NDArray) -> NDArray:

--- a/fynance/plot/__init__.py
+++ b/fynance/plot/__init__.py
@@ -13,6 +13,7 @@ API the notebook workflow and the optional Streamlit app both build on.
 
 # Local packages
 from .attribution import plot_contribution, plot_turnover
+from .costs import plot_cost_decomposition
 from .equity import plot_drawdown, plot_equity
 from .returns import plot_returns_hist, plot_rolling_sharpe
 from .tearsheet import tearsheet, tearsheet_text
@@ -24,6 +25,7 @@ __all__ = [
     'plot_rolling_sharpe',
     'plot_contribution',
     'plot_turnover',
+    'plot_cost_decomposition',
     'tearsheet',
     'tearsheet_text',
 ]

--- a/fynance/plot/costs.py
+++ b/fynance/plot/costs.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Transaction-cost decomposition figures. """
+
+from __future__ import annotations
+
+# Built-in packages
+from typing import Any
+
+# Third-party packages
+import numpy as np
+
+__all__ = ['plot_cost_decomposition']
+
+
+def plot_cost_decomposition(cost_components: dict[str, Any], index: Any = None,
+                            ax: Any = None) -> Any:
+    """ Stack the cumulative cost components as a share of capital.
+
+    ``cost_components`` maps a component name (e.g. ``"transaction"``,
+    ``"market_impact"``) to its per-step cost series; each is accumulated and
+    stacked, so the panel reads as cumulative fees in **% of capital** broken
+    down by source — the detail a single aggregate ``total_cost`` hides. Returns
+    the matplotlib ``Axes``.
+    """
+    import matplotlib.pyplot as plt
+
+    names = list(cost_components)
+    cumulative = [
+        np.nancumsum(np.asarray(cost_components[k], dtype=np.float64)) * 100.0
+        for k in names
+    ]
+    x = range(cumulative[0].shape[0]) if index is None else index
+
+    if ax is None:
+        _, ax = plt.subplots()
+
+    ax.stackplot(x, *cumulative, labels=names, alpha=0.8)
+    ax.set_title("Cumulative fees")
+    ax.set_ylabel("Cumulative cost (% of capital)")
+    ax.grid(alpha=0.3)
+    ax.legend(loc="upper left", fontsize=8)
+
+    return ax

--- a/fynance/plot/tearsheet.py
+++ b/fynance/plot/tearsheet.py
@@ -14,6 +14,7 @@ import numpy as np
 # Local packages
 from fynance.plot._helpers import as_equity
 from fynance.plot.attribution import plot_contribution, plot_turnover
+from fynance.plot.costs import plot_cost_decomposition
 from fynance.plot.equity import plot_drawdown, plot_equity
 from fynance.plot.returns import plot_rolling_sharpe
 
@@ -63,19 +64,26 @@ def tearsheet(result: Any, period: int = 252, figsize: tuple = (11, 7), *,
     """
     import matplotlib.pyplot as plt
 
-    # A multi-asset book carries per-asset attribution: add a contribution and a
-    # turnover panel below the core 2x2 report (single-asset stays a 2x2).
+    # Optional extra panels grow the core 2x2 report by one row each:
+    #  - a multi-asset book adds per-asset contribution + turnover;
+    #  - a cost breakdown adds a full-width cumulative-fees panel.
     asset_gross = getattr(result, "asset_gross_returns", None)
     positions = getattr(result, "positions", None)
     index = getattr(result, "index", None)
+    cost_components: dict[str, Any] | None = getattr(
+        result, "cost_components", None)
     is_book = (
         asset_gross is not None
         and np.asarray(asset_gross).ndim == 2
         and np.asarray(asset_gross).shape[1] > 1
     )
+    has_costs = cost_components is not None and any(
+        np.nansum(np.asarray(v, dtype=float)) != 0.0
+        for v in cost_components.values()
+    )
 
-    n_rows = 3 if is_book else 2
-    fig = plt.figure(figsize=(figsize[0], figsize[1] * (1.4 if is_book else 1.0)))
+    n_rows = 2 + int(is_book) + int(has_costs)
+    fig = plt.figure(figsize=(figsize[0], figsize[1] * n_rows / 2.0))
     gs = fig.add_gridspec(n_rows, 2)
 
     plot_equity(result, ax=fig.add_subplot(gs[0, 0]), base=base, logy=logy)
@@ -93,10 +101,16 @@ def tearsheet(result: Any, period: int = 252, figsize: tuple = (11, 7), *,
     table.scale(1.0, 1.3)
     ax_table.set_title("Summary")
 
+    row = 2
     if is_book:
-        plot_contribution(asset_gross, index=index, ax=fig.add_subplot(gs[2, 0]))
+        plot_contribution(asset_gross, index=index, ax=fig.add_subplot(gs[row, 0]))
         if positions is not None and np.asarray(positions).ndim == 2:
-            plot_turnover(positions, index=index, ax=fig.add_subplot(gs[2, 1]))
+            plot_turnover(positions, index=index, ax=fig.add_subplot(gs[row, 1]))
+        row += 1
+    if has_costs and cost_components is not None:
+        plot_cost_decomposition(cost_components, index=index,
+                                ax=fig.add_subplot(gs[row, :]))
+        row += 1
 
     fig.tight_layout()
 

--- a/fynance/research/experiment.py
+++ b/fynance/research/experiment.py
@@ -53,9 +53,10 @@ class Experiment:
         Master seed driving every stochastic step.
     metrics : dict of str to float, optional
         Summary metrics (``sharpe``/``sortino``/…); empty until a run fills it.
-    series : dict of str to list, optional
+    series : dict of str to (list or dict), optional
         JSON-friendly curves (e.g. ``equity``/``returns`` of float, plus an
-        optional ``index`` of ISO-8601 date strings) for the report.
+        optional ``index`` of ISO-8601 date strings and an optional
+        ``cost_components`` mapping of per-step cost breakdowns) for the report.
     created_at : str
         ISO-8601 UTC creation time (set automatically).
     fynance_version : str
@@ -76,7 +77,7 @@ class Experiment:
     code: str | None = None
     seed: int = 0
     metrics: dict[str, float] = field(default_factory=dict)
-    series: dict[str, list[Any]] | None = None
+    series: dict[str, Any] | None = None
     created_at: str = field(default_factory=_utc_now)
     fynance_version: str = field(default_factory=_fynance_version)
 

--- a/fynance/research/report.py
+++ b/fynance/research/report.py
@@ -116,6 +116,11 @@ def _write_png(experiment: Experiment, png_path: Path, period: int) -> bool:
     book_positions = experiment.series.get("positions")
     if book_positions:
         ns["positions"] = np.asarray(book_positions, dtype=float)
+    cost_components = experiment.series.get("cost_components")
+    if cost_components:
+        ns["cost_components"] = {
+            k: np.asarray(v, dtype=float) for k, v in cost_components.items()
+        }
     result: Any = SimpleNamespace(**ns) if len(ns) > 1 else equity
     fig = tearsheet(result, period=period)
     fig.savefig(png_path, dpi=110, bbox_inches="tight")

--- a/fynance/research/runner.py
+++ b/fynance/research/runner.py
@@ -230,7 +230,7 @@ def run_experiment(
         "seed": seed,
     }
 
-    series: dict[str, list[Any]] = {
+    series: dict[str, Any] = {
         "equity": np.asarray(result.equity, dtype=float).tolist(),
         "returns": np.asarray(result.returns, dtype=float).tolist(),
     }
@@ -249,6 +249,14 @@ def run_experiment(
         book_positions = np.asarray(result.positions, dtype=float)
         if book_positions.ndim == 2:
             series["positions"] = book_positions.tolist()
+    # Persist the per-step cost breakdown so the report can stack a
+    # cumulative-fees panel; present only when the cost model decomposes it.
+    cost_components = getattr(result, "cost_components", None)
+    if cost_components:
+        series["cost_components"] = {
+            str(k): np.asarray(v, dtype=float).tolist()
+            for k, v in cost_components.items()
+        }
 
     experiment = Experiment(
         name=name,

--- a/fynance/tests/backtest/test_cost.py
+++ b/fynance/tests/backtest/test_cost.py
@@ -83,6 +83,25 @@ def test_impact_bad_exponent_raises():
         MarketImpactCost(exponent=0.0)
 
 
+def test_proportional_components_sum_to_total():
+    cost = ProportionalCost(fee=0.002, slippage=0.001)
+    w = np.array([[1.0, 0.0], [0.5, 0.5], [0.0, 1.0]])
+    comps = cost.components(w)
+    assert set(comps) == {"transaction"}
+    assert np.allclose(comps["transaction"], cost(w))
+
+
+def test_impact_components_split_and_sum_to_total():
+    cost = MarketImpactCost(fee=0.001, impact=0.05, exponent=1.5)
+    w = np.array([[1.0, 0.0], [0.0, 1.0], [0.0, 1.0]])
+    comps = cost.components(w)
+    assert set(comps) == {"transaction", "market_impact"}
+    # The two components add up to the aggregate per-step cost.
+    assert np.allclose(comps["transaction"] + comps["market_impact"], cost(w))
+    # The convex impact term is strictly positive on a real trade.
+    assert comps["market_impact"][0] > 0.0
+
+
 def test_impact_lowers_net_equity_in_backtest():
     rng = np.random.default_rng(0)
     T = 300

--- a/fynance/tests/backtest/test_engine.py
+++ b/fynance/tests/backtest/test_engine.py
@@ -8,7 +8,7 @@ import numpy as np
 
 # Local packages
 from fynance.backtest import BacktestResult, backtest
-from fynance.backtest.cost import ProportionalCost
+from fynance.backtest.cost import MarketImpactCost, ProportionalCost
 
 
 def test_buy_and_hold_matches_price_path():
@@ -135,3 +135,20 @@ def test_single_asset_has_no_attribution():
     res = backtest(returns, np.ones(50), shift=True)
     assert res.asset_gross_returns is None
     assert res.gross_returns.ndim == 1
+
+
+def test_cost_components_captured_and_sum_to_total():
+    returns = np.array([0.01, 0.02, 0.03, -0.01])
+    positions = np.array([1.0, 0.0, 1.0, -1.0])
+    cost = MarketImpactCost(fee=0.001, impact=0.05, exponent=1.5)
+    res = backtest(returns, positions, cost=cost, shift=True)
+    assert res.cost_components is not None
+    assert set(res.cost_components) == {"transaction", "market_impact"}
+    stacked = sum(res.cost_components.values())
+    assert np.allclose(stacked, res.costs)
+
+
+def test_cost_components_none_without_cost_model():
+    # No cost model -> no breakdown to carry.
+    res = backtest(np.array([0.01, 0.02]), np.array([1.0, 1.0]))
+    assert res.cost_components is None

--- a/fynance/tests/plot/test_smoke.py
+++ b/fynance/tests/plot/test_smoke.py
@@ -13,7 +13,9 @@ import matplotlib.pyplot as plt  # noqa: E402
 
 # Local packages
 from fynance.backtest import backtest  # noqa: E402
+from fynance.backtest.cost import MarketImpactCost  # noqa: E402
 from fynance.plot import (  # noqa: E402
+    plot_cost_decomposition,
     plot_drawdown,
     plot_equity,
     plot_returns_hist,
@@ -83,4 +85,26 @@ def test_plot_equity_logy_explicit_overrides_auto():
     # logy=True forces log even on a flat curve (still strictly positive).
     ax = plot_equity(np.linspace(1.0, 1.2, 100), logy=True)
     assert ax.get_yscale() == "log"
+    plt.close("all")
+
+
+def test_plot_cost_decomposition_returns_axes():
+    comps = {"transaction": np.full(20, 0.001),
+             "market_impact": np.full(20, 0.0005)}
+    ax = plot_cost_decomposition(comps)
+    assert ax is not None
+    plt.close("all")
+
+
+def test_tearsheet_adds_cost_panel_when_components_present():
+    rng = np.random.default_rng(0)
+    returns = rng.normal(0.0005, 0.01, 200)
+    positions = np.sign(rng.normal(size=200))
+    res_cost = backtest(returns, positions,
+                        cost=MarketImpactCost(fee=0.001, impact=0.05), shift=True)
+    res_plain = backtest(returns, positions, shift=True)
+    # The cumulative-fees panel adds exactly one (full-width) axis.
+    fig_cost = tearsheet(res_cost, period=50)
+    fig_plain = tearsheet(res_plain, period=50)
+    assert len(fig_cost.axes) == len(fig_plain.axes) + 1
     plt.close("all")

--- a/fynance/tests/research/test_run_experiment.py
+++ b/fynance/tests/research/test_run_experiment.py
@@ -164,3 +164,15 @@ def test_run_experiment_single_asset_provenance():
     exp = run_experiment(momentum(), gbm(200, seed=2), name="single")
     assert exp.spec["data"]["n_assets"] == 1
     assert "asset_contrib" not in exp.series
+
+
+def test_cost_components_persisted_and_round_trip():
+    # momentum() carries a ProportionalCost -> a single "transaction" component.
+    exp = run_experiment(momentum(), gbm(300, seed=9), name="costs")
+    comps = exp.series.get("cost_components")
+    assert comps is not None
+    assert set(comps) == {"transaction"}
+    # The component(s) sum to the aggregate total cost reported in the summary.
+    assert np.isclose(np.sum(comps["transaction"]), exp.metrics["total_cost"])
+    # JSON round-trip preserves the breakdown.
+    assert Experiment.from_dict(exp.to_dict()).series["cost_components"] == comps


### PR DESCRIPTION
Roadmap §3, item 2 ("Décomposition des coûts dans le tearsheet") — the last open §3 item, so this PR also removes the section from the roadmap.

## What

Cost models may now expose an **optional** `components(weights) -> dict[str, NDArray]` breakdown (the `CostModel` protocol documents it as optional; only `__call__` stays required):
- `ProportionalCost` → `{"transaction": …}`
- `MarketImpactCost` → `{"transaction": fee·turnover, "market_impact": convex term}`

The values sum to `__call__` by contract. The engine captures the breakdown into the new **`BacktestResult.cost_components`** (`None` when the model doesn't decompose); the research runner persists it (JSON round-trips), and the tearsheet adds a full-width **cumulative-fees** panel — cost in % of capital, stacked by source — via the new `plot_cost_decomposition`. The tearsheet layout now grows one row per optional panel (book attribution and/or cost decomposition), single-asset cost-free runs unchanged.

## Tests

- `test_cost.py` — `components()` of both models sum to `__call__`; impact term split & positive.
- `test_engine.py` — `cost_components` captured & sums to `costs`; `None` with no cost model.
- `test_smoke.py` — `plot_cost_decomposition` returns an Axes; the panel adds exactly one tearsheet axis.
- `test_run_experiment.py` — components persisted, sum to `total_cost`, survive the JSON round-trip.

## Test plan

- `pytest` — **966 passed, 1 skipped**
- `ruff check fynance/` — clean
- `mypy fynance/` — clean (181 files)
- `sphinx -W` (clean build) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
