### PR TITLE
feat: add risk attribution module (fynance.portfolio.attribution)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Risk attribution.** New `fynance.portfolio.attribution` module:
+  `marginal_risk` (∂σₚ/∂w), `risk_contribution` (absolute or percentage,
+  summing to σₚ / 1) and the causal `roll_risk_contribution` walking a
+  `(T, N)` weight path against a trailing covariance window (accepts the
+  same `cov=` estimators as the allocators).
 - **Allocator `cov=` seam.** The six allocators (`ERC`/`HRP`/`IVP`/`MVP`/
   `MVP_uc`/`MDP`) accept an opt-in `cov=` callable mapping the `(T, N)`
   training window to an `(N, N)` covariance matrix (e.g.

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -85,7 +85,9 @@ Template:
 - **Why**: raw `np.cov` on short windows is the dominant source of MVP/ERC
   weight instability; the closed forms need numpy only (no new dependency);
   a callable seam preserves the frozen `portfolio.allocation` API and makes
-  the estimators reusable elsewhere (risk attribution, future risk tools).
+  the estimators reusable elsewhere (the `portfolio.attribution` diagnostics
+  landed in PR #237 on the same seam, validating that ERC equalizes
+  contributions).
   Verified OOS on synthetic two-block panels: condition number 97.4 -> 91.1
   (LW) / 82.5 (denoised); mean MVP OOS vol 0.005909 -> 0.005790 over 20 seeds.
 - **Rejected alternatives**: depending on scikit-learn (heavy dependency for a

--- a/doc/source/portfolio.attribution.rst
+++ b/doc/source/portfolio.attribution.rst
@@ -1,0 +1,14 @@
+**********************
+Risk decomposition
+**********************
+
+Risk decomposition for portfolio weights: marginal risk (:func:`~fynance.portfolio.attribution.marginal_risk`), risk contribution (:func:`~fynance.portfolio.attribution.risk_contribution`), and causal rolling risk contributions (:func:`~fynance.portfolio.attribution.roll_risk_contribution`).
+
+.. currentmodule:: fynance.portfolio.attribution
+
+.. autosummary::
+   :toctree: generated/
+
+   marginal_risk
+   risk_contribution
+   roll_risk_contribution

--- a/doc/source/portfolio.rst
+++ b/doc/source/portfolio.rst
@@ -18,6 +18,13 @@ Portfolio allocation algorithms and rolling walk-forward wrappers.
       (MDP), Minimum Variance Portfolio (MVP, MVP_uc) and a rolling
       walk-forward wrapper.
 
+   .. grid-item-card:: :octicon:`list-ordered;1.2em;sd-mr-1` Risk decomposition
+      :link: portfolio.attribution
+      :link-type: doc
+
+      Marginal and absolute risk contributions of assets to portfolio
+      volatility, with causal rolling decomposition.
+
    .. grid-item-card:: :octicon:`pin;1.2em;sd-mr-1` Position sizing
       :link: portfolio.sizing
       :link-type: doc
@@ -36,5 +43,6 @@ Portfolio allocation algorithms and rolling walk-forward wrappers.
    :hidden:
 
    portfolio.allocation
+   portfolio.attribution
    portfolio.covariance
    portfolio.sizing

--- a/fynance/portfolio/__init__.py
+++ b/fynance/portfolio/__init__.py
@@ -15,6 +15,7 @@
    :caption: Contents:
 
    portfolio.allocation
+   portfolio.attribution
    portfolio.covariance
    portfolio.sizing
 
@@ -25,11 +26,13 @@
 # Third party packages
 
 # Local packages
-from . import allocation, covariance, sizing
+from . import allocation, attribution, covariance, sizing
 from .allocation import *
+from .attribution import *
 from .covariance import *
 from .sizing import *
 
 __all__ = allocation.__all__
+__all__ += attribution.__all__
 __all__ += covariance.__all__
 __all__ += sizing.__all__

--- a/fynance/portfolio/attribution.py
+++ b/fynance/portfolio/attribution.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+r""" Ex-ante risk decomposition for portfolios.
+
+Marginal and absolute risk contributions of a weight vector to portfolio
+variance, plus a causal rolling variant for walk-forward decomposition of
+a `(T, N)` weight path against sliding windows of returns.
+
+Main entry points
+-----------------
+- :func:`marginal_risk` — marginal contribution of each asset to portfolio
+  volatility.
+- :func:`risk_contribution` — absolute (or percentage) risk contribution
+  of each asset.
+- :func:`roll_risk_contribution` — causal rolling risk contributions over
+  a time series.
+
+"""
+
+from __future__ import annotations
+
+# Built-in packages
+from typing import Callable
+
+# Third-party packages
+import numpy as np
+from numpy.typing import NDArray
+
+__all__ = ['marginal_risk', 'risk_contribution', 'roll_risk_contribution']
+
+
+def marginal_risk(w: NDArray, sigma: NDArray) -> NDArray:
+    r""" Marginal contribution of each asset to portfolio volatility.
+
+    Compute the gradient of portfolio volatility with respect to weights:
+    :math:`\partial \sigma_p / \partial w = (\Sigma w) / \sigma_p`, where
+    :math:`\sigma_p = \sqrt{w^\top \Sigma w}` is the portfolio volatility.
+
+    Parameters
+    ----------
+    w : array_like
+        Portfolio weights, shape ``(N,)`` or ``(N, 1)``.
+    sigma : array_like
+        Symmetric ``(N, N)`` covariance matrix.
+
+    Returns
+    -------
+    np.ndarray
+        Marginal risk per asset, shape ``(N,)``. If portfolio volatility
+        is zero, returns zeros.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> w = np.array([0.6, 0.4])
+    >>> sigma = np.array([[0.04, 0.0], [0.0, 0.01]])
+    >>> mr = marginal_risk(w, sigma)
+    >>> mr.shape
+    (2,)
+    >>> bool(np.all(mr > 0))
+    True
+
+    """
+    w = np.asarray(w, dtype=np.float64).ravel()
+    sigma = np.asarray(sigma, dtype=np.float64)
+
+    if sigma.ndim != 2 or sigma.shape[0] != sigma.shape[1]:
+        raise ValueError("sigma must be a square 2-D covariance matrix.")
+    if sigma.shape[0] != w.shape[0]:
+        raise ValueError(
+            f"sigma shape {sigma.shape} does not match w shape {w.shape}."
+        )
+    if not np.all(np.isfinite(sigma)):
+        raise ValueError("sigma contains non-finite values (NaN or inf).")
+    if not np.all(np.isfinite(w)):
+        raise ValueError("w contains non-finite values (NaN or inf).")
+
+    sigma_w = sigma @ w
+    sigma_p = np.sqrt(w @ sigma_w)
+
+    if sigma_p == 0.0:
+        return np.zeros_like(w)
+
+    return sigma_w / sigma_p
+
+
+def risk_contribution(
+    w: NDArray,
+    sigma: NDArray,
+    pct: bool = True,
+) -> NDArray:
+    r""" Risk contribution of each asset to portfolio variance.
+
+    Absolute risk contribution: :math:`RC_i = w_i \cdot MR_i`, where
+    :math:`MR_i` is the marginal risk. When :math:`pct=True`, normalize
+    by portfolio volatility so contributions sum to 1 (percentage).
+
+    Parameters
+    ----------
+    w : array_like
+        Portfolio weights, shape ``(N,)`` or ``(N, 1)``.
+    sigma : array_like
+        Symmetric ``(N, N)`` covariance matrix.
+    pct : bool, optional
+        If True (default), return percentage contributions that sum to 1.
+        If False, return absolute contributions that sum to portfolio
+        volatility.
+
+    Returns
+    -------
+    np.ndarray
+        Risk contribution per asset, shape ``(N,)``. If portfolio
+        volatility is zero, returns zeros.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> w = np.array([0.5, 0.5])
+    >>> sigma = np.array([[0.04, 0.0], [0.0, 0.01]])
+    >>> rc_pct = risk_contribution(w, sigma, pct=True)
+    >>> np.allclose(rc_pct, [0.8, 0.2])
+    True
+
+    """
+    w = np.asarray(w, dtype=np.float64).ravel()
+    sigma = np.asarray(sigma, dtype=np.float64)
+
+    if sigma.ndim != 2 or sigma.shape[0] != sigma.shape[1]:
+        raise ValueError("sigma must be a square 2-D covariance matrix.")
+    if sigma.shape[0] != w.shape[0]:
+        raise ValueError(
+            f"sigma shape {sigma.shape} does not match w shape {w.shape}."
+        )
+    if not np.all(np.isfinite(sigma)):
+        raise ValueError("sigma contains non-finite values (NaN or inf).")
+    if not np.all(np.isfinite(w)):
+        raise ValueError("w contains non-finite values (NaN or inf).")
+
+    mr = marginal_risk(w, sigma)
+    rc = w * mr
+
+    if not pct:
+        return rc
+
+    # Normalize to sum to 1
+    sigma_w = sigma @ w
+    sigma_p = np.sqrt(w @ sigma_w)
+
+    if sigma_p == 0.0:
+        return np.zeros_like(w)
+
+    return rc / sigma_p
+
+
+def roll_risk_contribution(
+    W: NDArray,
+    X: NDArray,
+    n: int = 252,
+    cov: Callable[[NDArray], NDArray] | None = None,
+    pct: bool = True,
+) -> NDArray:
+    r""" Causal rolling risk contributions over a time series.
+
+    For each time step :math:`t \geq n`, estimate the covariance matrix
+    from returns in the past :math:`n` periods and compute risk
+    contributions for the weights at time :math:`t`. Earlier rows are
+    filled with NaN (no covariance estimate yet).
+
+    Parameters
+    ----------
+    W : array_like
+        Weight time series, shape ``(T, N)``.
+    X : array_like
+        Returns panel, shape ``(T, N)``, rows in chronological order
+        (oldest first).
+    n : int, optional
+        Window length for covariance estimation. Default 252.
+    cov : callable, optional
+        Covariance estimator callable that accepts a returns panel and
+        returns a symmetric ``(N, N)`` matrix. If None (default), uses
+        :func:`numpy.cov` with ``rowvar=False``.
+    pct : bool, optional
+        If True (default), return percentage contributions summing to 1.
+        If False, return absolute contributions summing to portfolio
+        volatility per period.
+
+    Returns
+    -------
+    np.ndarray
+        Risk contributions per period, shape ``(T, N)``. Rows ``t < n``
+        are filled with NaN.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> rng = np.random.default_rng(0)
+    >>> X = rng.standard_normal((50, 3))
+    >>> W = rng.uniform(0.2, 0.4, (50, 3))
+    >>> W /= W.sum(axis=1, keepdims=True)
+    >>> rc = roll_risk_contribution(W, X, n=20)
+    >>> rc.shape
+    (50, 3)
+    >>> np.isnan(rc[:20]).all()
+    True
+
+    """
+    W = np.asarray(W, dtype=np.float64)
+    X = np.asarray(X, dtype=np.float64)
+
+    if W.ndim != 2 or X.ndim != 2:
+        raise ValueError("W and X must both be 2-D arrays.")
+    if W.shape != X.shape:
+        raise ValueError(
+            f"W shape {W.shape} does not match X shape {X.shape}."
+        )
+    if n < 1 or n >= W.shape[0]:
+        raise ValueError(
+            f"Window length n={n} must be >= 1 and < T={W.shape[0]}."
+        )
+    if not np.all(np.isfinite(W)):
+        raise ValueError("W contains non-finite values (NaN or inf).")
+    if not np.all(np.isfinite(X)):
+        raise ValueError("X contains non-finite values (NaN or inf).")
+
+    T, N = W.shape
+    rc = np.full((T, N), np.nan, dtype=np.float64)
+
+    for t in range(n, T):
+        window = X[t - n : t]
+
+        # Estimate covariance: use provided callable or numpy.cov
+        if cov is not None:
+            sigma_t = cov(window)
+        else:
+            sigma_t = np.atleast_2d(np.cov(window, rowvar=False))
+
+        # Compute risk contribution for weights at time t
+        rc[t] = risk_contribution(W[t], sigma_t, pct=pct)
+
+    return rc

--- a/fynance/tests/portfolio/test_attribution.py
+++ b/fynance/tests/portfolio/test_attribution.py
@@ -1,0 +1,331 @@
+""" Tests for risk decomposition (fynance.portfolio.attribution). """
+
+import warnings
+
+import numpy as np
+import pytest
+
+from fynance.portfolio.allocation import ERC
+from fynance.portfolio.attribution import (
+    marginal_risk,
+    risk_contribution,
+    roll_risk_contribution,
+)
+from fynance.portfolio.covariance import ledoit_wolf
+
+# =========================================================================== #
+#                          Basic invariants                                   #
+# =========================================================================== #
+
+
+class TestMarginalRisk:
+    """ Tests for marginal_risk function. """
+
+    def test_marginal_risk_basic(self):
+        """ Marginal risk should be (sigma @ w) / sigma_p. """
+        w = np.array([0.6, 0.4])
+        sigma = np.array([[0.04, 0.0], [0.0, 0.01]])
+
+        mr = marginal_risk(w, sigma)
+
+        # sigma @ w = [0.04*0.6, 0.01*0.4] = [0.024, 0.004]
+        # sigma_p = sqrt(0.024*0.6 + 0.004*0.4) = sqrt(0.01440 + 0.00160) = sqrt(0.016) = 0.1265
+        # mr = [0.024/0.1265, 0.004/0.1265]
+        expected = np.array([0.024, 0.004]) / np.sqrt(0.016)
+        assert np.allclose(mr, expected)
+
+    def test_marginal_risk_flattens_input(self):
+        """ marginal_risk should accept (N, 1) and flatten it. """
+        w = np.array([[0.5], [0.5]])
+        sigma = np.array([[0.04, 0.0], [0.0, 0.01]])
+
+        mr = marginal_risk(w, sigma)
+
+        # Should produce same result as 1-D input
+        mr_flat = marginal_risk(np.array([0.5, 0.5]), sigma)
+        assert np.allclose(mr, mr_flat)
+
+    def test_marginal_risk_zero_sigma_p(self):
+        """ marginal_risk should return zeros when sigma_p == 0. """
+        w = np.array([0.5, 0.5])
+        sigma = np.zeros((2, 2))
+
+        mr = marginal_risk(w, sigma)
+
+        assert np.allclose(mr, 0.0)
+
+    def test_marginal_risk_validates_square_sigma(self):
+        """ marginal_risk should raise on non-square sigma. """
+        w = np.array([0.5, 0.5])
+        sigma = np.ones((2, 3))
+
+        with pytest.raises(ValueError, match="square"):
+            marginal_risk(w, sigma)
+
+    def test_marginal_risk_validates_shape_match(self):
+        """ marginal_risk should raise on shape mismatch. """
+        w = np.array([0.5, 0.5, 0.5])
+        sigma = np.eye(2)
+
+        with pytest.raises(ValueError, match="does not match"):
+            marginal_risk(w, sigma)
+
+
+class TestRiskContribution:
+    """ Tests for risk_contribution function. """
+
+    def test_risk_contribution_pct_hand_checked(self):
+        """ risk_contribution on 2-asset example: w=[0.5, 0.5], sigma=[[0.04,0],[0,0.01]]. """
+        w = np.array([0.5, 0.5])
+        sigma = np.array([[0.04, 0.0], [0.0, 0.01]])
+
+        rc_pct = risk_contribution(w, sigma, pct=True)
+
+        # Expected: [0.8, 0.2] (from contract specification)
+        assert np.allclose(rc_pct, [0.8, 0.2])
+
+    def test_risk_contribution_pct_sum_to_one(self):
+        """ risk_contribution(pct=True) should sum to 1. """
+        rng = np.random.default_rng(42)
+        N = 6
+
+        # Create a random PSD covariance matrix: A @ A.T
+        A = rng.standard_normal((N, N))
+        sigma = A @ A.T
+        w = rng.uniform(0.1, 1.0, N)
+        w /= w.sum()
+
+        rc_pct = risk_contribution(w, sigma, pct=True)
+
+        assert np.allclose(rc_pct.sum(), 1.0, rtol=1e-12)
+
+    def test_risk_contribution_absolute_sum_to_sigma_p(self):
+        """ risk_contribution(pct=False) should sum to sigma_p. """
+        rng = np.random.default_rng(43)
+        N = 6
+
+        A = rng.standard_normal((N, N))
+        sigma = A @ A.T
+        w = rng.uniform(0.1, 1.0, N)
+        w /= w.sum()
+
+        rc_abs = risk_contribution(w, sigma, pct=False)
+        sigma_p = np.sqrt(w @ sigma @ w)
+
+        assert np.allclose(rc_abs.sum(), sigma_p, rtol=1e-12)
+
+    def test_risk_contribution_homogeneity(self):
+        """ risk_contribution(2*w, pct=True) should equal the w version. """
+        rng = np.random.default_rng(44)
+        N = 5
+
+        A = rng.standard_normal((N, N))
+        sigma = A @ A.T
+        w = rng.uniform(0.1, 1.0, N)
+        w /= w.sum()
+
+        rc_w = risk_contribution(w, sigma, pct=True)
+        rc_2w = risk_contribution(2.0 * w, sigma, pct=True)
+
+        assert np.allclose(rc_w, rc_2w)
+
+    def test_risk_contribution_zero_sigma_p(self):
+        """ risk_contribution should return zeros when sigma_p == 0. """
+        w = np.array([0.5, 0.5])
+        sigma = np.zeros((2, 2))
+
+        rc_pct = risk_contribution(w, sigma, pct=True)
+        rc_abs = risk_contribution(w, sigma, pct=False)
+
+        assert np.allclose(rc_pct, 0.0)
+        assert np.allclose(rc_abs, 0.0)
+
+    def test_risk_contribution_degenerate_no_warnings(self):
+        """ risk_contribution on zero sigma should not raise warnings. """
+        w = np.array([0.5, 0.5])
+        sigma = np.zeros((2, 2))
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            rc = risk_contribution(w, sigma, pct=True)
+            assert np.allclose(rc, 0.0)
+
+
+# =========================================================================== #
+#                              ERC integration                                #
+# =========================================================================== #
+
+
+class TestErcIntegration:
+    """ Test risk contributions on ERC-allocated portfolios. """
+
+    def test_erc_contributions_are_equal(self):
+        """ risk_contribution of ERC weights should be approximately 1/N. """
+        rng = np.random.default_rng(45)
+        N, T = 5, 300
+        X = rng.standard_normal((T, N))
+
+        # Compute ERC weights
+        w_erc = ERC(X).flatten()
+
+        # Compute covariance
+        sigma = np.cov(X, rowvar=False)
+
+        # Compute risk contributions
+        rc = risk_contribution(w_erc, sigma, pct=True)
+
+        # All entries should be close to 1/N
+        expected = 1.0 / N
+        assert np.allclose(rc, expected, atol=1e-3)
+
+
+# =========================================================================== #
+#                           Diagonal sigma                                    #
+# =========================================================================== #
+
+
+class TestDiagonalSigma:
+    """ Test on diagonal covariance matrices. """
+
+    def test_diagonal_sigma_contributions(self):
+        """ On diagonal sigma, contributions are proportional to w_i^2 * var_i. """
+        # w = [0.3, 0.7], diag(sigma) = [0.04, 0.09]
+        w = np.array([0.3, 0.7])
+        sigma = np.diag([0.04, 0.09])
+
+        rc_pct = risk_contribution(w, sigma, pct=True)
+
+        # sigma_p^2 = w @ sigma @ w = 0.3^2 * 0.04 + 0.7^2 * 0.09 = 0.0477
+        # rc_abs = w * (sigma @ w) = [0.3, 0.7] * [0.012, 0.063] = [0.0036, 0.0441]
+        # rc_pct = rc_abs / sigma_p^2
+        sigma_p_sq = 0.3**2 * 0.04 + 0.7**2 * 0.09
+        expected = np.array([0.0036, 0.0441]) / sigma_p_sq
+
+        assert np.allclose(rc_pct, expected, rtol=1e-10)
+
+
+# =========================================================================== #
+#                            Rolling risk contribution                        #
+# =========================================================================== #
+
+
+class TestRollRiskContribution:
+    """ Tests for roll_risk_contribution function. """
+
+    def test_roll_output_shape(self):
+        """ roll_risk_contribution output should be (T, N). """
+        rng = np.random.default_rng(46)
+        T, N = 100, 5
+        X = rng.standard_normal((T, N))
+        W = rng.uniform(0.1, 1.0, (T, N))
+        W /= W.sum(axis=1, keepdims=True)
+
+        rc = roll_risk_contribution(W, X, n=20)
+
+        assert rc.shape == (T, N)
+
+    def test_roll_early_rows_are_nan(self):
+        """ Rows t < n should be filled with NaN. """
+        rng = np.random.default_rng(47)
+        T, N = 100, 5
+        n = 30
+        X = rng.standard_normal((T, N))
+        W = rng.uniform(0.1, 1.0, (T, N))
+        W /= W.sum(axis=1, keepdims=True)
+
+        rc = roll_risk_contribution(W, X, n=n)
+
+        assert np.isnan(rc[:n]).all()
+        assert np.any(~np.isnan(rc[n:]))
+
+    def test_roll_causality(self):
+        """ Future data in X should not affect past risk contributions. """
+        rng = np.random.default_rng(48)
+        T, N = 200, 5
+        n = 50
+        X = rng.standard_normal((T, N))
+        W = rng.uniform(0.1, 1.0, (T, N))
+        W /= W.sum(axis=1, keepdims=True)
+
+        # Compute contributions
+        rc_orig = roll_risk_contribution(W, X.copy(), n=n, pct=True)
+
+        # Modify data after t0
+        t0 = n + 7
+        X_modified = X.copy()
+        X_modified[t0:] *= 3.0
+
+        rc_modified = roll_risk_contribution(W, X_modified, n=n, pct=True)
+
+        # Rows strictly before t0 should be unchanged
+        assert np.allclose(rc_orig[:t0], rc_modified[:t0], equal_nan=True)
+
+    def test_roll_contributions_sum_to_one_pct(self):
+        """ roll_risk_contribution with pct=True should have rows summing to 1. """
+        rng = np.random.default_rng(49)
+        T, N = 100, 5
+        n = 20
+        X = rng.standard_normal((T, N))
+        W = rng.uniform(0.1, 1.0, (T, N))
+        W /= W.sum(axis=1, keepdims=True)
+
+        rc = roll_risk_contribution(W, X, n=n, pct=True)
+
+        # Rows >= n should sum to ~1.0
+        for t in range(n, T):
+            assert np.allclose(rc[t].sum(), 1.0, rtol=1e-10)
+
+    def test_roll_with_ledoit_wolf(self):
+        """ roll_risk_contribution should work with ledoit_wolf covariance. """
+        rng = np.random.default_rng(50)
+        T, N = 100, 5
+        n = 20
+        X = rng.standard_normal((T, N))
+        W = rng.uniform(0.1, 1.0, (T, N))
+        W /= W.sum(axis=1, keepdims=True)
+
+        rc = roll_risk_contribution(W, X, n=n, cov=ledoit_wolf, pct=True)
+
+        assert rc.shape == (T, N)
+        assert np.isnan(rc[:n]).all()
+        # Rows >= n should sum to ~1.0
+        for t in range(n, min(n + 10, T)):
+            assert np.allclose(rc[t].sum(), 1.0, rtol=1e-3)
+
+
+# =========================================================================== #
+#                             Edge cases                                      #
+# =========================================================================== #
+
+
+class TestEdgeCases:
+    """ Tests for edge cases and error handling. """
+
+    def test_risk_contribution_validates_inputs(self):
+        """ risk_contribution should validate input shapes and values. """
+        w = np.array([0.5, 0.5])
+        sigma = np.eye(2)
+
+        # Non-finite w
+        with pytest.raises(ValueError, match="non-finite"):
+            risk_contribution(np.array([0.5, np.nan]), sigma)
+
+        # Non-finite sigma
+        with pytest.raises(ValueError, match="non-finite"):
+            risk_contribution(w, np.array([[1.0, np.inf], [np.inf, 1.0]]))
+
+    def test_roll_risk_contribution_validates_inputs(self):
+        """ roll_risk_contribution should validate input shapes and window size. """
+        X = np.ones((100, 3))
+        W = np.ones((100, 3)) / 3.0
+
+        # Shape mismatch
+        with pytest.raises(ValueError, match="does not match"):
+            roll_risk_contribution(W, X[:-1], n=20)
+
+        # Invalid n
+        with pytest.raises(ValueError, match="must be"):
+            roll_risk_contribution(W, X, n=0)
+
+        with pytest.raises(ValueError, match="must be"):
+            roll_risk_contribution(W, X, n=100)


### PR DESCRIPTION
## Summary
- New `fynance.portfolio.attribution` module: `marginal_risk` (gradient of portfolio vol), `risk_contribution` (absolute contributions summing to σₚ, or percentage summing to 1) and causal `roll_risk_contribution` over a `(T, N)` weight path with a trailing covariance window (strictly-past `X[t-n:t]`).
- Accepts the same `cov=` estimator callables as the allocators (#235/#236).
- Leaf 03/06 of the `portfolio-risk` epic.

## Why
ERC exists but the diagnostic it optimizes — who contributes how much risk — was exposed nowhere; `diversified_ratio` was the only book-level risk statistic.

## Verification (synthetic two-block GBM panel, N=10, T=750)
Rolling ERC book: max post-warmup deviation of contributions from 1/N = 1.93e-03; a 60%-concentrated book shows asset 0 carrying 80.8% of risk.

## Changelog
Added under [Unreleased]: risk attribution module.

## Test plan
- [x] `pytest` — 1074 passed, 1 skipped (20 new tests: sum invariants rtol 1e-12, ERC integration, diagonal closed form, rolling causality)
- [x] `ruff` / `mypy` / interrogate / Sphinx -W
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)