### PR TITLE
feat: add fixed-width fractional differentiation (fracdiff)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Fractional differentiation.** `fracdiff(X, d, tol)` in
+  `fynance.features.engineering`: fixed-width-window fractional
+  differentiation (AFML ch. 5) on a Numba kernel — stationarize while
+  keeping maximal memory; strictly causal, NaN warm-up head.
 - **Cross-sectional operators.** New `fynance.features.cross_section`
   module: NaN-aware per-bar panel transforms `cs_rank` (average-tie
   percentile ranks), `cs_zscore`, `cs_demean` (optionally weighted),

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -72,7 +72,7 @@ Template:
 
 <!-- new entries below, newest first -->
 
-### 2026-07-05 — Cross-sectional factor research epic (PRs #243–#244, epic)  [accepted]
+### 2026-07-05 — Cross-sectional factor research epic (PRs #243–#245, epic)  [accepted]
 
 Gives fynance the *input half* of the factor workflow the v2.11 panel harness
 consumes. Six parallel leaves, key choices:

--- a/fynance/features/engineering.py
+++ b/fynance/features/engineering.py
@@ -3,8 +3,10 @@
 
 """ Feature-engineering & selection research tools.
 
-Multi-resolution feature stacking, incremental (O(1)) moment updates, and a
-Granger-causality test for filtering candidate features.
+Multi-resolution feature stacking, incremental (O(1)) moment updates, a
+Granger-causality test for filtering candidate features, and fixed-width
+fractional differentiation (:func:`fracdiff`) for stationarizing a series
+while preserving memory.
 """
 
 from __future__ import annotations
@@ -15,6 +17,7 @@ from typing import Any, Callable
 
 # Third-party packages
 import numpy as np
+from numba import njit
 from numpy.typing import NDArray
 from scipy import stats as _sp_stats
 
@@ -23,7 +26,7 @@ from fynance.features.indicators import realized_volatility
 
 __all__ = [
     'IncrementalMoments', 'adaptive_roll', 'adaptive_volatility',
-    'granger_causality', 'multi_resolution',
+    'fracdiff', 'granger_causality', 'multi_resolution',
 ]
 
 
