### PR TITLE
feat: add walk-forward permutation feature importance (MDA)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Walk-forward feature importance (MDA).** `walk_forward_mda` in
+  `fynance.research.importance`: permutation importance evaluated
+  out-of-fold on the purged walk-forward splitter — fit once per fold,
+  permute the test window only, seeded; returns an `ImportanceResult`
+  (per-feature mean/std score drop + baseline).
 - **Fractional differentiation.** `fracdiff(X, d, tol)` in
   `fynance.features.engineering`: fixed-width-window fractional
   differentiation (AFML ch. 5) on a Numba kernel — stationarize while

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -72,7 +72,7 @@ Template:
 
 <!-- new entries below, newest first -->
 
-### 2026-07-05 — Cross-sectional factor research epic (PRs #243–#245, epic)  [accepted]
+### 2026-07-05 — Cross-sectional factor research epic (PRs #243–#246, epic)  [accepted]
 
 Gives fynance the *input half* of the factor workflow the v2.11 panel harness
 consumes. Six parallel leaves, key choices:

--- a/doc/source/research.rst
+++ b/doc/source/research.rst
@@ -21,5 +21,7 @@ adapters live downstream.
    permutation_test
    probabilistic_sharpe_ratio
    deflated_sharpe_ratio
+   ImportanceResult
+   walk_forward_mda
    gbm
    regime_switching

