### PR TITLE
feat: add conditioned covariance estimators (fynance.portfolio.covariance)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Conditioned covariance estimators.** New `fynance.portfolio.covariance`
+  module: `sample_cov`, closed-form `ledoit_wolf` shrinkage (identity /
+  constant-correlation / diagonal targets), RiskMetrics-style `ewma_cov`
+  (Numba kernel), PCA `factor_cov` (low-rank + diagonal, PSD by construction)
+  and Marchenko-Pastur `denoise_cov` — interchangeable `(T, N) → (N, N)`
+  callables, groundwork for the allocators' opt-in `cov=` seam.
+
 ### Changed
 
 ### Fixed

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -72,6 +72,25 @@ Template:
 
 <!-- new entries below, newest first -->
 
+### 2026-07-05 — Conditioned covariance estimators as interchangeable callables (PR #235)  [accepted]
+
+- **Choice**: ship covariance conditioning as a standalone
+  `portfolio.covariance` module of `(T, N) -> (N, N)` callables — closed-form
+  Ledoit-Wolf (three targets), RiskMetrics EWMA on a Numba kernel, PCA factor
+  model, Marchenko-Pastur clipping — rather than baking estimators into each
+  allocator. The allocators gain an opt-in `cov=` callable in the next leaf,
+  `None` keeping today's `np.cov` path bit-for-bit.
+- **Why**: raw `np.cov` on short windows is the dominant source of MVP/ERC
+  weight instability; the closed forms need numpy only (no new dependency);
+  a callable seam preserves the frozen `portfolio.allocation` API and makes
+  the estimators reusable elsewhere (risk attribution, future risk tools).
+  Verified OOS on synthetic two-block panels: condition number 97.4 -> 91.1
+  (LW) / 82.5 (denoised); mean MVP OOS vol 0.005909 -> 0.005790 over 20 seeds.
+- **Rejected alternatives**: depending on scikit-learn (heavy dependency for a
+  ~40-line closed form); nonlinear/oracle shrinkage (unwarranted complexity —
+  can land later as just another callable); per-allocator estimator flags
+  (couples the stable API to an estimator zoo).
+
 ### 2026-06-23 — Multi-asset / panel R&D harness (PRs #215–#219, epic)  [accepted]
 
 Took the research harness from single-asset to **multi-pair**: a model predicts a

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -26,7 +26,7 @@ shipped, `03-decisions.md` for *why*. Keep it short and true.
 > du **workflow d'idéation 2026-07** (43 propositions générées sous 6 angles,
 > scorées valeur/fit/faisabilité par panel de juges, 29 retenues) — détail
 > complet (descriptions, API sketches, scores) dans
