### PR TITLE
chore: release v2.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [2.12.0] - 2026-07-05
+
+### Added
+
 - **Book-level vol targeting.** `book_vol_target(W, X, ...)` in
   `fynance.portfolio.sizing`: causal `(T,)` leverage series targeting a
   constant volatility for a whole `(T, N)` position book (weights decided at

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fynance"
-version = "2.11.2"
+version = "2.12.0"
 description = "Pure-Python (Numba-accelerated) machine learning, econometrics and statistical tools for financial analysis and backtesting"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## [2.12.0] - 2026-07-05

### Added

- **Book-level vol targeting.** `book_vol_target(W, X, ...)` in
  `fynance.portfolio.sizing`: causal `(T,)` leverage series targeting a
  constant volatility for a whole `(T, N)` position book (weights decided at
  `t-1` earn the return over `(t-1, t]`) — the multi-asset counterpart of
  `vol_target`.
- **Exposure-constraint overlay.** New `fynance.portfolio.constraints`
  module: `project_weights` projects a weight vector or `(T, N)` book onto a
  feasible set — per-asset box, gross-leverage cap, net-exposure range, named
  group bounds — as a least-distance SLSQP projection (split `v = p - m`
  formulation), with a fast clip-and-scale path for box+gross and an
  interval-arithmetic infeasibility pre-check.
- **Risk-budgeting allocation.** New `RBP(X, budgets=None, ...)` allocator
  (generalized ERC, Roncalli least-squares objective): weights whose risk
  contributions match an arbitrary budget vector; `budgets=None` reproduces
  `ERC`, and the `cov=` seam / `rolling_allocation` forwarding apply.
- **Risk attribution.** New `fynance.portfolio.attribution` module:
  `marginal_risk` (∂σₚ/∂w), `risk_contribution` (absolute or percentage,
  summing to σₚ / 1) and the causal `roll_risk_contribution` walking a
  `(T, N)` weight path against a trailing covariance window (accepts the
  same `cov=` estimators as the allocators).
- **Allocator `cov=` seam.** The six allocators (`ERC`/`HRP`/`IVP`/`MVP`/
  `MVP_uc`/`MDP`) accept an opt-in `cov=` callable mapping the `(T, N)`
  training window to an `(N, N)` covariance matrix (e.g.
  `portfolio.covariance.ledoit_wolf`); the default `None` keeps the
  sample-covariance path bit-for-bit, and `rolling_allocation` forwards
  `cov=` through its existing `**kwargs`.
- **Conditioned covariance estimators.** New `fynance.portfolio.covariance`
  module: `sample_cov`, closed-form `ledoit_wolf` shrinkage (identity /
  constant-correlation / diagonal targets), RiskMetrics-style `ewma_cov`
  (Numba kernel), PCA `factor_cov` (low-rank + diagonal, PSD by construction)
  and Marchenko-Pastur `denoise_cov` — interchangeable `(T, N) → (N, N)`
  callables, groundwork for the allocators' opt-in `cov=` seam.

### Changed

### Fixed

### Deprecated

### Removed

## Test plan
- [x] CI green on develop (all 6 feature PRs #235-#240 merged with full gates)
- [ ] CI green on this PR