@@ -277,3 +280,175 @@ def adaptive_volatility(
     return adaptive_roll(
         X, realized_volatility, windows, regimes, period=period,
     )
+
+
+def _fracdiff_weights(d: float, tol: float) -> NDArray:
+    """ Fixed-width weights of the fractional-differentiation operator.
+
+    Generates ``w_0, w_1, ..., w_{K-1}`` from the binomial-series recursion
+    ``w_0 = 1``, ``w_k = -w_{k-1} * (d - k + 1) / k``, stopping (and
+    discarding) the first weight whose magnitude drops below ``tol`` — this
+    is the fixed-width-window truncation of Lopez de Prado (2018), ch. 5.
+    At least ``w_0`` is always kept.
+
+    Parameters
+    ----------
+    d : float
+        Order of differentiation.
+    tol : float
+        Weight-magnitude cutoff below which the (infinite, in general) series
+        of weights is truncated.
+
+    Returns
+    -------
+    np.ndarray
+        Weights ``[w_0, ..., w_{K-1}]``, shape ``(K,)``.
+
+    """
+    weights = [1.0]
+    k = 1
+    while True:
+        w_k = -weights[-1] * (d - k + 1) / k
+        if abs(w_k) < tol:
+            break
+        weights.append(w_k)
+        k += 1
+
+    return np.asarray(weights, dtype=np.float64)
+
+
+@njit(cache=True)
+def _fracdiff_kernel(X, w):
+    T = X.shape[0]
+    K = w.shape[0]
+    out = np.empty(T, dtype=np.float64)
+    for t in range(T):
+        if t < K - 1:
+            out[t] = np.nan
+        else:
+            s = 0.0
+            for k in range(K):
+                s += w[k] * X[t - k]
+            out[t] = s
+
+    return out
+
+
+def fracdiff(X: NDArray, d: float = 0.4, tol: float = 1e-5) -> NDArray:
+    r""" Fixed-width-window fractional differentiation of a price series.
+
+    Stationarizes a (typically non-stationary, e.g. price or log-price)
+    series while retaining as much memory as possible, unlike integer
+    differencing (``d=1``) which is stationary but wipes out most of the
+    long-run dependence. Applies the fractional difference operator
+    :math:`(1-L)^d` — where :math:`L` is the lag operator — truncated to a
+    fixed-width window, so that it is usable causally (online) rather than
+    needing the full history at every step as the "expanding window"
+    variant does.
+
+    The weights follow the binomial-series recursion
+
+    .. math::
+
+        w_0 = 1, \qquad w_k = -w_{k-1} \frac{d - k + 1}{k},
+
+    truncated to the first :math:`K` terms such that :math:`|w_K| < tol`
+    (:math:`K` is fixed for the whole series — "fixed-width window"). The
+    output is the causal convolution
+
+    .. math::
+
+        y_t = \sum_{k=0}^{K-1} w_k X_{t-k}, \qquad t \ge K - 1,
+
+    with the first :math:`K - 1` entries set to NaN (insufficient history).
+    Only past and current values of ``X`` are used, so :func:`fracdiff` is
+    strictly causal and safe to use in a walk-forward / online setting.
+
+    Parameters
+    ----------
+    X : np.ndarray[float64, ndim=1 or 2]
+        Input series (e.g. price level). If two-dimensional, shape
+        ``(T, N)``, each column is treated independently. Must be finite
+        (no NaN / inf).
+    d : float, optional
+        Order of differentiation, must lie in ``[0, 2]``. ``d=0`` leaves the
+        series unchanged (post-warmup); ``d=1`` reduces, with the default
+        `tol`, to the ordinary first difference; non-integer ``d`` in
+        between trades off memory (small ``d``) against stationarity (large
+        ``d``). Default is 0.4.
+    tol : float, optional
+        Weight-magnitude cutoff used to fix the window width :math:`K` (see
+        :func:`_fracdiff_weights`). Smaller `tol` keeps more weights (longer
+        memory, larger warmup) at the cost of more computation. Default is
+        1e-5.
+
+    Returns
+    -------
+    np.ndarray[float64, ndim=1 or 2]
+        Fractionally differentiated series, same shape as `X`. The first
+        ``K - 1`` rows are NaN. If ``X`` has fewer than ``K`` observations,
+        the output is entirely NaN.
+
+    Raises
+    ------
+    ValueError
+        If `d` is not in ``[0, 2]``, if `X` contains non-finite values, or if
+        `X` is not 1-D or 2-D.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> X = np.array([1.0, 2.0, 4.0, 7.0, 11.0])
+    >>> fracdiff(X, d=1.0)
+    array([nan,  1.,  2.,  3.,  4.])
+    >>> np.array_equal(fracdiff(X, d=1.0)[1:], np.diff(X))
+    True
+    >>> fracdiff(X, d=0.0)
+    array([ 1.,  2.,  4.,  7., 11.])
+
+    Notes
+    -----
+    There is an inherent memory-vs-stationarity trade-off (Lopez de Prado,
+    2018, ch. 5): larger ``d`` differentiates more aggressively, making the
+    series more likely to be stationary (e.g. pass an ADF test) but erasing
+    more of the long-run memory that predictive models rely on; smaller
+    ``d`` preserves memory but may leave the series non-stationary. The
+    common recipe is to search for the minimal ``d`` for which the
+    fractionally differentiated series is stationary.
+
+    References
+    ----------
+    M. Lopez de Prado, "Advances in Financial Machine Learning", Wiley,
+    2018, ch. 5.
+
+    See Also
+    --------
+    multi_resolution, adaptive_roll
+
+    """
+    if not (0 <= d <= 2):
+
+        raise ValueError(f"d must be in [0, 2], got {d}")
+
+    x = np.asarray(X, dtype=np.float64)
+
+    if not np.all(np.isfinite(x)):
+
+        raise ValueError("X must contain only finite values (no NaN/inf)")
+
+    w = _fracdiff_weights(d, tol)
+
+    if x.ndim == 1:
+
+        return _fracdiff_kernel(x, w)
+
+    elif x.ndim == 2:
+
+        cols = [_fracdiff_kernel(np.ascontiguousarray(x[:, j]), w)
+                for j in range(x.shape[1])]
+
+        return np.column_stack(cols)
+
+    else:
+
+        raise ValueError(f"X must be 1-D or 2-D, got ndim={x.ndim}")

--- a/fynance/tests/features/test_engineering.py
+++ b/fynance/tests/features/test_engineering.py
@@ -8,6 +8,8 @@ import pytest
 
 from fynance.features.engineering import (
     IncrementalMoments,
+    _fracdiff_weights,
+    fracdiff,
     granger_causality,
     multi_resolution,
 )
@@ -94,3 +96,117 @@ def test_incremental_empty_is_zero():
     assert im.mean == 0.0
     assert im.var == 0.0
     assert im.std == 0.0
+
+
+def test_fracdiff_weights_known_values_d_half():
+    w = _fracdiff_weights(0.5, tol=1e-5)
+    expected_head = np.array([1.0, -0.5, -0.125, -0.0625])
+    np.testing.assert_allclose(w[:4], expected_head, rtol=1e-12)
+
+
+def test_fracdiff_weights_always_keep_w0():
+    # d=0 makes w_1 vanish exactly, but w_0 = 1 must always be kept.
+    w = _fracdiff_weights(0.0, tol=1e-5)
+    assert w.shape == (1,)
+    assert w[0] == 1.0
+
+
+def test_fracdiff_d0_is_identity_post_warmup():
+    X = np.array([1.0, 2.0, 4.0, 7.0, 11.0])
+    y = fracdiff(X, d=0.0)
+    assert np.array_equal(y, X)
+
+
+def test_fracdiff_d1_equals_first_difference_post_warmup():
+    X = np.array([1.0, 2.0, 4.0, 7.0, 11.0])
+    y = fracdiff(X, d=1.0)
+    assert np.isnan(y[0])
+    np.testing.assert_array_equal(y[1:], np.diff(X))
+
+
+def _slow_fracdiff(X, d, tol):
+    """ Reference double-loop implementation, independent of the kernel. """
+    w = _fracdiff_weights(d, tol)
+    K = len(w)
+    T, N = X.shape
+    out = np.full((T, N), np.nan)
+    for n in range(N):
+        for t in range(K - 1, T):
+            s = 0.0
+            for k in range(K):
+                s += w[k] * X[t - k, n]
+            out[t, n] = s
+
+    return out
+
+
+def test_fracdiff_matches_slow_python_reference():
+    # tol=1e-3 (rather than the 1e-5 default) keeps K well below T=300, so the
+    # convolution is actually exercised rather than degenerating to all-NaN.
+    rng = np.random.RandomState(7)
+    X = 100 * np.exp(np.cumsum(rng.standard_normal((300, 3)) * 0.01, axis=0))
+    d, tol = 0.4, 1e-3
+    fast = fracdiff(X, d=d, tol=tol)
+    slow = _slow_fracdiff(X, d, tol)
+    np.testing.assert_allclose(fast, slow, rtol=1e-12, equal_nan=True)
+
+
+def test_fracdiff_is_causal():
+    rng = np.random.RandomState(3)
+    X = 100 * np.exp(np.cumsum(rng.standard_normal(200) * 0.01))
+    t0 = 100
+    X_perturbed = X.copy()
+    X_perturbed[t0:] += rng.standard_normal(X.shape[0] - t0)
+
+    y = fracdiff(X, d=0.4, tol=1e-3)
+    y_perturbed = fracdiff(X_perturbed, d=0.4, tol=1e-3)
+
+    np.testing.assert_array_equal(y[:t0], y_perturbed[:t0])
+    assert not np.allclose(y[t0:], y_perturbed[t0:], equal_nan=True)
+
+
+def test_fracdiff_nan_head_length():
+    rng = np.random.RandomState(4)
+    tol = 1e-3
+    K = _fracdiff_weights(0.4, tol).shape[0]
+    X = rng.standard_normal(K + 50) + 100
+    y = fracdiff(X, d=0.4, tol=tol)
+    assert np.all(np.isnan(y[:K - 1]))
+    assert np.all(np.isfinite(y[K - 1:]))
+
+
+def test_fracdiff_short_series_all_nan():
+    tol = 1e-3
+    K = _fracdiff_weights(0.4, tol).shape[0]
+    X = np.arange(1.0, float(K))  # length K - 1 < K
+    y = fracdiff(X, d=0.4, tol=tol)
+    assert y.shape == (K - 1,)
+    assert np.all(np.isnan(y))
+
+
+def test_fracdiff_2d_matches_stacked_1d():
+    rng = np.random.RandomState(9)
+    X = rng.standard_normal((100, 3)).cumsum(axis=0) + 100
+    y2d = fracdiff(X, d=0.4, tol=1e-3)
+    stacked = np.column_stack(
+        [fracdiff(X[:, j], d=0.4, tol=1e-3) for j in range(3)]
+    )
+    np.testing.assert_array_equal(y2d, stacked)
+
+
+@pytest.mark.parametrize("d", [-0.1, 2.1])
+def test_fracdiff_invalid_d_raises(d):
+    with pytest.raises(ValueError):
+        fracdiff(np.arange(10.0), d=d)
+
+
+def test_fracdiff_nan_input_raises():
+    X = np.array([1.0, 2.0, np.nan, 4.0])
+    with pytest.raises(ValueError):
+        fracdiff(X)
+
+
+def test_fracdiff_inf_input_raises():
+    X = np.array([1.0, 2.0, np.inf, 4.0])
+    with pytest.raises(ValueError):
+        fracdiff(X)


### PR DESCRIPTION
## Summary
- `fracdiff(X, d=0.4, tol=1e-5)` in `fynance.features.engineering`: fixed-width-window fractional differentiation (López de Prado, AFML ch. 5) — binomial weight recursion truncated at `|w_k| < tol`, causal Numba convolution kernel, NaN warm-up head of length K−1, 1-D or column-wise `(T, N)`.
- Leaf 04/06 of the `factor-research` epic.

## Verification (seeded GBM, T=2000, tol=1e-5)
Window width K: 3382 (d=0.2 → all-NaN on T=2000, documented behavior), 1458 (d=0.4), 590 (d=0.6). Lag-1 autocorrelation: raw 0.998 → 0.890 (d=0.4) → 0.610 (d=0.6) — the documented memory-vs-stationarity trade-off.

## Changelog
Added under [Unreleased]: fractional differentiation. Epic ADR PR list updated.

## Test plan
- [x] `pytest` — 1185 passed (weight golden values d=0.5, d=0 identity, d=1 == np.diff, slow-loop parity rtol 1e-12, causality, 2-D consistency)
- [x] `ruff` / `mypy` / interrogate / Sphinx -W
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)