-> `plans/_feature-catalog-2026-07.md` (local).
+> `plans/_catalog/feature-catalog-2026-07.md` (local).
 
 > ⚠️ **Hors scope ici** : la recherche de stratégie sur **vraie data** (benchmarks
 > empiriques loss / architecture / normalisation, évaluation Sharpe out-of-sample,

--- a/doc/source/portfolio.covariance.rst
+++ b/doc/source/portfolio.covariance.rst
@@ -1,0 +1,16 @@
+**********************
+Conditioned covariance
+**********************
+
+Conditioned covariance estimators for portfolio allocation: sample covariance (:func:`~fynance.portfolio.covariance.sample_cov`), Ledoit-Wolf shrinkage (:func:`~fynance.portfolio.covariance.ledoit_wolf`), exponentially weighted covariance (:func:`~fynance.portfolio.covariance.ewma_cov`), factor-model covariance (:func:`~fynance.portfolio.covariance.factor_cov`) and Marchenko-Pastur eigenvalue denoising (:func:`~fynance.portfolio.covariance.denoise_cov`).
+
+.. currentmodule:: fynance.portfolio.covariance
+
+.. autosummary::
+   :toctree: generated/
+
+   sample_cov
+   ledoit_wolf
+   ewma_cov
+   factor_cov
+   denoise_cov

--- a/doc/source/portfolio.rst
+++ b/doc/source/portfolio.rst
@@ -24,9 +24,17 @@ Portfolio allocation algorithms and rolling walk-forward wrappers.
 
       Fractional Kelly, volatility targeting and transaction costs.
 
+   .. grid-item-card:: :octicon:`graph;1.2em;sd-mr-1` Conditioned covariance
+      :link: portfolio.covariance
+      :link-type: doc
+
+      Sample covariance, Ledoit-Wolf shrinkage, exponentially weighted,
+      factor-model and Marchenko-Pastur denoised estimators.
+
 .. toctree::
    :maxdepth: 1
    :hidden:
 
    portfolio.allocation
+   portfolio.covariance
    portfolio.sizing

--- a/fynance/portfolio/__init__.py
+++ b/fynance/portfolio/__init__.py
@@ -15,6 +15,7 @@
    :caption: Contents:
 
    portfolio.allocation
+   portfolio.covariance
    portfolio.sizing
 
 """
@@ -24,9 +25,11 @@
 # Third party packages
 
 # Local packages
-from . import allocation, sizing
+from . import allocation, covariance, sizing
 from .allocation import *
+from .covariance import *
 from .sizing import *
 
 __all__ = allocation.__all__
+__all__ += covariance.__all__
 __all__ += sizing.__all__

--- a/fynance/portfolio/covariance.py
+++ b/fynance/portfolio/covariance.py
@@ -1,0 +1,494 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+r""" Conditioned covariance estimators for portfolio allocation.
+
+Estimators of the asset return covariance matrix, from the raw sample
+estimator to shrinkage, exponentially-weighted and denoising variants
+that are better conditioned for use in Markowitz-style optimizers
+(minimum variance, ERC, MDP, ...). Every estimator takes a ``(T, N)``
+array of returns (rows = time, columns = assets) and returns a
+symmetric ``(N, N)`` covariance matrix, so they are interchangeable as
+the ``cov=`` callable consumed by the allocators.
+
+Main entry points
+-----------------
+- :func:`sample_cov` — plain sample covariance (``numpy.cov`` wrapper).
+- :func:`ledoit_wolf` — closed-form linear shrinkage (identity,
+  constant-correlation or diagonal target).
+- :func:`ewma_cov` — RiskMetrics-style exponentially weighted
+  covariance.
+- :func:`factor_cov` — low-rank + diagonal (statistical factor model)
+  covariance.
+- :func:`denoise_cov` — Marchenko-Pastur eigenvalue clipping on the
+  correlation matrix.
+
+"""
+
+from __future__ import annotations
+
+# Third-party packages
+import numpy as np
+from numba import njit
+from numpy.typing import NDArray
+
+__all__ = ['sample_cov', 'ledoit_wolf', 'ewma_cov', 'factor_cov', 'denoise_cov']
+
+
+# =========================================================================== #
+#                                helpers                                      #
+# =========================================================================== #
+
+
+def _validate_returns(X: NDArray) -> NDArray:
+    """ Cast to float64, reshape 1-D input to a single column, check finiteness.
+
+    Parameters
+    ----------
+    X : array_like
+        Returns panel, 1-D (single asset) or 2-D (``T, N``).
+
+    Returns
+    -------
+    np.ndarray
+        Validated ``(T, N)`` float64 array.
+
+    """
+    X = np.asarray(X, dtype=np.float64)
+    if X.ndim == 1:
+        X = X.reshape(-1, 1)
+    elif X.ndim != 2:
+        raise ValueError(f"X must be 1-D or 2-D, got ndim={X.ndim}.")
+
+    if not np.all(np.isfinite(X)):
+        raise ValueError("X contains non-finite values (NaN or inf).")
+
+    return X
+
+
+def _symmetrize(M: NDArray) -> NDArray:
+    """ Force exact symmetry of a square matrix: ``(M + M.T) / 2``. """
+    M = np.asarray(M, dtype=np.float64)
+
+    return (M + M.T) / 2.0
+
+
+# =========================================================================== #
+#                                sample covariance                            #
+# =========================================================================== #
+
+
+def sample_cov(X: NDArray, ddof: int = 1) -> NDArray:
+    r""" Sample covariance matrix of a returns panel.
+
+    Thin, validated wrapper around :func:`numpy.cov`: a 1-D input is
+    treated as a single asset (returns ``[[var]]``); non-finite values
+    raise.
+
+    Parameters
+    ----------
+    X : array_like
+        Returns panel, shape ``(T,)`` or ``(T, N)``.
+    ddof : int, optional
+        Delta degrees of freedom (``ddof=1`` is the unbiased sample
+        covariance, ``ddof=0`` the population/maximum-likelihood one).
+        Default 1.
+
+    Returns
+    -------
+    np.ndarray
+        Symmetric ``(N, N)`` covariance matrix.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> X = np.array([[1.0, 2.0], [2.0, 1.0], [3.0, 4.0]])
+    >>> sample_cov(X, ddof=1)
+    array([[1.        , 1.        ],
+           [1.        , 2.33333333]])
+
+    """
+    X = _validate_returns(X)
+    cov = np.atleast_2d(np.cov(X, rowvar=False, ddof=ddof))
+
+    return _symmetrize(cov)
+
+
+# =========================================================================== #
+#                                Ledoit-Wolf shrinkage                        #
+# =========================================================================== #
+
+
+def _lw_shrinkage(X: NDArray, target: str) -> tuple[float, NDArray, NDArray]:
+    """ Ledoit-Wolf shrinkage intensity, sample covariance and target matrix.
+
+    Shared computation for :func:`ledoit_wolf` and :func:`_lw_intensity`.
+    Implements the closed-form intensity of Ledoit & Wolf (2004a/2004b):
+    ``kappa_hat = (pi_hat - rho_hat) / gamma_hat``, ``delta = clip(kappa_hat
+    / T, 0, 1)``, where ``pi_hat`` is the (target-independent) sum of
+    asymptotic variances of the sample covariance entries, ``rho_hat`` the
+    asymptotic covariance between the target and the sample covariance, and
+    ``gamma_hat = ||F - S||_F^2`` the (squared) misspecification of the
+    target.
+
+    """
+    if target not in ('identity', 'const_corr', 'diag'):
+        raise ValueError(
+            f"Unknown target {target!r}; expected 'identity', 'const_corr' "
+            "or 'diag'."
+        )
+
+    X = _validate_returns(X)
+    T, N = X.shape
+    Xc = X - X.mean(axis=0)
+    S = Xc.T @ Xc / T
+
+    if N == 1:
+        return 0.0, S, S.copy()
+
+    X2 = Xc ** 2
+    row_sq = X2.sum(axis=1)
+    pi_hat = float(np.mean(row_sq ** 2) - np.sum(S ** 2))
+    pi_ii = np.mean(X2 ** 2, axis=0) - np.diag(S) ** 2
+
+    if target == 'identity':
+        mu = np.trace(S) / N
+        F = mu * np.eye(N)
+        rho_hat = float((np.mean(row_sq ** 2) - (mu * N) ** 2) / N)
+    elif target == 'diag':
+        F = np.diag(np.diag(S))
+        rho_hat = float(np.sum(pi_ii))
+    else:  # const_corr
+        d = np.sqrt(np.diag(S))
+        denom = np.outer(d, d)
+        safe_denom = np.where(denom > 0, denom, 1.0)
+        corr = np.where(denom > 0, S / safe_denom, 0.0)
+        r_bar = (np.sum(corr) - N) / (N * (N - 1))
+
+        F = r_bar * denom
+        np.fill_diagonal(F, np.diag(S))
+
+        Z = X2 - np.diag(S)[None, :]
+        G = Z * Xc
+        theta1 = G.T @ Xc / T  # theta1[i, j] = theta_hat_{ii,ij}
+        safe_d = np.where(d > 0, d, 1.0)
+        ratio = np.where(
+            (d[:, None] > 0) & (d[None, :] > 0),
+            d[None, :] / safe_d[:, None],
+            0.0,
+        )
+        term = ratio * theta1 + ratio.T * theta1.T
+        np.fill_diagonal(term, 0.0)
+        rho_hat = float(np.sum(pi_ii) + 0.5 * r_bar * np.sum(term))
+
+    gamma_hat = float(np.sum((F - S) ** 2))
+    if gamma_hat <= 0.0:
+        delta = 0.0
+    else:
+        kappa_hat = (pi_hat - rho_hat) / gamma_hat
+        delta = float(np.clip(kappa_hat / T, 0.0, 1.0))
+
+    return delta, S, F
+
+
+def _lw_intensity(X: NDArray, target: str = 'const_corr') -> float:
+    """ Ledoit-Wolf shrinkage intensity (in ``[0, 1]``) for a returns panel.
+
+    Exposed as a private helper so callers/tests can inspect the intensity
+    without recomputing the shrunk matrix. See :func:`ledoit_wolf`.
+
+    """
+    delta, _, _ = _lw_shrinkage(X, target)
+
+    return delta
+
+
+def ledoit_wolf(X: NDArray, target: str = 'const_corr') -> NDArray:
+    r""" Ledoit-Wolf linear shrinkage covariance estimator.
+
+    Closed-form convex combination :math:`(1 - \delta) S + \delta F` of the
+    sample covariance :math:`S` and a low-variance target :math:`F`, with
+    the shrinkage intensity :math:`\delta \in [0, 1]` chosen to minimize
+    the asymptotic expected Frobenius loss. Well conditioned even when
+    :math:`N` is comparable to or larger than :math:`T` (where the plain
+    sample covariance is singular or ill-conditioned).
+
+    Parameters
+    ----------
+    X : array_like
+        Returns panel, shape ``(T,)`` or ``(T, N)``.
+    target : {'const_corr', 'identity', 'diag'}, optional
+        Shrinkage target:
+
+        - ``'const_corr'`` — constant-correlation matrix built from the
+          mean off-diagonal correlation (Ledoit & Wolf, 2004b).
+        - ``'identity'`` — mean-variance scaled identity (Ledoit & Wolf,
+          2004a).
+        - ``'diag'`` — ``diag(S)``, i.e. shrink off-diagonal entries only.
+
+        Default ``'const_corr'``.
+
+    Returns
+    -------
+    np.ndarray
+        Symmetric ``(N, N)`` shrunk covariance matrix.
+
+    References
+    ----------
+    .. [1] O. Ledoit, M. Wolf, "A well-conditioned estimator for
+       large-dimensional covariance matrices", Journal of Multivariate
+       Analysis, 88(2), 2004, 365-411.
+    .. [2] O. Ledoit, M. Wolf, "Honey, I shrunk the sample covariance
+       matrix", The Journal of Portfolio Management, 30(4), 2004, 110-119.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> rng = np.random.default_rng(0)
+    >>> X = rng.standard_normal((50, 4))
+    >>> S = ledoit_wolf(X)
+    >>> S.shape
+    (4, 4)
+    >>> bool(np.allclose(S, S.T))
+    True
+
+    """
+    delta, S, F = _lw_shrinkage(X, target)
+    cov = delta * F + (1.0 - delta) * S
+
+    return _symmetrize(cov)
+
+
+# =========================================================================== #
+#                       exponentially weighted covariance                     #
+# =========================================================================== #
+
+
+@njit(cache=True)
+def _ewma_cov_kernel(Xc: NDArray, lam: float) -> NDArray:
+    """ Accumulate lambda-weighted outer products of demeaned rows.
+
+    ``Xc`` is already demeaned; weights ``lam ** (T - 1 - t)`` are
+    normalized to sum to one inside the loop, no ``(T, N, N)`` temp.
+
+    """
+    T, N = Xc.shape
+    weights = np.empty(T, dtype=np.float64)
+    wsum = 0.0
+    for t in range(T):
+        wt = lam ** (T - 1 - t)
+        weights[t] = wt
+        wsum += wt
+
+    cov = np.zeros((N, N), dtype=np.float64)
+    for t in range(T):
+        wn = weights[t] / wsum
+        for i in range(N):
+            wxi = wn * Xc[t, i]
+            for j in range(i, N):
+                cov[i, j] += wxi * Xc[t, j]
+
+    for i in range(N):
+        for j in range(i + 1, N):
+            cov[j, i] = cov[i, j]
+
+    return cov
+
+
+def ewma_cov(X: NDArray, halflife: float = 63.0) -> NDArray:
+    r""" RiskMetrics-style exponentially weighted covariance matrix.
+
+    Weights recent observations more heavily: :math:`\lambda = 0.5^{1 /
+    halflife}`, weight of observation :math:`t` (out of :math:`T`, most
+    recent last) proportional to :math:`\lambda^{T - 1 - t}`, normalized to
+    sum to one. Data is demeaned by the plain (equally-weighted) column
+    mean before accumulating weighted outer products.
+
+    Parameters
+    ----------
+    X : array_like
+        Returns panel, shape ``(T,)`` or ``(T, N)``, rows in chronological
+        order (oldest first).
+    halflife : float, optional
+        Number of steps after which a past observation's weight is halved.
+        Default 63.0 (~ one quarter of trading days).
+
+    Returns
+    -------
+    np.ndarray
+        Symmetric ``(N, N)`` covariance matrix.
+
+    References
+    ----------
+    .. [1] J.P. Morgan/Reuters, "RiskMetrics -- Technical Document",
+       4th edition, 1996.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> rng = np.random.default_rng(0)
+    >>> X = rng.standard_normal((100, 3))
+    >>> S = ewma_cov(X, halflife=20.0)
+    >>> S.shape
+    (3, 3)
+    >>> bool(np.allclose(S, S.T))
+    True
+
+    """
+    X = _validate_returns(X)
+    if halflife <= 0:
+        raise ValueError("halflife must be strictly positive.")
+
+    Xc = X - X.mean(axis=0)
+    lam = 0.5 ** (1.0 / halflife)
+    cov = _ewma_cov_kernel(Xc, lam)
+
+    return _symmetrize(cov)
+
+
+# =========================================================================== #
+#                                factor covariance                            #
+# =========================================================================== #
+
+
+def factor_cov(X: NDArray, n_factors: int = 3) -> NDArray:
+    r""" Statistical factor-model covariance (low-rank + diagonal).
+
+    Eigendecomposes the (population) sample covariance and keeps the
+    ``k = min(n_factors, N)`` largest eigenpairs as a common (systematic)
+    component :math:`B B^\top` with loadings :math:`B = V_k
+    \text{diag}(\sqrt{l_k})`; the remainder of each asset's variance is
+    kept as an idiosyncratic diagonal term. The result is positive
+    semi-definite by construction and matches the sample covariance's
+    diagonal (total variance) exactly.
+
+    Parameters
+    ----------
+    X : array_like
+        Returns panel, shape ``(T,)`` or ``(T, N)``.
+    n_factors : int, optional
+        Number of factors to keep, clipped to ``N``. Default 3.
+
+    Returns
+    -------
+    np.ndarray
+        Symmetric ``(N, N)`` covariance matrix, ``B @ B.T + diag(idio)``.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> rng = np.random.default_rng(0)
+    >>> X = rng.standard_normal((100, 5))
+    >>> S = factor_cov(X, n_factors=2)
+    >>> S.shape
+    (5, 5)
+    >>> bool(np.all(np.linalg.eigvalsh(S) >= -1e-10))
+    True
+
+    """
+    if n_factors < 1:
+        raise ValueError("n_factors must be a positive integer.")
+
+    X = _validate_returns(X)
+    T, N = X.shape
+    S = sample_cov(X, ddof=0)
+    k = min(n_factors, N)
+
+    eigvals, eigvecs = np.linalg.eigh(S)
+    order = np.argsort(eigvals)[::-1][:k]
+    lk = np.clip(eigvals[order], 0.0, None)
+    Vk = eigvecs[:, order]
+    B = Vk * np.sqrt(lk)[None, :]
+
+    common = B @ B.T
+    eps = 1e-12 * np.trace(S) / N
+    idio = np.clip(np.diag(S) - np.diag(common), eps, None)
+    cov = common + np.diag(idio)
+
+    return _symmetrize(cov)
+
+
+# =========================================================================== #
+#                          Marchenko-Pastur denoising                         #
+# =========================================================================== #
+
+
+def denoise_cov(sigma: NDArray, n_obs: int, method: str = 'clip') -> NDArray:
+    r""" Marchenko-Pastur eigenvalue clipping on the correlation matrix.
+
+    Converts ``sigma`` to a correlation matrix, replaces the "noise"
+    eigenvalues (those at or below the Marchenko-Pastur upper edge
+    :math:`\lambda_+ = (1 + \sqrt{q})^2`, :math:`q = N / n\_obs`) by their
+    mean (trace-preserving), reconstructs, forces a unit diagonal and
+    rescales back by the original volatilities.
+
+    Parameters
+    ----------
+    sigma : array_like
+        Symmetric ``(N, N)`` covariance matrix to denoise.
+    n_obs : int
+        Number of observations the covariance was estimated on.
+    method : {'clip'}, optional
+        Denoising method. Only ``'clip'`` (constant-residual-eigenvalue) is
+        implemented; the keyword is validated so the signature is stable
+        for future methods. Default ``'clip'``.
+
+    Returns
+    -------
+    np.ndarray
+        Symmetric ``(N, N)`` denoised covariance matrix, same diagonal and
+        trace as ``sigma``.
+
+    References
+    ----------
+    .. [1] V.A. Marchenko, L.A. Pastur, "Distribution of eigenvalues for
+       some sets of random matrices", Mat. Sb., 72(114), 1967, 507-536.
+    .. [2] M. Lopez de Prado, "Machine Learning for Asset Managers",
+       Cambridge University Press, 2020 (constant residual eigenvalue
+       method).
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> rng = np.random.default_rng(0)
+    >>> X = rng.standard_normal((60, 10))
+    >>> S = sample_cov(X, ddof=0)
+    >>> D = denoise_cov(S, n_obs=60)
+    >>> D.shape
+    (10, 10)
+    >>> bool(np.allclose(np.diag(D), np.diag(S)))
+    True
+
+    """
+    if method != 'clip':
+        raise ValueError(f"Unknown method {method!r}; only 'clip' is supported.")
+    if n_obs <= 0:
+        raise ValueError("n_obs must be strictly positive.")
+
+    sigma = np.asarray(sigma, dtype=np.float64)
+    if sigma.ndim != 2 or sigma.shape[0] != sigma.shape[1]:
+        raise ValueError("sigma must be a square 2-D covariance matrix.")
+    if not np.all(np.isfinite(sigma)):
+        raise ValueError("sigma contains non-finite values (NaN or inf).")
+
+    sigma = _symmetrize(sigma)
+    N = sigma.shape[0]
+    vols = np.sqrt(np.diag(sigma))
+    denom = np.outer(vols, vols)
+    safe_denom = np.where(denom > 0, denom, 1.0)
+    corr = np.where(denom > 0, sigma / safe_denom, 0.0)
+    np.fill_diagonal(corr, 1.0)
+
+    q = N / float(n_obs)
+    lam_plus = (1.0 + np.sqrt(q)) ** 2
+
+    eigvals, eigvecs = np.linalg.eigh(corr)
+    mask = eigvals <= lam_plus
+    if np.any(mask):
+        eigvals = np.where(mask, np.mean(eigvals[mask]), eigvals)
+
+    denoised_corr = (eigvecs * eigvals) @ eigvecs.T
+    np.fill_diagonal(denoised_corr, 1.0)
+    cov = denoised_corr * denom
+
+    return _symmetrize(cov)

--- a/fynance/tests/portfolio/test_covariance.py
+++ b/fynance/tests/portfolio/test_covariance.py
@@ -1,0 +1,319 @@
+""" Tests for conditioned covariance estimators (fynance.portfolio.covariance). """
+
+import numpy as np
+import pytest
+
+from fynance.portfolio.covariance import (
+    _lw_intensity,
+    denoise_cov,
+    ewma_cov,
+    factor_cov,
+    ledoit_wolf,
+    sample_cov,
+)
+
+# ---------------------------------------------------------------------------
+# Slow, obviously-correct reference implementations
+# ---------------------------------------------------------------------------
+
+
+def _ref_ewma_cov(X: np.ndarray, halflife: float) -> np.ndarray:
+    """ Explicit-loop RiskMetrics-style EWMA covariance (reference). """
+    T, N = X.shape
+    lam = 0.5 ** (1.0 / halflife)
+    mean = X.mean(axis=0)
+    weights = [lam ** (T - 1 - t) for t in range(T)]
+    wsum = sum(weights)
+    weights = [w / wsum for w in weights]
+
+    cov = np.zeros((N, N))
+    for t in range(T):
+        x = X[t] - mean
+        for i in range(N):
+            for j in range(N):
+                cov[i, j] += weights[t] * x[i] * x[j]
+
+    return cov
+
+
+def _ref_lw_const_corr_intensity(X: np.ndarray) -> float:
+    """ Explicit-loop Ledoit & Wolf (2004b) constant-correlation intensity. """
+    T, N = X.shape
+    mean = X.mean(axis=0)
+    Xc = X - mean
+    S = np.zeros((N, N))
+    for t in range(T):
+        for i in range(N):
+            for j in range(N):
+                S[i, j] += Xc[t, i] * Xc[t, j]
+    S /= T
+
+    d = np.sqrt(np.diag(S))
+    r_bar_num = 0.0
+    for i in range(N):
+        for j in range(N):
+            if i != j:
+                r_bar_num += S[i, j] / (d[i] * d[j])
+    r_bar = r_bar_num / (N * (N - 1))
+
+    F = np.zeros((N, N))
+    for i in range(N):
+        for j in range(N):
+            F[i, j] = S[i, i] if i == j else r_bar * d[i] * d[j]
+
+    pi_mat = np.zeros((N, N))
+    for i in range(N):
+        for j in range(N):
+            acc = 0.0
+            for t in range(T):
+                acc += (Xc[t, i] * Xc[t, j] - S[i, j]) ** 2
+            pi_mat[i, j] = acc / T
+    pi_hat = pi_mat.sum()
+
+    rho_hat = np.trace(pi_mat)
+    for i in range(N):
+        for j in range(N):
+            if i == j:
+                continue
+            theta_ii = 0.0
+            theta_jj = 0.0
+            for t in range(T):
+                theta_ii += (Xc[t, i] ** 2 - S[i, i]) * (Xc[t, i] * Xc[t, j] - S[i, j])
+                theta_jj += (Xc[t, j] ** 2 - S[j, j]) * (Xc[t, i] * Xc[t, j] - S[i, j])
+            theta_ii /= T
+            theta_jj /= T
+            rho_hat += 0.5 * r_bar * (
+                np.sqrt(S[j, j] / S[i, i]) * theta_ii
+                + np.sqrt(S[i, i] / S[j, j]) * theta_jj
+            )
+
+    gamma_hat = np.sum((F - S) ** 2)
+    kappa_hat = (pi_hat - rho_hat) / gamma_hat
+
+    return float(np.clip(kappa_hat / T, 0.0, 1.0))
+
+
+# ---------------------------------------------------------------------------
+# Reference-implementation parity
+# ---------------------------------------------------------------------------
+
+
+def test_ewma_cov_matches_reference_loop():
+    rng = np.random.default_rng(1)
+    X = rng.standard_normal((200, 5)) * 0.01
+    got = ewma_cov(X, halflife=30.0)
+    ref = _ref_ewma_cov(X, halflife=30.0)
+    assert np.allclose(got, ref, rtol=1e-10)
+
+
+def test_lw_const_corr_intensity_matches_reference_loop():
+    rng = np.random.default_rng(2)
+    X = rng.standard_normal((200, 5)) * 0.01
+    got = _lw_intensity(X, target='const_corr')
+    ref = _ref_lw_const_corr_intensity(X)
+    assert np.isclose(got, ref, rtol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# Properties on seeded (T, N) grids
+# ---------------------------------------------------------------------------
+
+GRIDS = [(30, 2), (30, 8), (300, 2), (300, 8)]
+
+
+@pytest.mark.parametrize("T,N", GRIDS)
+def test_sample_cov_properties(T, N):
+    rng = np.random.default_rng(100 + T + N)
+    X = rng.standard_normal((T, N)) * 0.01
+    S = sample_cov(X)
+    assert S.shape == (N, N)
+    assert np.allclose(S, S.T)
+    eigvals = np.linalg.eigvalsh(S)
+    assert np.all(eigvals >= -1e-10)
+
+
+@pytest.mark.parametrize("T,N", GRIDS)
+@pytest.mark.parametrize("target", ["identity", "const_corr", "diag"])
+def test_ledoit_wolf_properties(T, N, target):
+    rng = np.random.default_rng(200 + T + N)
+    X = rng.standard_normal((T, N)) * 0.01
+    S = ledoit_wolf(X, target=target)
+    assert S.shape == (N, N)
+    assert np.allclose(S, S.T)
+    eigvals = np.linalg.eigvalsh(S)
+    assert np.all(eigvals >= -1e-10)
+
+    intensity = _lw_intensity(X, target=target)
+    assert -1e-12 <= intensity <= 1.0 + 1e-12
+
+
+@pytest.mark.parametrize("T,N", GRIDS)
+def test_ewma_cov_properties(T, N):
+    rng = np.random.default_rng(300 + T + N)
+    X = rng.standard_normal((T, N)) * 0.01
+    S = ewma_cov(X, halflife=63.0)
+    assert S.shape == (N, N)
+    assert np.allclose(S, S.T)
+    eigvals = np.linalg.eigvalsh(S)
+    assert np.all(eigvals >= -1e-10)
+
+
+@pytest.mark.parametrize("T,N", GRIDS)
+def test_factor_cov_properties(T, N):
+    rng = np.random.default_rng(400 + T + N)
+    X = rng.standard_normal((T, N)) * 0.01
+    S = factor_cov(X, n_factors=3)
+    assert S.shape == (N, N)
+    assert np.allclose(S, S.T)
+    eigvals = np.linalg.eigvalsh(S)
+    assert np.all(eigvals >= -1e-10)
+
+    ref_diag = np.diag(sample_cov(X, ddof=0))
+    assert np.allclose(np.diag(S), ref_diag, rtol=1e-8, atol=1e-14)
+
+
+@pytest.mark.parametrize("T,N", GRIDS)
+def test_denoise_cov_properties(T, N):
+    rng = np.random.default_rng(500 + T + N)
+    X = rng.standard_normal((T, N)) * 0.01
+    S = sample_cov(X, ddof=0)
+    D = denoise_cov(S, n_obs=T)
+    assert D.shape == (N, N)
+    assert np.allclose(D, D.T)
+    eigvals = np.linalg.eigvalsh(D)
+    assert np.all(eigvals >= -1e-10)
+
+    assert np.allclose(np.diag(D), np.diag(S), atol=1e-8)
+    assert np.isclose(np.trace(D), np.trace(S), atol=1e-8)
+
+
+# ---------------------------------------------------------------------------
+# Limiting cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("target", ["identity", "const_corr", "diag"])
+def test_ledoit_wolf_shrinks_less_as_t_grows(target):
+    # Non-spherical, non-constant-correlation population: heterogeneous vols
+    # and a mixed correlation structure, so the true covariance never
+    # coincides exactly with any of the shrinkage targets (which would make
+    # full shrinkage asymptotically optimal and break monotonicity).
+    rng = np.random.default_rng(7)
+    N = 5
+    vols = np.array([0.01, 0.02, 0.015, 0.03, 0.008])
+    corr = np.full((N, N), 0.3)
+    np.fill_diagonal(corr, 1.0)
+    corr[0, 1] = corr[1, 0] = 0.7
+    sigma = corr * np.outer(vols, vols)
+
+    X_small = rng.multivariate_normal(np.zeros(N), sigma, size=30)
+    X_large = rng.multivariate_normal(np.zeros(N), sigma, size=5000)
+
+    delta_small = _lw_intensity(X_small, target=target)
+    delta_large = _lw_intensity(X_large, target=target)
+    assert delta_large < delta_small
+
+
+def test_ewma_cov_huge_halflife_matches_sample_cov_ddof0():
+    rng = np.random.default_rng(8)
+    X = rng.standard_normal((300, 4)) * 0.01
+    got = ewma_cov(X, halflife=1e6)
+    ref = sample_cov(X, ddof=0)
+    # lam = 0.5 ** (1 / 1e6) is extremely close to but not exactly 1, so
+    # weights are near-uniform rather than bit-identical to 1/T; tolerance
+    # is scaled to the data (~1e-4 covariance entries) with headroom for
+    # that residual near-uniformity.
+    scale = np.abs(ref).max()
+    assert np.allclose(got, ref, atol=1e-5 * scale, rtol=1e-3)
+
+
+def test_factor_cov_full_rank_matches_sample_cov_ddof0():
+    rng = np.random.default_rng(9)
+    N = 6
+    X = rng.standard_normal((300, N)) * 0.01
+    got = factor_cov(X, n_factors=N)
+    ref = sample_cov(X, ddof=0)
+    assert np.allclose(got, ref, rtol=1e-8, atol=1e-14)
+
+
+@pytest.mark.parametrize("target", ["identity", "const_corr", "diag"])
+def test_n1_returns_variance_for_every_estimator(target):
+    rng = np.random.default_rng(10)
+    X = rng.standard_normal((100, 1)) * 0.01
+    ref_var = sample_cov(X, ddof=1)
+
+    assert np.allclose(sample_cov(X, ddof=1), ref_var)
+    assert np.allclose(ledoit_wolf(X, target=target), sample_cov(X, ddof=0), rtol=1e-9)
+    assert np.allclose(ewma_cov(X, halflife=1e6), sample_cov(X, ddof=0), rtol=1e-6)
+    assert np.allclose(factor_cov(X, n_factors=1), sample_cov(X, ddof=0), rtol=1e-9)
+    S0 = sample_cov(X, ddof=0)
+    assert np.allclose(denoise_cov(S0, n_obs=100), S0, rtol=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Scale equivariance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("c", [2.0, 0.1, 5.0])
+def test_scale_equivariance(c):
+    rng = np.random.default_rng(11)
+    X = rng.standard_normal((150, 5)) * 0.01
+
+    assert np.allclose(sample_cov(c * X), c ** 2 * sample_cov(X), rtol=1e-9)
+    assert np.allclose(
+        ewma_cov(c * X, halflife=40.0), c ** 2 * ewma_cov(X, halflife=40.0), rtol=1e-9
+    )
+    assert np.allclose(
+        factor_cov(c * X, n_factors=3), c ** 2 * factor_cov(X, n_factors=3), rtol=1e-9
+    )
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+def test_nan_input_raises():
+    X = np.array([[1.0, np.nan], [2.0, 1.0], [3.0, 4.0]])
+    with pytest.raises(ValueError):
+        sample_cov(X)
+    with pytest.raises(ValueError):
+        ledoit_wolf(X)
+    with pytest.raises(ValueError):
+        ewma_cov(X)
+    with pytest.raises(ValueError):
+        factor_cov(X)
+
+
+def test_inf_input_raises():
+    X = np.array([[1.0, np.inf], [2.0, 1.0], [3.0, 4.0]])
+    with pytest.raises(ValueError):
+        sample_cov(X)
+
+
+def test_denoise_cov_bogus_method_raises():
+    S = np.eye(3)
+    with pytest.raises(ValueError):
+        denoise_cov(S, n_obs=100, method='bogus')
+
+
+def test_ledoit_wolf_bogus_target_raises():
+    rng = np.random.default_rng(12)
+    X = rng.standard_normal((50, 3))
+    with pytest.raises(ValueError):
+        ledoit_wolf(X, target='bogus')
+
+
+def test_factor_cov_bad_n_factors_raises():
+    rng = np.random.default_rng(13)
+    X = rng.standard_normal((50, 3))
+    with pytest.raises(ValueError):
+        factor_cov(X, n_factors=0)
+
+
+def test_1d_input_reshaped():
+    rng = np.random.default_rng(14)
+    x = rng.standard_normal(100) * 0.01
+    S = sample_cov(x)
+    assert S.shape == (1, 1)


### PR DESCRIPTION
## Summary
- New `fynance.portfolio.covariance` module: `sample_cov`, closed-form `ledoit_wolf` (identity / constant-correlation / diagonal targets), RiskMetrics-style `ewma_cov` (Numba `@njit` kernel), PCA `factor_cov` (low-rank + diagonal, PSD by construction), Marchenko-Pastur `denoise_cov`.
- All estimators are interchangeable `(T, N) -> (N, N)` callables — the contract for the allocators' opt-in `cov=` seam (next leaf of the `portfolio-risk` epic).
- Leaf 01/06 of the `portfolio-risk` epic (roadmap §3); also fixes the catalog path in the roadmap preamble.

## Why
Raw `np.cov` on short windows is the dominant source of MVP/ERC weight instability. Closed-form shrinkage/denoising needs numpy only (no scikit-learn dependency), and a callable seam will preserve the frozen `portfolio.allocation` API. See the ADR entry (2026-07-05).

## Verification (synthetic two-block GBM panel, N=20, T=252)
- Condition number: `sample_cov` 97.41 → `ledoit_wolf` 91.13, `denoise_cov` 82.52.
- OOS MVP vol over 20 seeds (train 126 / test 126): 0.005909 (sample) → 0.005790 (LW).

## Changelog
Added under [Unreleased]: conditioned covariance estimators module.

## Test plan
- [x] `pytest` — 1018 passed, 1 skipped (47 new tests incl. pure-Python reference parity at rtol 1e-10)
- [x] `ruff check fynance/` / `mypy` (0 errors) / interrogate 95% / Sphinx -W
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)