### PR TITLE
feat: add pairwise rolling statistics (roll_cov/corr/beta, cross_corr)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Pairwise rolling statistics.** `roll_cov` / `roll_corr` / `roll_beta`
+  (trailing two-series moments on Numba kernels, window inclusive of `t`)
+  and `cross_corr` (lead-lag correlation profile) in
+  `fynance.features.roll_functions`.
+
 ### Changed
 
 ### Fixed

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -72,6 +72,29 @@ Template:
 
 <!-- new entries below, newest first -->
 
+### 2026-07-05 — Cross-sectional factor research epic (PRs #243, epic)  [accepted]
+
+Gives fynance the *input half* of the factor workflow the v2.11 panel harness
+consumes. Six parallel leaves, key choices:
+
+- **Choice**: pairwise rolling kernels (`roll_cov/corr/beta`, `cross_corr`)
+  live in `features.roll_functions` (not metrics) so the future
+  benchmark-relative metrics can reuse them; windows are trailing and include
+  `t` (house convention, matches `roll_min`); cross-sectional operators
+  (`cs_*`) are NaN-aware per bar (panels with dead assets are the norm);
+  AFML labels (`triple_barrier`, `meta_labels`, uniqueness weights) are
+  documented as **training targets that read future prices by design** — to
+  be consumed only through purged splits; MDA importance fits once per fold
+  and permutes the test window only (no per-feature refit); the factor suite
+  splits metrics (`metrics.factor`) from figures (`plot.factor`) to keep
+  `import fynance` matplotlib-free.
+- **Why**: the mapped gap was blunt — everything was single-asset
+  time-series; the panel training stack (`ObjectiveModel`, `RankingLoss`,
+  per-bar IC) had no tooling to build/evaluate the factor panels it consumes.
+- **Rejected alternatives**: depending on alphalens (abandoned upstream,
+  pandas-first); pandas-based implementations (numpy is the lingua franca);
+  putting labels in `data/` (they are feature-layer transforms of prices).
+
 ### 2026-07-05 — Constraint overlay as least-distance projection (PR #239)  [accepted]
 
 - **Choice**: enforce book-level limits (box / gross / net / group) as a

--- a/doc/source/features.roll_functions.rst
+++ b/doc/source/features.roll_functions.rst
@@ -2,7 +2,7 @@
  Rolling Functions 
 *******************
 
-This module contains some tools to compute rolling functions, such as rolling minimum (:func:`~fynance.features.roll_functions.roll_min`) and rolling maximum (:func:`~fynance.features.roll_functions.roll_max`).
+This module contains some tools to compute rolling functions, such as rolling minimum (:func:`~fynance.features.roll_functions.roll_min`) and rolling maximum (:func:`~fynance.features.roll_functions.roll_max`), and pairwise rolling statistics between two series (:func:`~fynance.features.roll_functions.roll_corr`, :func:`~fynance.features.roll_functions.roll_beta`).
 
 .. currentmodule:: fynance.features.roll_functions
 
@@ -14,3 +14,14 @@ Minimum and maximum
 
    roll_min
    roll_max
+
+Pairwise statistics
+===================
+
+.. autosummary::
+   :toctree: generated/
+
+   roll_cov
+   roll_corr
+   roll_beta
+   cross_corr

--- a/fynance/features/roll_functions.py
+++ b/fynance/features/roll_functions.py
@@ -6,17 +6,27 @@
 # @Last modified by: ArthurBernard
 # @Last modified time: 2020-09-18 22:21:22
 
-""" Rolling extremum functions.
+""" Rolling extremum and pairwise statistics.
 
 Rolling minimum and maximum over a lagged window. Used directly as
 features (e.g. price-channel breakouts) and internally by
 :func:`fynance.features.scale.roll_normalize` to compute lookahead-safe
 min-max scaling parameters.
 
+Also provides trailing *pairwise* rolling statistics between two aligned
+1-D series (covariance, Pearson correlation, OLS beta) and a full-sample
+lead-lag cross-correlation profile — e.g. a rolling hedge ratio
+(:func:`roll_beta`) or checking whether one series leads another
+(:func:`cross_corr`).
+
 Main entry points
 -----------------
 - :func:`roll_min` — rolling minimum over a window.
 - :func:`roll_max` — rolling maximum over a window.
