### PR TITLE
chore: release v2.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [2.11.2] - 2026-06-25
+
+### Added
+
 - **Trading-profile metrics.** `sign_changes` / `trades_per_year`
   (`fynance.metrics`) count position direction flips (long↔flat↔short), total
   and per-asset for a book — the round-trip churn a turnover-blind `total_cost`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fynance"
-version = "2.11.1"
+version = "2.11.2"
 description = "Pure-Python (Numba-accelerated) machine learning, econometrics and statistical tools for financial analysis and backtesting"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Release **v2.11.2** — patch (additive trading-profile metrics + cost decomposition).

## [2.11.2]

### Added

- **Trading-profile metrics.** `sign_changes` / `trades_per_year` (`fynance.metrics`) count position direction flips (long↔flat↔short), total and per-asset for a book; `BacktestResult.summary()` now reports `n_sign_changes` / `trades_per_year`.
- **Cost decomposition.** Optional `components(weights)` on cost models → `BacktestResult.cost_components` → persisted by the research runner → full-width cumulative-fees tearsheet panel via `plot_cost_decomposition`.

## Test plan

- `pytest` — 966 passed, 1 skipped
- `ruff check fynance/` — clean
- `mypy fynance/` — clean (181 files)
- `sphinx -W` (clean build) — clean
- CI green on develop (PRs #226, #227)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
