### PR TITLE
feat: add risk-budgeting allocator RBP (generalized ERC)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Risk-budgeting allocation.** New `RBP(X, budgets=None, ...)` allocator
+  (generalized ERC, Roncalli least-squares objective): weights whose risk
+  contributions match an arbitrary budget vector; `budgets=None` reproduces
+  `ERC`, and the `cov=` seam / `rolling_allocation` forwarding apply.
 - **Risk attribution.** New `fynance.portfolio.attribution` module:
   `marginal_risk` (∂σₚ/∂w), `risk_contribution` (absolute or percentage,
   summing to σₚ / 1) and the causal `roll_risk_contribution` walking a

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -72,6 +72,23 @@ Template:
 
 <!-- new entries below, newest first -->
 
+### 2026-07-05 — Risk budgeting as a separate `RBP` allocator (PR #238)  [accepted]
+
+- **Choice**: ship risk budgeting as a new `RBP(X, budgets=None, cov=None)`
+  function with the Roncalli least-squares objective
+  `sum_i (w_i (Sigma w)_i - b_i w'Sigma w)^2`, sharing ERC's scaffolding
+  (unit-trace rescale, SLSQP, bound clamping) — not as a `budgets=` parameter
+  on `ERC`.
+- **Why**: `portfolio.allocation` is a frozen API — a new function is purely
+  additive and leaves ERC's contract untouched; `budgets=None` reproduces ERC
+  within optimizer tolerance (regression-tested at 1e-4), and budget matching
+  is verified through `portfolio.attribution` (ex-ante error ~8e-7 on
+  synthetic panels, ~7e-4 through the rolling path).
+- **Rejected alternatives**: extending `ERC`'s signature (behavior-drift risk
+  in the stable API); Roncalli's log-barrier / fixed-point formulation
+  (cleaner convexity but a second optimizer pattern to maintain for no
+  observed accuracy gain here).
+
 ### 2026-07-05 — Conditioned covariance estimators as interchangeable callables (PR #235)  [accepted]
 
 - **Choice**: ship covariance conditioning as a standalone

--- a/doc/source/portfolio.allocation.rst
+++ b/doc/source/portfolio.allocation.rst
@@ -2,7 +2,7 @@
 Portfolio allocation
 ********************
 
-Currently this module contains only five algorithms: Equal Risk Contribution (:func:`~fynance.portfolio.allocation.ERC`), Hierarchical Risk Parity (:func:`~fynance.portfolio.allocation.HRP`), Inverse Variance Portfolio (:func:`~fynance.portfolio.allocation.IVP`), Maximum Diversified Portfolio (:func:`~fynance.portfolio.allocation.MDP`), Minimum Variance Portfolio constrained (:func:`~fynance.portfolio.allocation.MVP`) and unconstrained (:func:`~fynance.portfolio.allocation.MVP_uc`).
+Currently this module contains the following algorithms: Equal Risk Contribution (:func:`~fynance.portfolio.allocation.ERC`), Risk Budgeting Portfolio (:func:`~fynance.portfolio.allocation.RBP`), Hierarchical Risk Parity (:func:`~fynance.portfolio.allocation.HRP`), Inverse Variance Portfolio (:func:`~fynance.portfolio.allocation.IVP`), Maximum Diversified Portfolio (:func:`~fynance.portfolio.allocation.MDP`), Minimum Variance Portfolio constrained (:func:`~fynance.portfolio.allocation.MVP`) and unconstrained (:func:`~fynance.portfolio.allocation.MVP_uc`).
 
 The module contains also an object to roll these allocations algorithms (:func:`~fynance.portfolio.allocation.rolling_allocation`).
 
@@ -15,6 +15,7 @@ Allocation algorithms
    :toctree: generated/
 
    ERC
+   RBP
    HRP
    IVP
    MDP

--- a/fynance/portfolio/allocation.py
+++ b/fynance/portfolio/allocation.py
@@ -23,6 +23,8 @@ reaches the allocator unchanged through its ``**kwargs`` forwarding.
 Main entry points
 -----------------
 - :func:`ERC` — Equal Risk Contribution (risk-parity).