+- :func:`roll_cov` — trailing rolling covariance between two series.
+- :func:`roll_corr` — trailing rolling Pearson correlation between two series.
+- :func:`roll_beta` — trailing rolling OLS slope of ``x`` on ``y``.
+- :func:`cross_corr` — full-sample lead-lag cross-correlation profile.
 
 """
 
@@ -32,7 +42,7 @@ from numpy.typing import NDArray
 
 from fynance._wrappers import WrapperArray
 
-__all__ = ["roll_min", "roll_max"]
+__all__ = ["roll_min", "roll_max", "roll_cov", "roll_corr", "roll_beta", "cross_corr"]
 
 
 @njit(cache=True)
@@ -234,3 +244,432 @@ def _roll_max(X, w):
         return _roll_max_2d(X, w)
 
     return _roll_max_1d(X, w)
+
+
+# =========================================================================== #
+#                          Pairwise rolling statistics                        #
+# =========================================================================== #
+
+
+def _validate_pair(x: NDArray, y: NDArray) -> tuple[NDArray, NDArray]:
+    """ Cast ``x``/``y`` to contiguous float64 1-D arrays and validate them. """
+    x = np.ascontiguousarray(np.asarray(x, dtype=np.float64))
+    y = np.ascontiguousarray(np.asarray(y, dtype=np.float64))
+
+    if x.ndim != 1 or y.ndim != 1:
+
+        raise ValueError(
+            f"x and y must be 1-D, got ndim={x.ndim} and ndim={y.ndim}"
+        )
+
+    if x.shape[0] != y.shape[0]:
+
+        raise ValueError(
+            f"x and y must have the same length, got {x.shape[0]} and "
+            f"{y.shape[0]}"
+        )
+
+    if np.isnan(x).any() or np.isnan(y).any():
+
+        raise ValueError("x and y must not contain NaN")
+
+    return x, y
+
+
+def _validate_window(w: int) -> int:
+    """ Validate the trailing window size ``w`` (must be an int >= 2). """
+    if not isinstance(w, (int, np.integer)) or w < 2:
+
+        raise ValueError(f"w must be an integer >= 2, got {w!r}")
+
+    return int(w)
+
+
+@njit(cache=True)
+def _roll_cov_1d(x, y, w):
+    """ Trailing rolling covariance (ddof=0) of two aligned 1-D series. """
+    T = x.shape[0]
+    out = np.empty(T, dtype=np.float64)
+    for t in range(T):
+        if t < w - 1:
+            out[t] = np.nan
+            continue
+
+        start = t - w + 1
+        sx = 0.0
+        sy = 0.0
+        for i in range(start, t + 1):
+            sx += x[i]
+            sy += y[i]
+        mx = sx / w
+        my = sy / w
+
+        sxy = 0.0
+        for i in range(start, t + 1):
+            sxy += (x[i] - mx) * (y[i] - my)
+        out[t] = sxy / w
+
+    return out
+
+
+@njit(cache=True)
+def _roll_corr_1d(x, y, w):
+    """ Trailing rolling Pearson correlation (ddof cancels) of two series. """
+    T = x.shape[0]
+    out = np.empty(T, dtype=np.float64)
+    for t in range(T):
+        if t < w - 1:
+            out[t] = np.nan
+            continue
+
+        start = t - w + 1
+        sx = 0.0
+        sy = 0.0
+        for i in range(start, t + 1):
+            sx += x[i]
+            sy += y[i]
+        mx = sx / w
+        my = sy / w
+
+        sxy = 0.0
+        sxx = 0.0
+        syy = 0.0
+        for i in range(start, t + 1):
+            dx = x[i] - mx
+            dy = y[i] - my
+            sxy += dx * dy
+            sxx += dx * dx
+            syy += dy * dy
+
+        denom = np.sqrt(sxx * syy)
+        if denom == 0.0:
+            out[t] = np.nan
+        else:
+            out[t] = sxy / denom
+
+    return out
+
+
+@njit(cache=True)
+def _roll_beta_1d(x, y, w):
+    """ Trailing rolling OLS slope of ``x`` on ``y`` (ddof cancels). """
+    T = x.shape[0]
+    out = np.empty(T, dtype=np.float64)
+    for t in range(T):
+        if t < w - 1:
+            out[t] = np.nan
+            continue
+
+        start = t - w + 1
+        sx = 0.0
+        sy = 0.0
+        for i in range(start, t + 1):
+            sx += x[i]
+            sy += y[i]
+        mx = sx / w
+        my = sy / w
+
+        sxy = 0.0
+        syy = 0.0
+        for i in range(start, t + 1):
+            dx = x[i] - mx
+            dy = y[i] - my
+            sxy += dx * dy
+            syy += dy * dy
+
+        if syy == 0.0:
+            out[t] = np.nan
+        else:
+            out[t] = sxy / syy
+
+    return out
+
+
+@njit(cache=True)
+def _cross_corr_1d(x, y, max_lag):
+    """ Full-sample corr(x[t], y[t - lag]) for lag in [-max_lag, max_lag]. """
+    T = x.shape[0]
+    n_lags = 2 * max_lag + 1
+    out = np.empty(n_lags, dtype=np.float64)
+
+    for idx in range(n_lags):
+        lag = idx - max_lag
+
+        if lag >= 0:
+            n = T - lag
+            sx = 0.0
+            sy = 0.0
+            for i in range(n):
+                sx += x[lag + i]
+                sy += y[i]
+            mx = sx / n
+            my = sy / n
+
+            sxy = 0.0
+            sxx = 0.0
+            syy = 0.0
+            for i in range(n):
+                dx = x[lag + i] - mx
+                dy = y[i] - my
+                sxy += dx * dy
+                sxx += dx * dx
+                syy += dy * dy
+        else:
+            k = -lag
+            n = T - k
+            sx = 0.0
+            sy = 0.0
+            for i in range(n):
+                sx += x[i]
+                sy += y[k + i]
+            mx = sx / n
+            my = sy / n
+
+            sxy = 0.0
+            sxx = 0.0
+            syy = 0.0
+            for i in range(n):
+                dx = x[i] - mx
+                dy = y[k + i] - my
+                sxy += dx * dy
+                sxx += dx * dx
+                syy += dy * dy
+
+        denom = np.sqrt(sxx * syy)
+        if denom == 0.0:
+            out[idx] = np.nan
+        else:
+            out[idx] = sxy / denom
+
+    return out
+
+
+def roll_cov(x: NDArray, y: NDArray, w: int = 63) -> NDArray:
+    r""" Trailing rolling covariance between two aligned 1-D series.
+
+    .. math::
+
+        roll\_cov^w_t(x, y) = \frac{1}{w} \sum_{i=t-w+1}^{t}
+            (x_i - \bar{x}_t)(y_i - \bar{y}_t)
+
+    where :math:`\bar{x}_t` and :math:`\bar{y}_t` are the means of ``x`` and
+    ``y`` over the trailing window :math:`[t - w + 1, t]` (inclusive of
+    ``t``, the "house" trailing-window convention shared with
+    :func:`roll_min`/:func:`roll_max`). The variance used is the *biased*
+    (``ddof=0``) estimator.
+
+    Parameters
+    ----------
+    x : np.ndarray[float64, ndim=1]
+        First series. Cast to ``float64`` if needed; must not contain NaN.
+    y : np.ndarray[float64, ndim=1]
+        Second series, same length as ``x``. Cast to ``float64`` if needed;
+        must not contain NaN.
+    w : int, optional
+        Size of the trailing window, must be an integer >= 2. Default is 63.
+
+    Returns
+    -------
+    np.ndarray[float64, ndim=1]
+        Trailing rolling covariance. The first ``w - 1`` entries are
+        ``np.nan`` (insufficient history).
+
+    Examples
+    --------
+    >>> x = np.array([1., 2., 3., 4., 5., 6.])
+    >>> y = 2 * x
+    >>> roll_cov(x, y, w=2)
+    array([nan, 0.5, 0.5, 0.5, 0.5, 0.5])
+
+    See Also
+    --------
+    roll_corr, roll_beta
+
+    """
+    x, y = _validate_pair(x, y)
+    w = _validate_window(w)
+
+    return _roll_cov_1d(x, y, w)
+
+
+def roll_corr(x: NDArray, y: NDArray, w: int = 63) -> NDArray:
+    r""" Trailing rolling Pearson correlation between two aligned 1-D series.
+
+    .. math::
+
+        roll\_corr^w_t(x, y) = \frac{
+            \sum_{i=t-w+1}^{t} (x_i - \bar{x}_t)(y_i - \bar{y}_t)
+        }{
+            \sqrt{\sum_{i=t-w+1}^{t} (x_i - \bar{x}_t)^2}
+            \sqrt{\sum_{i=t-w+1}^{t} (y_i - \bar{y}_t)^2}
+        }
+
+    over the trailing window :math:`[t - w + 1, t]` (inclusive of ``t``, see
+    :func:`roll_cov`). The ``1/w`` normalization of the covariance and the two
+    variances cancels out, so the result does not depend on ``ddof``.
+
+    Parameters
+    ----------
+    x : np.ndarray[float64, ndim=1]
+        First series. Cast to ``float64`` if needed; must not contain NaN.
+    y : np.ndarray[float64, ndim=1]
+        Second series, same length as ``x``. Cast to ``float64`` if needed;
+        must not contain NaN.
+    w : int, optional
+        Size of the trailing window, must be an integer >= 2. Default is 63.
+
+    Returns
+    -------
+    np.ndarray[float64, ndim=1]
+        Trailing rolling correlation, in ``[-1, 1]``. The first ``w - 1``
+        entries are ``np.nan`` (insufficient history). If either series has
+        zero variance within a window, that entry is ``np.nan`` (checked
+        explicitly before dividing — no ``RuntimeWarning`` is raised).
+
+    Examples
+    --------
+    >>> x = np.array([1., 2., 3., 4., 5.])
+    >>> y = 2 * x
+    >>> roll_corr(x, y, w=3)
+    array([nan, nan,  1.,  1.,  1.])
+
+    See Also
+    --------
+    roll_cov, roll_beta
+
+    """
+    x, y = _validate_pair(x, y)
+    w = _validate_window(w)
+
+    return _roll_corr_1d(x, y, w)
+
+
+def roll_beta(x: NDArray, y: NDArray, w: int = 63) -> NDArray:
+    r""" Trailing rolling OLS slope of ``x`` regressed on ``y``.
+
+    .. math::
+
+        roll\_beta^w_t(x, y) = \frac{roll\_cov^w_t(x, y)}{roll\_var^w_t(y)}
+
+    i.e. the slope of the univariate OLS regression of ``x`` on ``y`` over
+    the trailing window :math:`[t - w + 1, t]` (inclusive of ``t``, see
+    :func:`roll_cov`). Typical use is a rolling hedge ratio: how many units
+    of ``y`` are needed to hedge one unit of ``x``. As with :func:`roll_corr`,
+    the ``1/w`` normalization cancels, so the result does not depend on
+    ``ddof``.
+
+    Parameters
+    ----------
+    x : np.ndarray[float64, ndim=1]
+        Dependent series. Cast to ``float64`` if needed; must not contain
+        NaN.
+    y : np.ndarray[float64, ndim=1]
+        Independent (regressor) series, same length as ``x``. Cast to
+        ``float64`` if needed; must not contain NaN.
+    w : int, optional
+        Size of the trailing window, must be an integer >= 2. Default is 63.
+
+    Returns
+    -------
+    np.ndarray[float64, ndim=1]
+        Trailing rolling OLS slope. The first ``w - 1`` entries are
+        ``np.nan`` (insufficient history). If ``y`` has zero variance within
+        a window, that entry is ``np.nan`` (checked explicitly before
+        dividing — no ``RuntimeWarning`` is raised).
+
+    Examples
+    --------
+    ``y = 2 * x`` has a constant beta of 0.5 (``cov(x, y) / var(y) =
+    2 var(x) / 4 var(x)``), regardless of the window content:
+
+    >>> x = np.array([1., 2., 3., 4., 5.])
+    >>> y = 2 * x
+    >>> roll_beta(x, y, w=3)
+    array([nan, nan, 0.5, 0.5, 0.5])
+
+    See Also
+    --------
+    roll_cov, roll_corr
+
+    """
+    x, y = _validate_pair(x, y)
+    w = _validate_window(w)
+
+    return _roll_beta_1d(x, y, w)
+
+
+def cross_corr(x: NDArray, y: NDArray, max_lag: int = 20) -> NDArray:
+    r""" Full-sample lead-lag cross-correlation profile of two series.
+
+    .. math::
+
+        cross\_corr_{lag}(x, y) = corr(x_t, y_{t - lag}),
+        \quad lag \in \{-max\_lag, \dots, max\_lag\}
+
+    where the correlation is computed over the full overlapping sample (all
+    valid ``t``, i.e. ``T - |lag|`` pairs), *not* a trailing window.
+
+    **Lag convention.** Entry ``lag`` correlates ``x[t]`` with ``y[t - lag]``.
+    A positive ``lag`` therefore pairs ``x`` at time ``t`` with ``y`` *earlier*
+    in the series (at ``t - lag``): if that pairing is where the correlation
+    peaks, ``y``'s past values line up with ``x``'s current values, i.e.
+    ``y`` **leads** ``x`` by ``lag`` bars. Conversely a negative ``lag`` that
+    maximizes the correlation means ``y`` **lags** ``x`` (``x`` leads ``y``)
+    by ``|lag|`` bars. For example, if ``y[t] = x[t - 3]`` (``y`` is ``x``
+    delayed by 3 bars, so ``x`` leads ``y`` by 3), the profile peaks at
+    ``lag = -3``, since ``y[t - (-3)] = y[t + 3] = x[t]``.
+
+    Parameters
+    ----------
+    x : np.ndarray[float64, ndim=1]
+        First series. Cast to ``float64`` if needed; must not contain NaN.
+    y : np.ndarray[float64, ndim=1]
+        Second series, same length as ``x``. Cast to ``float64`` if needed;
+        must not contain NaN.
+    max_lag : int, optional
+        Maximum absolute lag to scan, must be a non-negative integer and
+        strictly less than ``len(x)``. Default is 20.
+
+    Returns
+    -------
+    np.ndarray[float64, ndim=1]
+        Cross-correlation profile of length ``2 * max_lag + 1``, ordered from
+        ``lag=-max_lag`` to ``lag=max_lag``. Entries where either side has
+        zero variance over the overlap are ``np.nan`` (checked explicitly
+        before dividing — no ``RuntimeWarning`` is raised).
+
+    Examples
+    --------
+    ``y`` is ``x`` delayed by 3 bars (``x`` leads ``y`` by 3): the profile
+    peaks at ``lag = -3``.
+
+    >>> rng = np.random.default_rng(0)
+    >>> x = rng.normal(size=200)
+    >>> y = np.roll(x, 3)
+    >>> y[:3] = rng.normal(size=3)  # avoid a spurious wrap-around match
+    >>> profile = cross_corr(x, y, max_lag=5)
+    >>> profile.shape
+    (11,)
+    >>> int(np.arange(-5, 6)[np.argmax(profile)])
+    -3
+
+    See Also
+    --------
+    roll_corr
+
+    """
+    x, y = _validate_pair(x, y)
+
+    if not isinstance(max_lag, (int, np.integer)) or max_lag < 0:
+
+        raise ValueError(
+            f"max_lag must be a non-negative integer, got {max_lag!r}"
+        )
+
+    if max_lag >= x.shape[0]:
+
+        raise ValueError(
+            f"max_lag={max_lag} must be strictly less than len(x)={x.shape[0]}"
+        )
+
+    return _cross_corr_1d(x, y, int(max_lag))

--- a/fynance/tests/features/test_roll_functions.py
+++ b/fynance/tests/features/test_roll_functions.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Test pairwise rolling statistics (roll_cov/roll_corr/roll_beta/cross_corr). """
+
+# Third-party packages
+import numpy as np
+import pytest
+
+# Local packages
+import fynance as fy
+from fynance.features.roll_functions import cross_corr, roll_beta, roll_corr, roll_cov
+
+# --------------------------------------------------------------------------- #
+#                    Slow, independent pure-Python reference                  #
+# --------------------------------------------------------------------------- #
+
+
+def _ref_roll_cov(x, y, w):
+    T = x.shape[0]
+    out = np.full(T, np.nan)
+    for t in range(w - 1, T):
+        xw = x[t - w + 1: t + 1]
+        yw = y[t - w + 1: t + 1]
+        mx = sum(xw) / w
+        my = sum(yw) / w
+        s = sum((xi - mx) * (yi - my) for xi, yi in zip(xw, yw))
+        out[t] = s / w
+    return out
+
+
+def _ref_roll_corr(x, y, w):
+    T = x.shape[0]
+    out = np.full(T, np.nan)
+    for t in range(w - 1, T):
+        xw = x[t - w + 1: t + 1]
+        yw = y[t - w + 1: t + 1]
+        mx = sum(xw) / w
+        my = sum(yw) / w
+        sxy = sum((xi - mx) * (yi - my) for xi, yi in zip(xw, yw))
+        sxx = sum((xi - mx) ** 2 for xi in xw)
+        syy = sum((yi - my) ** 2 for yi in yw)
+        denom = (sxx * syy) ** 0.5
+        out[t] = np.nan if denom == 0. else sxy / denom
+    return out
+
+
+def _ref_roll_beta(x, y, w):
+    T = x.shape[0]
+    out = np.full(T, np.nan)
+    for t in range(w - 1, T):
+        xw = x[t - w + 1: t + 1]
+        yw = y[t - w + 1: t + 1]
+        mx = sum(xw) / w
+        my = sum(yw) / w
+        sxy = sum((xi - mx) * (yi - my) for xi, yi in zip(xw, yw))
+        syy = sum((yi - my) ** 2 for yi in yw)
+        out[t] = np.nan if syy == 0. else sxy / syy
+    return out
+
+
+def _ref_cross_corr(x, y, max_lag):
+    T = x.shape[0]
+    out = np.full(2 * max_lag + 1, np.nan)
+    for idx, lag in enumerate(range(-max_lag, max_lag + 1)):
+        # corr(x[t], y[t - lag]) over all valid t.
+        if lag >= 0:
+            xw = x[lag:]
+            yw = y[: T - lag]
+        else:
+            k = -lag
+            xw = x[: T - k]
+            yw = y[k:]
+        n = len(xw)
+        mx = sum(xw) / n
+        my = sum(yw) / n
+        sxy = sum((xi - mx) * (yi - my) for xi, yi in zip(xw, yw))
+        sxx = sum((xi - mx) ** 2 for xi in xw)
+        syy = sum((yi - my) ** 2 for yi in yw)
+        denom = (sxx * syy) ** 0.5
+        out[idx] = np.nan if denom == 0. else sxy / denom
+    return out
+
+
+@pytest.fixture()
+def series_pair():
+    rng = np.random.default_rng(123)
+    x = rng.normal(size=500)
+    y = 0.4 * x + rng.normal(scale=1.3, size=500)
+    return x, y
+
+
+# --------------------------------------------------------------------------- #
+#                              Reference parity                               #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize('w', [2, 5, 20, 63])
+def test_roll_cov_matches_reference(series_pair, w):
+    x, y = series_pair
+    out = roll_cov(x, y, w=w)
+    expected = _ref_roll_cov(x, y, w)
+    np.testing.assert_allclose(out, expected, rtol=1e-12, equal_nan=True)
+
+
+@pytest.mark.parametrize('w', [2, 5, 20, 63])
+def test_roll_corr_matches_reference(series_pair, w):
+    x, y = series_pair
+    out = roll_corr(x, y, w=w)
+    expected = _ref_roll_corr(x, y, w)
+    np.testing.assert_allclose(out, expected, rtol=1e-12, equal_nan=True)
+
+
+@pytest.mark.parametrize('w', [2, 5, 20, 63])
+def test_roll_beta_matches_reference(series_pair, w):
+    x, y = series_pair
+    out = roll_beta(x, y, w=w)
+    expected = _ref_roll_beta(x, y, w)
+    np.testing.assert_allclose(out, expected, rtol=1e-12, equal_nan=True)
+
+
+def test_cross_corr_matches_reference(series_pair):
+    x, y = series_pair
+    max_lag = 15
+    out = cross_corr(x, y, max_lag=max_lag)
+    expected = _ref_cross_corr(x, y, max_lag)
+    np.testing.assert_allclose(out, expected, rtol=1e-12, equal_nan=True)
+
+
+# --------------------------------------------------------------------------- #
+#                                Known values                                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_roll_corr_of_y_equal_2x_is_one():
+    rng = np.random.default_rng(1)
+    x = rng.normal(size=100)
+    y = 2. * x
+    out = roll_corr(x, y, w=10)
+    assert np.all(np.isnan(out[:9]))
+    assert out[9:] == pytest.approx(1.0)
+
+
+def test_roll_beta_of_y_equal_2x_is_half():
+    # roll_beta(x, y) = cov(x, y) / var(y); for y = 2x, cov(x, y) = 2 var(x)
+    # and var(y) = 4 var(x), so beta = 2 var(x) / (4 var(x)) = 0.5.
+    rng = np.random.default_rng(2)
+    x = rng.normal(size=100)
+    y = 2. * x
+    out = roll_beta(x, y, w=10)
+    assert np.all(np.isnan(out[:9]))
+    assert out[9:] == pytest.approx(0.5)
+
+
+# --------------------------------------------------------------------------- #
+#                                  Causality                                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_roll_cov_corr_beta_are_causal():
+    rng = np.random.default_rng(3)
+    x = rng.normal(size=200)
+    y = rng.normal(size=200)
+    w = 20
+    t0 = 100
+
+    base_cov, base_corr, base_beta = roll_cov(x, y, w), roll_corr(x, y, w), roll_beta(x, y, w)
+
+    x2 = x.copy()
+    y2 = y.copy()
+    x2[t0:] += rng.normal(size=200 - t0)
+    y2[t0:] += rng.normal(size=200 - t0)
+
+    new_cov, new_corr, new_beta = roll_cov(x2, y2, w), roll_corr(x2, y2, w), roll_beta(x2, y2, w)
+
+    # Everything strictly before t0 is untouched by a perturbation at/after t0.
+    np.testing.assert_array_equal(base_cov[:t0], new_cov[:t0])
+    np.testing.assert_array_equal(base_corr[:t0], new_corr[:t0])
+    np.testing.assert_array_equal(base_beta[:t0], new_beta[:t0])
+    # Sanity: the perturbation does actually change later outputs.
+    assert not np.allclose(base_cov[t0:], new_cov[t0:], equal_nan=True)
+
+
+# --------------------------------------------------------------------------- #
+#                          NaN head / zero variance                           #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize('w', [2, 7, 30])
+def test_nan_head_length_is_w_minus_1(series_pair, w):
+    x, y = series_pair
+    for out in (roll_cov(x, y, w=w), roll_corr(x, y, w=w), roll_beta(x, y, w=w)):
+        assert np.all(np.isnan(out[: w - 1]))
+        assert np.all(np.isfinite(out[w - 1:]))
+
+
+def test_zero_variance_stretch_gives_nan_no_warnings(recwarn):
+    # roll_corr is symmetric in x/y: zero variance in *either* side gives NaN.
+    x_flat = np.concatenate([np.full(20, 3.0), np.random.default_rng(4).normal(size=20)])
+    y = np.random.default_rng(5).normal(size=40)
+    w = 10
+    corr = roll_corr(x_flat, y, w=w)
+    assert np.all(np.isnan(corr[w - 1:20]))
+
+    # roll_beta = cov(x, y) / var(y): only zero variance in the *denominator*
+    # (y) forces NaN — zero variance in x alone gives beta = 0 (cov = 0), not
+    # NaN, since var(y) != 0 there.
+    beta_x_flat = roll_beta(x_flat, y, w=w)
+    assert np.all(np.isfinite(beta_x_flat[w - 1:20]))
+    assert beta_x_flat[w - 1:20] == pytest.approx(0.0)
+
+    y_flat = np.concatenate([np.full(20, -1.0), np.random.default_rng(6).normal(size=20)])
+    x = np.random.default_rng(7).normal(size=40)
+    beta_y_flat = roll_beta(x, y_flat, w=w)
+    assert np.all(np.isnan(beta_y_flat[w - 1:20]))
+
+    assert len(recwarn) == 0
+
+
+# --------------------------------------------------------------------------- #
+#                                  cross_corr                                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_cross_corr_argmax_matches_documented_lag_convention():
+    # y[t] = x[t - 3] + tiny noise: x leads y by 3 bars. Per the documented
+    # convention (entry `lag` correlates x[t] with y[t - lag]), the profile
+    # must peak at lag = -3, since y[t - (-3)] = y[t + 3] = x[t].
+    rng = np.random.default_rng(6)
+    x = rng.normal(size=1000)
+    noise = rng.normal(scale=1e-6, size=1000)
+    y = np.empty(1000)
+    y[:3] = rng.normal(size=3)
+    y[3:] = x[:-3] + noise[3:]
+
+    max_lag = 10
+    profile = cross_corr(x, y, max_lag=max_lag)
+    lags = np.arange(-max_lag, max_lag + 1)
+    assert lags[np.argmax(profile)] == -3
+
+
+def test_cross_corr_shape_and_symmetry_indexing():
+    rng = np.random.default_rng(7)
+    x = rng.normal(size=300)
+    y = rng.normal(size=300)
+    max_lag = 8
+    profile = cross_corr(x, y, max_lag=max_lag)
+    assert profile.shape == (2 * max_lag + 1,)
+    # lag=0 is corr(x, y) computed over the full overlap (all T points).
+    expected_lag0 = np.corrcoef(x, y)[0, 1]
+    assert profile[max_lag] == pytest.approx(expected_lag0)
+
+
+# --------------------------------------------------------------------------- #
+#                                   Errors                                    #
+# --------------------------------------------------------------------------- #
+
+
+def test_length_mismatch_raises():
+    x = np.array([1., 2., 3.])
+    y = np.array([1., 2.])
+    with pytest.raises(ValueError):
+        roll_cov(x, y, w=2)
+    with pytest.raises(ValueError):
+        roll_corr(x, y, w=2)
+    with pytest.raises(ValueError):
+        roll_beta(x, y, w=2)
+    with pytest.raises(ValueError):
+        cross_corr(x, y, max_lag=1)
+
+
+def test_window_below_two_raises():
+    x = np.array([1., 2., 3., 4.])
+    y = np.array([4., 3., 2., 1.])
+    with pytest.raises(ValueError):
+        roll_cov(x, y, w=1)
+    with pytest.raises(ValueError):
+        roll_corr(x, y, w=1)
+    with pytest.raises(ValueError):
+        roll_beta(x, y, w=1)
+
+
+def test_max_lag_out_of_bounds_raises():
+    x = np.arange(5.)
+    y = np.arange(5.)
+    with pytest.raises(ValueError):
+        cross_corr(x, y, max_lag=5)
+    with pytest.raises(ValueError):
+        cross_corr(x, y, max_lag=6)
+
+
+def test_nan_input_raises():
+    x = np.array([1., np.nan, 3.])
+    y = np.array([1., 2., 3.])
+    with pytest.raises(ValueError):
+        roll_cov(x, y, w=2)
+    with pytest.raises(ValueError):
+        cross_corr(x, y, max_lag=1)
+
+
+def test_exposed_on_top_level_package():
+    assert fy.roll_cov is roll_cov
+    assert fy.roll_corr is roll_corr
+    assert fy.roll_beta is roll_beta
+    assert fy.cross_corr is cross_corr