--- a/fynance/research/__init__.py
+++ b/fynance/research/__init__.py
@@ -15,10 +15,20 @@ downstream, never here.
 """
 
 # Local
-from . import compare, experiment, guards, ledger, report, runner, synthetic
+from . import (
+    compare,
+    experiment,
+    guards,
+    importance,
+    ledger,
+    report,
+    runner,
+    synthetic,
+)
 from .compare import *
 from .experiment import *
 from .guards import *
+from .importance import *
 from .ledger import *
 from .report import *
 from .runner import *
@@ -30,5 +40,6 @@ __all__ += synthetic.__all__
 __all__ += runner.__all__
 __all__ += report.__all__
 __all__ += guards.__all__
+__all__ += importance.__all__
 __all__ += compare.__all__
 __all__ += ledger.__all__

--- a/fynance/research/importance.py
+++ b/fynance/research/importance.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Walk-forward permutation feature importance (MDA).
+
+Mean-Decrease-Accuracy (MDA) importance evaluated **out-of-fold** on the
+existing purged walk-forward splitter (:func:`fynance.data.split.walk_forward`):
+for each fold the model is fit once on the train window, scored on the test
+window, then re-scored after permuting one feature at a time *within the test
+window only* -- the score drop attributed to that feature is averaged across
+folds and repeats. Entry point: :func:`walk_forward_mda`.
+
+"""
+
+# Built-in
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+# Third-party
+import numpy as np
+from numpy.typing import NDArray
+
+# Local
+from fynance.core import SignalModel
+from fynance.data.split import walk_forward
+
+__all__ = ['ImportanceResult', 'walk_forward_mda']
+
+
+def _neg_mse(y_true: NDArray[np.float64], y_pred: NDArray[np.float64]) -> float:
+    """ Negative mean squared error (higher is better). """
+    return float(-np.mean((y_true - y_pred) ** 2))
+
+
+@dataclass
+class ImportanceResult:
+    """ Result of :func:`walk_forward_mda`.
+
+    Parameters
+    ----------
+    importances : numpy.ndarray, shape (n_features,)
+        Mean out-of-sample score drop per permuted feature, averaged across
+        folds and repeats. Higher means more important (permuting the feature
+        hurts the score more).
+    stds : numpy.ndarray, shape (n_features,)
+        Standard deviation of the score drop across folds x repeats.
+    baseline : float
+        Mean (unpermuted) out-of-sample score across folds.
+    n_folds : int
+        Number of walk-forward folds evaluated.
+    feature_names : list of str, optional
+        Feature labels aligned with ``importances``/``stds``, if provided.
+
+    """
+
+    importances: NDArray[np.float64]
+    stds: NDArray[np.float64]
+    baseline: float
+    n_folds: int
+    feature_names: list[str] | None = None
+
+
+def walk_forward_mda(
+    model_factory: Callable[[], SignalModel],
+    X: NDArray[np.float64],
+    y: NDArray[np.float64],
+    *,
+    train: int = 252,
+    test: int = 63,
+    step: int | None = None,
+    purge: int = 0,
+    metric: Callable[[NDArray[np.float64], NDArray[np.float64]], float] | None = None,
+    n_repeats: int = 5,
+    seed: int = 0,
+    feature_names: list[str] | None = None,
+) -> ImportanceResult:
+    """ Mean-decrease-accuracy feature importance, evaluated out-of-fold.
+
+    Splits ``X``/``y`` with the purged walk-forward generator
+    :func:`fynance.data.split.walk_forward`. Per fold: fit ``model_factory()``
+    once on the train window, score it on the (unpermuted) test window, then
+    -- without refitting -- for each repeat and each feature, permute that
+    feature's column **within the test window only** and re-score. The score
+    drop (``baseline - permuted``) is the importance signal; it is averaged
+    across folds x repeats (mean -> ``importances``, std -> ``stds``).
+
+    Parameters
+    ----------
+    model_factory : callable
+        Zero-argument callable returning a fresh model exposing
+        ``fit(X, y) -> self`` / ``predict(X) -> ndarray``
+        (:class:`fynance.core.SignalModel`). Called once per fold, so every
+        fold starts from an untrained model.
+    X : numpy.ndarray, shape (n_samples, n_features)
+        Feature matrix, strictly time-ordered (row ``t`` must not depend on
+        rows after ``t``).
+    y : numpy.ndarray, shape (n_samples,)
+        Target aligned with ``X``.
+    train, test : int
+        Train and test window lengths, forwarded to
+        :func:`~fynance.data.split.walk_forward`.
+    step : int, optional
+        Roll step (defaults to ``test``; see
+        :func:`~fynance.data.split.walk_forward`).
+    purge : int
+        Embargo between train and test windows, forwarded as-is.
+    metric : callable, optional
+        ``(y_true, y_pred) -> float``, **higher is better**. Defaults to the
+        negative mean squared error (``-mean((y_true - y_pred) ** 2)``).
+    n_repeats : int
+        Number of independent permutation draws per feature per fold.
+    seed : int
+        Master seed. Fold ``i`` / repeat ``r`` draws its permutations from
+        ``numpy.random.default_rng(seed + i * 1000 + r)``, so the result is
+        fully reproducible for a fixed seed and independent across folds and
+        repeats.
+    feature_names : list of str, optional
+        Labels carried through to :attr:`ImportanceResult.feature_names`;
+        must match ``X.shape[1]`` if given.
+
+    Returns
+    -------
+    ImportanceResult
+        See :class:`ImportanceResult`.
+
+    Raises
+    ------
+    ValueError
+        If ``X`` is not 2-D, ``y`` is not 1-D, their lengths mismatch,
+        ``train + test`` exceeds the number of samples (no fold would fit),
+        or ``feature_names`` has the wrong length.
+
+    Examples
+    --------
+    A closed-form linear model recovers the planted feature (column 0) as the
+    most important, well above the pure-noise columns:
+
+    >>> import numpy as np
+    >>> from fynance.research.importance import walk_forward_mda
+    >>> class LinearModel:
+    ...     def fit(self, X, y):
+    ...         design = np.column_stack([X, np.ones(len(X))])
+    ...         self.coef_, *_ = np.linalg.lstsq(design, y, rcond=None)
+    ...         return self
+    ...     def predict(self, X):
+    ...         design = np.column_stack([X, np.ones(len(X))])
+    ...         return design @ self.coef_
+    >>> rng = np.random.default_rng(0)
+    >>> n, k = 300, 3
+    >>> X = rng.standard_normal((n, k))
+    >>> y = 2.0 * X[:, 0] + 0.1 * rng.standard_normal(n)
+    >>> result = walk_forward_mda(LinearModel, X, y, train=150, test=50,
+    ...                            n_repeats=3, seed=0)
+    >>> result.n_folds
+    3
+    >>> bool(result.importances[0] > result.importances[1])
+    True
+    >>> bool(result.importances[0] > result.importances[2])
+    True
+
+    """
+    X = np.asarray(X, dtype=np.float64)
+    y = np.asarray(y, dtype=np.float64)
+
+    if X.ndim != 2:
+        raise ValueError(f"X must be 2-D (n_samples, n_features), got ndim={X.ndim}")
+
+    if y.ndim != 1:
+        raise ValueError(f"y must be 1-D, got ndim={y.ndim}")
+
+    n_samples, n_features = X.shape
+
+    if y.shape[0] != n_samples:
+        raise ValueError(
+            f"X and y length mismatch: X has {n_samples} rows, y has "
+            f"{y.shape[0]}"
+        )
+
+    if train + test > n_samples:
+        raise ValueError(
+            f"train + test ({train + test}) exceeds the number of samples "
+            f"({n_samples}); no walk-forward fold would fit"
+        )
+
+    if feature_names is not None and len(feature_names) != n_features:
+        raise ValueError(
+            f"feature_names has {len(feature_names)} entries, expected "
+            f"{n_features} (X.shape[1])"
+        )
+
+    if metric is None:
+        metric = _neg_mse
+
+    fold_drops: list[NDArray[np.float64]] = []
+    fold_baselines: list[float] = []
+
+    windows = walk_forward(n_samples, train=train, test=test, step=step, purge=purge)
+    for fold_idx, (train_idx, test_idx) in enumerate(windows):
+        model = model_factory()
+        model.fit(X[train_idx], y[train_idx])
+
+        X_test = X[test_idx]
+        y_test = y[test_idx]
+        baseline_pred = model.predict(X_test)
+        baseline_score = float(metric(y_test, baseline_pred))
+        fold_baselines.append(baseline_score)
+
+        repeat_drops = np.empty((n_repeats, n_features), dtype=np.float64)
+        for r in range(n_repeats):
+            rng = np.random.default_rng(seed + fold_idx * 1000 + r)
+            for j in range(n_features):
+                X_perm = X_test.copy()
+                X_perm[:, j] = rng.permutation(X_perm[:, j])
+                permuted_score = float(metric(y_test, model.predict(X_perm)))
+                repeat_drops[r, j] = baseline_score - permuted_score
+
+        fold_drops.append(repeat_drops)
+
+    all_drops = np.concatenate(fold_drops, axis=0)
+
+    return ImportanceResult(
+        importances=all_drops.mean(axis=0),
+        stds=all_drops.std(axis=0),
+        baseline=float(np.mean(fold_baselines)),
+        n_folds=len(fold_drops),
+        feature_names=feature_names,
+    )