+- :func:`RBP` — Risk Budgeting Portfolio (ERC generalized to arbitrary
+  per-asset risk budgets).
 - :func:`HRP` — Hierarchical Risk Parity.
 - :func:`IVP` — Inverse Variance Portfolio.
 - :func:`MDP` — Maximum Diversified Portfolio.
@@ -50,7 +52,7 @@ from scipy.optimize import Bounds, LinearConstraint, minimize
 # Local packages
 from fynance.metrics import diversified_ratio
 
-__all__ = ['ERC', 'HRP', 'IVP', 'MDP', 'MVP', 'MVP_uc', 'rolling_allocation']
+__all__ = ['ERC', 'HRP', 'IVP', 'MDP', 'MVP', 'MVP_uc', 'RBP', 'rolling_allocation']
 
 
 # =========================================================================== #
@@ -230,6 +232,214 @@ def ERC(
     const_ind = Bounds(low_bound * np.ones([N]), up_bound * np.ones([N]))
     result = minimize(
         f_ERC,
+        w0,
+        method='SLSQP',
+        constraints=[const_sum],
+        bounds=const_ind,
+        options={'ftol': 1e-12, 'maxiter': 1000},
+    )
+
+    return result.x.reshape([N, 1])
+
+
+# =========================================================================== #
+#                          Risk Budgeting Portfolio                           #
+# =========================================================================== #
+
+
+def _validate_budgets(budgets: NDArray[np.float64] | None, N: int) -> NDArray[np.float64]:
+    """ Validate and normalize a risk-budget vector.
+
+    Parameters
+    ----------
+    budgets : array_like or None
+        Candidate risk budgets, expected length ``N``. ``None`` means the
+        equal-budget default ``1 / N``.
+    N : int
+        Number of assets.
+
+    Returns
+    -------
+    np.ndarray
+        Length-``N`` budget vector, strictly positive and summing to
+        exactly 1.
+
+    Raises
+    ------
+    ValueError
+        If `budgets` does not have length `N`, contains a non-positive
+        entry, or its sum deviates from 1 by more than ``1e-8``.
+
+    """
+    if budgets is None:
+        return np.full(N, 1.0 / N)
+
+    b = np.asarray(budgets, dtype=np.float64).ravel()
+    if b.shape != (N,):
+        raise ValueError(
+            f"budgets must be a length-{N} vector, got shape {b.shape}."
+        )
+
+    if np.any(b <= 0):
+        raise ValueError("budgets entries must be strictly positive.")
+
+    total = b.sum()
+    if abs(total - 1.0) > 1e-8:
+        raise ValueError(
+            f"budgets must sum to 1 (within 1e-8), got sum={total!r}."
+        )
+
+    # Silently renormalize away any float rounding within the tolerance.
+    return b / total
+
+
+def RBP(
+    X: NDArray[np.float64],
+    budgets: NDArray[np.float64] | None = None,
+    w0: NDArray[np.float64] | None = None,
+    up_bound: float = 1.,
+    low_bound: float = 0.,
+    cov: Callable[[NDArray[np.float64]], NDArray[np.float64]] | None = None,
+) -> NDArray[np.float64]:
+    r""" Get weights of a Risk Budgeting Portfolio allocation.
+
+    Generalizes :func:`ERC` to arbitrary per-asset risk budgets: instead of
+    equalizing risk contributions, each asset ``i`` is allocated a target
+    share ``b_i`` of total portfolio variance, with :math:`\sum_i b_i = 1`.
+    Passing ``budgets=None`` falls back to the equal-budget case
+    :math:`b_i = 1/N \, \forall i`, which reproduces :func:`ERC`.
+
+    The optimizer (SLSQP) minimizes a smooth least-squares surrogate of the
+    gap between each asset's risk contribution and its target budget, under
+    sum-to-one and box constraints.
+
+    Notes
+    -----
+    Weights of the Risk Budgeting Portfolio, as described by T. Roncalli
+    [6]_, verify the following problem:
+
+    .. math::
+        w = \text{arg min } f(w) \\
+        u.c. \begin{cases}w'e = 1 \\
+                          0 \leq w_i \leq 1 \\
+             \end{cases}
+
+    With:
+
+    .. math::
+        f(w) = \sum_{i=1}^{N} \left( w_i (\Omega w)_i
+        - b_i \, w' \Omega w \right)^2
+
+    Where :math:`\Omega` is the variance-covariance matrix of `X`, :math:`N`
+    the number of assets and :math:`b` the target risk-budget vector (with
+    :math:`\sum_{i=1}^{N} b_i = 1`). With :math:`b_i = 1/N \, \forall i` this
+    objective shares the same minimizers as :func:`ERC`'s (both vanish
+    exactly when every asset's risk contribution matches its budget).
+
+    Parameters
+    ----------
+    X : array_like
+        Each column is a series of price or return's asset.
+    budgets : array_like, optional
+        Target risk budget per asset, length ``N``, strictly positive
+        entries summing to 1 (within ``1e-8``, silently renormalized inside
+        that tolerance). Default `None` spreads the budget equally
+        (:math:`b_i = 1/N`), reproducing :func:`ERC`.
+    w0 : array_like, optional
+        Initial weights for the optimizer.
+    up_bound, low_bound : float, optional
+        Respectively maximum and minimum values of weights, such that low_bound
+        :math:`\leq w_i \leq` up_bound :math:`\forall i`. Default is 0 and 1.
+    cov : callable, optional
+        Callable mapping the ``(T, N)`` training array to an ``(N, N)``
+        covariance matrix, e.g.
+        :func:`fynance.portfolio.covariance.ledoit_wolf`; default `None`
+        keeps the sample covariance.
+
+    Returns
+    -------
+    array_like
+        Weights whose risk contributions match `budgets`.
+
+    Raises
+    ------
+    ValueError
+        If `budgets` does not have length `N`, contains a non-positive
+        entry, or its sum deviates from 1 by more than ``1e-8``.
+
+    References
+    ----------
+    .. [6] T. Roncalli, "Introduction to Risk Parity and Budgeting", 2013,
+           https://arxiv.org/abs/1403.1889
+
+    See Also
+    --------
+    ERC
+    fynance.portfolio.attribution.risk_contribution
+
+    Examples
+    --------
+    Two independent assets with volatilities ``sigma_1=0.01`` and
+    ``sigma_2=0.03``: for a diagonal covariance the risk-budgeting
+    first-order condition reduces to :math:`w_i \sigma_i \propto
+    \sqrt{b_i}`, i.e. :math:`w_i \propto \sqrt{b_i} / \sigma_i`.
+
+    >>> import numpy as np
+    >>> rng = np.random.default_rng(0)
+    >>> sigma1, sigma2 = 0.01, 0.03
+    >>> X = np.column_stack([
+    ...     rng.normal(0.0, sigma1, 2000),
+    ...     rng.normal(0.0, sigma2, 2000),
+    ... ])
+    >>> b = np.array([0.8, 0.2])
+    >>> w = RBP(X, budgets=b)
+    >>> w.shape
+    (2, 1)
+    >>> bool(np.isclose(w.sum(), 1.0))
+    True
+    >>> expected = np.sqrt(b) / np.array([sigma1, sigma2])
+    >>> expected = expected / expected.sum()
+    >>> bool(np.allclose(w.flatten(), expected, atol=1e-2))
+    True
+
+    """
+    T, N = X.shape
+    b = _validate_budgets(budgets, N)
+    SIGMA = _estimate_cov(X, cov)
+    if N == 1:
+        return np.ones([1, 1])
+
+    up_bound = max(up_bound, 1 / N)
+    # Clamp low_bound so the box stays compatible with the sum-to-one
+    # constraint: with low_bound > 1/N every feasible weight already exceeds
+    # its share, the constraint is infeasible and SLSQP would silently return
+    # weights summing to more than one (as HRP/IVP already guard against).
+    low_bound = min(low_bound, 1 / N)
+    # Same scale-safety rationale as ERC: rescale the covariance to unit
+    # trace so the quartic objective is O(1) regardless of the input scale;
+    # this leaves the argmin (the weights) unchanged.
+    scale = np.trace(SIGMA) / N
+    if scale <= 0:
+        return np.ones([N, 1]) / N
+
+    SIGMA = SIGMA / scale
+    b_col = b.reshape([N, 1])
+
+    def f_RBP(w):
+        w = w.reshape([N, 1])
+        sigma_w = SIGMA @ w
+        port_var = w.T @ sigma_w
+
+        return np.sum((w * sigma_w - b_col * port_var) ** 2)
+
+    # Set inital weights
+    if w0 is None:
+        w0 = np.ones([N]) / N
+
+    const_sum = LinearConstraint(np.ones([1, N]), [1], [1])
+    const_ind = Bounds(low_bound * np.ones([N]), up_bound * np.ones([N]))
+    result = minimize(
+        f_RBP,
         w0,
         method='SLSQP',
         constraints=[const_sum],

--- a/fynance/tests/portfolio/test_allocation.py
+++ b/fynance/tests/portfolio/test_allocation.py
@@ -9,12 +9,14 @@ from fynance.portfolio.allocation import (
     IVP,
     MDP,
     MVP,
+    RBP,
     MVP_uc,
     _diversified_ratio_from_cov,
     _normalize,
     _perf_alloc,
     rolling_allocation,
 )
+from fynance.portfolio.attribution import risk_contribution
 from fynance.portfolio.covariance import ledoit_wolf
 
 # ---------------------------------------------------------------------------
@@ -275,6 +277,115 @@ def test_erc_high_low_bound_still_sums_to_one(returns):
     """
     w = ERC(returns, low_bound=0.3).flatten()
     assert abs(w.sum() - 1.0) < 1e-4, f"weights sum to {w.sum():.6f}"
+
+
+# ---------------------------------------------------------------------------
+# RBP
+# ---------------------------------------------------------------------------
+
+def test_rbp_matches_erc_with_equal_budgets():
+    """ budgets=None must reproduce ERC exactly (equal-budget case). """
+    rng = np.random.default_rng(42)
+    X = rng.normal(0.0, 0.01, size=(300, 5))
+    w_rbp = RBP(X)
+    w_erc = ERC(X)
+    np.testing.assert_allclose(w_rbp, w_erc, atol=1e-4)
+
+
+def test_rbp_matches_target_budgets():
+    """ RBP's risk contributions must match an unequal budget vector. """
+    rng = np.random.default_rng(7)
+    X = rng.normal(0.0, 0.01, size=(400, 3))
+    b = np.array([0.5, 0.3, 0.2])
+    w = RBP(X, b).flatten()
+    sigma = np.cov(X, rowvar=False)
+    rc = risk_contribution(w, sigma, pct=True)
+    np.testing.assert_allclose(rc, b, atol=1e-3)
+
+
+def test_rbp_closed_form_diagonal_covariance():
+    """ Two independent assets: w_i must match sqrt(b_i) / sigma_i (closed form).
+
+    For a diagonal covariance the risk-budgeting first-order condition
+    reduces to w_i sigma_i^2 = b_i * (w' Sigma w), i.e. w_i sigma_i is
+    proportional to sqrt(b_i) across assets. `sigma_i` is taken from the
+    (near-diagonal, at this sample size) sample covariance RBP actually
+    optimizes against, not the true generating parameter, to isolate
+    optimizer correctness from sampling noise in the covariance estimate.
+    """
+    rng = np.random.default_rng(1)
+    sigma1, sigma2 = 0.01, 0.03
+    X = np.column_stack([
+        rng.normal(0.0, sigma1, 20000),
+        rng.normal(0.0, sigma2, 20000),
+    ])
+    b = np.array([0.8, 0.2])
+    w = RBP(X, b).flatten()
+    std = np.sqrt(np.diag(np.cov(X, rowvar=False)))
+    expected = np.sqrt(b) / std
+    expected = expected / expected.sum()
+    np.testing.assert_allclose(w, expected, atol=1e-3)
+
+
+def test_rbp_sums_to_one_and_bound_binds():
+    """ Weights sum to 1; a tight up_bound binds and sum-to-one still holds. """
+    rng = np.random.default_rng(7)
+    X = rng.normal(0.0, 0.01, size=(400, 3))
+    b = np.array([0.5, 0.3, 0.2])
+
+    w = RBP(X, b).flatten()
+    assert abs(w.sum() - 1.0) < 1e-8
+
+    w_bounded = RBP(X, b, up_bound=0.4).flatten()
+    assert w_bounded.max() <= 0.4 + 1e-8
+    assert abs(w_bounded.sum() - 1.0) < 1e-8
+
+
+def test_rbp_budgets_validation_errors():
+    """ Wrong length, non-positive entry, and a sum != 1 all raise. """
+    rng = np.random.default_rng(7)
+    X = rng.normal(0.0, 0.01, size=(400, 3))
+
+    with pytest.raises(ValueError):
+        RBP(X, np.array([0.5, 0.5]))  # wrong length
+
+    with pytest.raises(ValueError):
+        RBP(X, np.array([0.5, -0.1, 0.6]))  # non-positive entry
+
+    with pytest.raises(ValueError):
+        RBP(X, np.array([0.5, 0.5, 0.2]))  # sum = 1.2
+
+
+def test_rbp_cov_seam_and_rolling():
+    """ RBP works with a cov= callable and through rolling_allocation. """
+    rng = np.random.default_rng(9)
+    fac = rng.normal(0.0, 1.0, size=(300, 6))
+    vols = np.linspace(0.01, 0.03, 6)
+    returns_ = (0.5 * fac[:, :1] + rng.normal(0.0, 1.0, size=(300, 6))) * vols
+    prices = 100 * np.cumprod(1 + returns_, axis=0)
+    b = np.array([0.30, 0.25, 0.15, 0.10, 0.10, 0.10])
+
+    # cov= seam: runs and loosely matches budgets.
+    w = RBP(returns_, b, cov=ledoit_wolf).flatten()
+    sigma = ledoit_wolf(returns_)
+    rc = risk_contribution(w, sigma, pct=True)
+    np.testing.assert_allclose(rc, b, atol=5e-3)
+
+    # rolling_allocation: budgets forwarded via **kwargs.
+    portfolio, w_mat = rolling_allocation(RBP, prices, n=120, s=30, budgets=b)
+    assert portfolio.shape == (300,)
+    assert w_mat.shape == (300, 6)
+    active = np.flatnonzero(np.abs(w_mat).sum(axis=1) > 1e-9)
+    assert active.size > 0
+    assert np.allclose(w_mat[active].sum(axis=1), 1.0, atol=1e-4)
+
+
+def test_rbp_single_asset():
+    """ N == 1 must not crash and return [[1.]]. """
+    X = RNG.normal(0.0, 0.01, size=(50, 1))
+    w = RBP(X)
+    assert w.shape == (1, 1)
+    np.testing.assert_allclose(w, [[1.0]])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- New `RBP(X, budgets=None, w0=None, up_bound=1., low_bound=0., cov=None)` in `fynance.portfolio.allocation`: weights whose risk contributions match an arbitrary budget vector (Roncalli least-squares objective); `budgets=None` reproduces `ERC`.
- Purely additive to the stable allocation API (ERC untouched); `cov=` seam and `rolling_allocation` forwarding apply.
- Leaf 04/06 of the `portfolio-risk` epic (follows #235–#237).

## Why
ERC hard-codes equal contributions; real mandates specify uneven risk budgets. See ADR entry 2026-07-05 (separate function vs ERC param — stable-API reasoning).

## Verification (synthetic two-block GBM panel, N=6, T=1000, budgets [.30 .25 .15 .10 .10 .10])
- Ex-ante contributions match budgets, max abs error 7.7e-7.
- Through `rolling_allocation` + `roll_risk_contribution`: mean post-warmup contributions [0.2996, 0.2503, 0.1502, 0.1007, 0.0994, 0.0998], max abs error 7.3e-4.

## Changelog
Added under [Unreleased]: risk-budgeting allocation.

## Test plan
- [x] `pytest` — 1082 passed (8 new tests: ERC equivalence 1e-4, budget matching, diagonal closed form, bounds, validation, cov seam + rolling)
- [x] `ruff` / `mypy` / interrogate / Sphinx -W
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)