### PR TITLE
chore: harmonize Claude Code config with sibling repos

### DIFF
--- a/.claude/hooks/pr_decision_guard.py
+++ b/.claude/hooks/pr_decision_guard.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""PreToolUse(Bash) safety net for `gh pr create`.
+
+If the branch changes structural code under <package_dir>/ (excluding tests) but
+adds no entry to the decision journal (<decisions>), ask the user to confirm
+before the PR is opened. This is only a net — the real capture is the
+`/finish-task` decision step; here we just make the omission visible.
+
+Emits a PreToolUse "ask" decision (human confirms / overrides) rather than a hard
+deny, so a genuinely decision-free PR isn't deterministically blocked. No-op for
+any command other than `gh pr create`, or if the project doesn't declare both a
+`package_dir` and a `decisions` path in .claude/workflow.json.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _allow() -> None:
+    """Exit without influencing the decision."""
+    sys.exit(0)
+
+
+def main() -> None:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        _allow()
+
+    cmd = (payload.get("tool_input") or {}).get("command", "")
+    if "gh pr create" not in cmd:
+        _allow()
+
+    try:
+        cfg = json.loads((ROOT / ".claude" / "workflow.json").read_text())
+    except Exception:
+        _allow()
+
+    pkg = cfg.get("package_dir")
+    base = cfg.get("base_branch", "develop")
+    decisions = cfg.get("decisions")
+    if not pkg or not decisions:
+        _allow()  # project hasn't opted into the guard
+
+    try:
+        changed = subprocess.run(
+            ["git", "diff", f"{base}...HEAD", "--name-only"],
+            cwd=ROOT, capture_output=True, text=True, timeout=10,
+        ).stdout.split()
+    except Exception:
+        _allow()
+
+    def is_structural(path: str) -> bool:
+        name = path.rsplit("/", 1)[-1]
+        return (
+            path.startswith(f"{pkg}/")
+            and "/tests/" not in path
+            and not name.startswith("test_")
+        )
+
+    touched_code = any(is_structural(p) for p in changed)
+    if touched_code and decisions not in changed:
+        reason = (
+            f"This branch changes structural code under {pkg}/ but adds no entry "
+            f"to {decisions}. Capture the *why* (the /finish-task decision step) "
+            f"before opening the PR — or confirm this PR genuinely needs no "
+            f"decision entry."
+        )
+        print(json.dumps({
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "ask",
+                "permissionDecisionReason": reason,
+            }
+        }))
+        sys.exit(0)
+
+    _allow()
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/session_start.py
+++ b/.claude/hooks/session_start.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""SessionStart hook — cheap orientation.
+
+Prints the current branch, the number of open roadmap tasks, and the most recent
+dated decision-journal entry. Stdout is injected into the session context by
+Claude Code. Reads paths from .claude/workflow.json; degrades gracefully if the
+descriptor or any target file is missing (prints what it can, never errors out).
+"""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]  # .claude/hooks/ -> repo root
+
+
+def _cfg() -> dict:
+    p = ROOT / ".claude" / "workflow.json"
+    try:
+        return json.loads(p.read_text())
+    except Exception:
+        return {}
+
+
+def _branch() -> str:
+    try:
+        out = subprocess.run(
+            ["git", "branch", "--show-current"],
+            cwd=ROOT, capture_output=True, text=True, timeout=5,
+        )
+        return out.stdout.strip() or "(detached)"
+    except Exception:
+        return "?"
+
+
+def main() -> None:
+    cfg = _cfg()
+    label = cfg.get("package_dir", ROOT.name)
+    lines = [f"{label} workflow — branch: {_branch()}"]
+
+    roadmap_rel = cfg.get("roadmap", "doc/dev/07-roadmap.md")
+    roadmap = ROOT / roadmap_rel
+    if roadmap.exists():
+        open_n = len(re.findall(r"(?m)^\s*- \[ \] ", roadmap.read_text()))
+        lines.append(f"open roadmap tasks: {open_n}  ({roadmap_rel})")
+
+    decisions = ROOT / cfg.get("decisions", "doc/dev/03-decisions.md")
+    if decisions.exists():
+        # Journal is newest-first; dated entries are h3 `### YYYY-MM-DD …`.
+        m = re.search(r"(?m)^### (\d{4}-\d{2}-\d{2} .+)$", decisions.read_text())
+        if m:
+            lines.append(f"last decision: {m.group(1)}")
+
+    print("\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,25 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/session_start.py\""
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/pr_decision_guard.py\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/workflow.json
+++ b/.claude/workflow.json
@@ -1,0 +1,13 @@
+{
+  "package_dir": "fynance",
+  "base_branch": "develop",
+  "roadmap": "doc/dev/07-roadmap.md",
+  "decisions": "doc/dev/03-decisions.md",
+  "status": "doc/dev/06-status.md",
+  "changelog": "CHANGELOG.md",
+  "plans_dir": "doc/dev/plans",
+  "plans_archive": "doc/dev/_archive/plans",
+  "test_cmd": "pytest",
+  "lint_cmd": "ruff check fynance/",
+  "docs_src": "doc/source"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,11 @@ __pycache__/
 .coverage
 htmlcov/
 
-# Claude Code harness settings stay local; CLAUDE.md is tracked (mirrors dccd)
-.claude/
+# Claude Code workflow — local-only state. The shared workflow.json / settings.json
+# and hooks ARE committed; per-machine overrides and finished plan trees are not.
+.claude/settings.local.json
+.claude/scheduled_tasks.lock
+.claude/worktrees/
 
 # Task tracking (local only)
 todo/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,14 +92,11 @@ test + verify) → `/finish-task` (tests, ADR, CHANGELOG, PR, archive the leaf) 
 `/abandon-task` salvages the lesson + closes a bad PR; `/groom-docs` keeps
 `doc/dev/` lean and true.
 
-**Model per task** (advisory — set via `/model` or a plan leaf's `complexity`:
-`low→haiku`, `medium→sonnet`, `high→opus`):
-
-| Model | For |
-|-------|-----|
-| `opus` | judgement, design, decisions, planning, review |
-| `sonnet` | implementation — code, tests, docstrings |
-| `haiku` | mechanical fan-out (doc scans, checklists) |
+**Model: `opus`, always.** Per the maintainer's standing preference, **all work on
+this repo runs on `opus`** — interactive sessions *and* every spawned subagent
+(including `/execute-leaf`), regardless of a leaf's `complexity`. The `complexity`
+tag still records effort/risk and orders the execution queue, but it **does not
+downgrade the model**: treat `low | medium | high` all as `opus`.
 
 ## Architecture
 


### PR DESCRIPTION
## Why

Across the four repos (Fynance, dccd, Trading_Bot, fynance-research) the Claude Code
setup had drifted. This brings Fynance in line with its siblings.

## What

- **Track `.claude/` dev-loop config** (`settings.json`, `workflow.json`, `hooks/`)
  instead of gitignoring the whole directory. Only per-machine state
  (`settings.local.json`, `scheduled_tasks.lock`, `worktrees/`) stays local —
  same `.gitignore` rule as fynance-research.
- **Adopt the shared Python hooks** (`session_start.py` orientation +
  `pr_decision_guard.py`) that read `workflow.json`, replacing the old inline-bash
  git-flow warning in `settings.json`.
- **Model policy → "opus, always"** in `CLAUDE.md` (complexity = effort/ordering
  only), matching Trading_Bot / fynance-research and resolving the contradiction
  with the standing opus-always preference.

Config/docs only — no package code touched. `ruff check fynance/` and
`ruff check .claude/hooks/` pass; `session_start.py` smoke-tested.