### PR DESCRIPTION
## Summary
- `roll_cov` / `roll_corr` / `roll_beta`: trailing two-series moments over `[t-w+1, t]` (inclusive of `t`, matching `roll_min`'s convention) on Numba kernels; NaN head, NaN on zero-variance windows, no warnings.
- `cross_corr(x, y, max_lag)`: full-sample lead-lag correlation profile, entry `lag` = `corr(x[t], y[t-lag])` (convention documented with a worked example).
- Doc page `features.roll_functions.rst` gains a Pairwise-statistics autosummary section.
- Leaf 02/06 of the `factor-research` epic (executed in parallel worktrees); kernels are the reuse target for the upcoming benchmark-relative metrics.

## Verification (synthetic)
True-corr-0.7 pair (T=2000): `roll_corr(w=252)` post-warmup mean 0.6949 (σ 0.030). `y[t]=x[t-5]`: `cross_corr` peaks at lag −5 (0.99999997), consistent with the documented convention.

## Changelog
Added under [Unreleased]: pairwise rolling statistics. New epic ADR entry (factor-research).

## Test plan
- [x] `pytest` — 1134 passed (reference-loop parity rtol 1e-12, causality, NaN/degenerate windows, lag-convention tests)
- [x] `ruff` / `mypy` / interrogate / Sphinx -W
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)