--- a/fynance/tests/research/test_importance.py
+++ b/fynance/tests/research/test_importance.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Tests for :mod:`fynance.research.importance`. """
+
+# Third-party
+import numpy as np
+import pytest
+
+# Local
+from fynance.research import ImportanceResult, walk_forward_mda
+
+
+class LinearModel:
+    """ Closed-form OLS with intercept, via ``lstsq`` on ``[X, 1]``. """
+
+    def fit(self, X, y):
+        design = np.column_stack([X, np.ones(len(X))])
+        coef, *_ = np.linalg.lstsq(design, y, rcond=None)
+        self.coef_ = coef[:-1]
+        self.intercept_ = coef[-1]
+        return self
+
+    def predict(self, X):
+        return X @ self.coef_ + self.intercept_
+
+
+class RecordingModel(LinearModel):
+    """ Same closed-form OLS, but keeps a live reference *and* a snapshot of
+    the train window at fit time so ``predict`` can assert the reference was
+    never mutated by the permutation loop (which must only touch the test
+    window's own copy).
+    """
+
+    def fit(self, X, y):
+        self._train_ref = X
+        self._train_snapshot = X.copy()
+        return super().fit(X, y)
+
+    def predict(self, X):
+        assert np.array_equal(self._train_ref, self._train_snapshot), (
+            "train window was mutated by the permutation loop"
+        )
+        return super().predict(X)
+
+
+def _planted_signal(seed, T=600, k=4):
+    rng = np.random.default_rng(seed)
+    X = rng.standard_normal((T, k))
+    y = 2.0 * X[:, 0] + 0.1 * rng.standard_normal(T)
+    return X, y
+
+
+# -- planted signal ----------------------------------------------------------
+
+def test_planted_signal_dominates_noise_features():
+    X, y = _planted_signal(seed=1)
+
+    result = walk_forward_mda(LinearModel, X, y, train=200, test=50, seed=0)
+
+    assert isinstance(result, ImportanceResult)
+    top = result.importances[0]
+    for j in range(1, X.shape[1]):
+        assert top > result.importances[j]
+        assert abs(result.importances[j]) < 0.1 * top
+
+
+# -- determinism ---------------------------------------------------------
+
+def test_same_seed_gives_identical_arrays():
+    X, y = _planted_signal(seed=2)
+
+    r1 = walk_forward_mda(LinearModel, X, y, train=200, test=50, seed=7)
+    r2 = walk_forward_mda(LinearModel, X, y, train=200, test=50, seed=7)
+
+    np.testing.assert_array_equal(r1.importances, r2.importances)
+    np.testing.assert_array_equal(r1.stds, r2.stds)
+    assert r1.baseline == r2.baseline
+    assert r1.n_folds == r2.n_folds
+
+
+def test_different_seed_same_top_feature():
+    X, y = _planted_signal(seed=3)
+
+    r_a = walk_forward_mda(LinearModel, X, y, train=200, test=50, seed=1)
+    r_b = walk_forward_mda(LinearModel, X, y, train=200, test=50, seed=2)
+
+    assert np.argmax(r_a.importances) == 0
+    assert np.argmax(r_b.importances) == 0
+    assert not np.array_equal(r_a.importances, r_b.importances)
+
+
+# -- permutation is test-window-only -----------------------------------------
+
+def test_permutation_never_touches_train_window():
+    X, y = _planted_signal(seed=4)
+
+    # RecordingModel.predict raises AssertionError if the train window it
+    # captured at fit time was ever mutated afterward; a plain, successful
+    # call is the assertion that permutation stayed inside the test window.
+    walk_forward_mda(RecordingModel, X, y, train=200, test=50, n_repeats=2,
+                     seed=0)
+
+
+# -- feature names -------------------------------------------------------
+
+def test_feature_names_passthrough():
+    X, y = _planted_signal(seed=5)
+    names = ["signal", "n1", "n2", "n3"]
+
+    result = walk_forward_mda(LinearModel, X, y, train=200, test=50,
+                               feature_names=names)
+
+    assert result.feature_names == names
+
+
+def test_feature_names_length_mismatch_raises():
+    X, y = _planted_signal(seed=5)
+
+    with pytest.raises(ValueError, match="feature_names"):
+        walk_forward_mda(LinearModel, X, y, train=200, test=50,
+                         feature_names=["only_one"])
+
+
+# -- validation ------------------------------------------------------------
+
+def test_rejects_x_y_length_mismatch():
+    X = np.zeros((100, 3))
+    y = np.zeros(99)
+
+    with pytest.raises(ValueError, match="length mismatch"):
+        walk_forward_mda(LinearModel, X, y, train=50, test=10)
+
+
+def test_rejects_non_2d_x():
+    X = np.zeros(100)
+    y = np.zeros(100)
+
+    with pytest.raises(ValueError, match="2-D"):
+        walk_forward_mda(LinearModel, X, y, train=50, test=10)
+
+
+def test_rejects_train_plus_test_over_n():
+    X = np.zeros((100, 3))
+    y = np.zeros(100)
+
+    with pytest.raises(ValueError, match="exceeds"):
+        walk_forward_mda(LinearModel, X, y, train=80, test=30)
+
+
+# -- purge smoke test ------------------------------------------------------
+
+def test_purge_smoke():
+    X, y = _planted_signal(seed=6, T=400)
+
+    result = walk_forward_mda(LinearModel, X, y, train=150, test=40, purge=5,
+                              seed=0)
+
+    assert result.n_folds > 0
+    assert result.importances.shape == (4,)
+    assert result.stds.shape == (4,)


### PR DESCRIPTION
## Summary
- New `fynance.research.importance` module: `walk_forward_mda(model_factory, X, y, ...)` — mean-decrease-accuracy importance evaluated out-of-fold on `fynance.data.split.walk_forward` (purge forwarded), one fit per fold, permutation of the test window only, seeded rng per fold×repeat; returns `ImportanceResult` (importances, stds, baseline, n_folds, feature_names).
- Leaf 06/06-numbered of the `factor-research` epic.

## Verification (synthetic T=1500, 6 features, y = 1.0·X₀ + 0.5·X₃ + noise)
importances: f0 = 1.729, f3 = 0.468 (drop ratio 3.69 ≈ the coef²-scaled expectation of 4), noise features ≈ ±3e-5 — four orders of magnitude below; 19 folds.

## Changelog
Added under [Unreleased]: walk-forward MDA. Epic ADR PR list updated.

## Test plan
- [x] `pytest` — passed (10 new tests: planted-signal ranking, determinism, train-window-untouched assertion, purge smoke, validation errors)
- [x] `ruff` / `mypy` / interrogate / Sphinx -W
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)