### PR TITLE
feat: add factor analysis suite (quantile returns, rolling IC, decay, tearsheet)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Factor analysis suite.** New `fynance.metrics.factor`
+  (`quantile_returns` -> `QuantileResult`, `roll_information_coefficient`,
+  `ic_decay` over non-overlapping horizons, `ic_summary` with ICIR/t-stat/
+  hit-rate, `factor_rank_autocorr`) and `fynance.plot.factor`
+  (`plot_quantile_returns`, `plot_ic_series`, `plot_ic_decay` and the
+  composed 2x2 `factor_tearsheet`) — alphalens-style factor evaluation on
+  data-agnostic `(T, N)` panels.
 - **Walk-forward feature importance (MDA).** `walk_forward_mda` in
   `fynance.research.importance`: permutation importance evaluated
   out-of-fold on the purged walk-forward splitter — fit once per fold,

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -72,7 +72,7 @@ Template:
 
 <!-- new entries below, newest first -->
 
-### 2026-07-05 — Cross-sectional factor research epic (PRs #243–#246, epic)  [accepted]
+### 2026-07-05 — Cross-sectional factor research epic (PRs #243–#247, epic)  [accepted]
 
 Gives fynance the *input half* of the factor workflow the v2.11 panel harness
 consumes. Six parallel leaves, key choices:

--- a/doc/source/metrics.rst
+++ b/doc/source/metrics.rst
@@ -47,6 +47,25 @@ Rolling versions
    roll_drawdown
    roll_mdd
 
+Factor analysis
+===============
+
+Alphalens-style evaluation of a cross-sectional factor on a data-agnostic
+``(T, N)`` panel. The alignment convention matches
+:func:`information_coefficient` — ``factor[t]`` is paired with the return
+realized *after* the factor is known.
+
+.. autosummary::
+   :toctree: generated/
+
+   information_coefficient
+   quantile_returns
+   roll_information_coefficient
+   ic_decay
+   ic_summary
+   factor_rank_autocorr
+   QuantileResult
+
 Aggregated report
 =================
 

--- a/doc/source/plot.rst
+++ b/doc/source/plot.rst
@@ -17,3 +17,17 @@ performance report. Each plot returns an ``Axes``/``Figure`` and never calls
    plot_drawdown
    plot_returns_hist
    plot_rolling_sharpe
+
+Factor tear-sheet
+=================
+
+Panels for the factor-evaluation metrics in :mod:`fynance.metrics.factor`, plus
+a one-call :func:`~fynance.plot.factor_tearsheet`.
+
+.. autosummary::
+   :toctree: generated/
+
+   plot_quantile_returns
+   plot_ic_series
+   plot_ic_decay
+   factor_tearsheet

--- a/fynance/metrics/__init__.py
+++ b/fynance/metrics/__init__.py
@@ -17,6 +17,7 @@ import sys as _sys
 # Local packages
 from .correlation import *
 from .drawdown import *
+from .factor import *
 from .ratios import *
 from .returns import *
 from .returns import perf_strat, returns_strat  # noqa: F401
@@ -25,14 +26,16 @@ from .trading import *
 
 # Aggregate __all__ via sys.modules (the star imports above rebind names that
 # collide with a submodule, e.g. the ``drawdown`` function vs the module).
-# ``information_coefficient`` and the trade-profile metrics (``sign_changes`` /
+# ``information_coefficient``, the factor-analysis helpers (``quantile_returns``,
+# ``roll_information_coefficient``, ``ic_decay``, ``ic_summary``,
+# ``factor_rank_autocorr``) and the trade-profile metrics (``sign_changes`` /
 # ``trades_per_year``) are exported here but intentionally NOT added to the
 # ``METRICS`` registry: that registry maps a name to a callable taking a single
-# equity/price curve (see ``summary``), whereas the IC takes an aligned
-# (pred, real) pair and the trade-profile metrics take a position series, so
-# neither fits that single-series contract.
+# equity/price curve (see ``summary``), whereas the IC and factor helpers take an
+# aligned (pred, real) / (factor, fwd) pair and the trade-profile metrics take a
+# position series, so none fit that single-series contract.
 __all__ = []
-for _m in ("correlation", "returns", "ratios", "drawdown", "trading"):
+for _m in ("correlation", "returns", "ratios", "drawdown", "factor", "trading"):
     __all__ += _sys.modules[f"{__name__}.{_m}"].__all__
 __all__ += ['perf_strat', 'returns_strat', 'METRICS', 'summary']
 

--- a/fynance/metrics/factor.py
+++ b/fynance/metrics/factor.py
@@ -1,0 +1,586 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Alphalens-style factor evaluation on data-agnostic ``(T, N)`` panels.
+
+A *factor* is a per-bar cross-sectional score (one value per asset per bar) used
+to rank assets; these helpers score how much forward-return signal that ranking
+carries. They operate on raw NumPy panels — no dates, no asset names — so they
+apply to any ``(T, N)`` factor/return pair.
+
+**Alignment convention** (shared with
+:func:`fynance.metrics.information_coefficient`): ``factor[t]`` is aligned with
+``fwd[t]``, the return realized *after* the factor is known. The caller builds
+``fwd`` (e.g. via :func:`fynance.features.horizon_returns`) so that no future
+information leaks into the factor.
+
+The suite mirrors a factor tear-sheet: quantile-portfolio returns
+(:func:`quantile_returns`), a trailing Information Coefficient
+(:func:`roll_information_coefficient`), IC decay across horizons
+(:func:`ic_decay`), IC summary statistics (:func:`ic_summary`) and factor rank
+autocorrelation (:func:`factor_rank_autocorr`, a turnover proxy).
+
+"""
+
+from __future__ import annotations
+
+# Built-in packages
+from dataclasses import dataclass
+
+# Third-party packages
+import numpy as np
+from numpy.typing import NDArray
+
+# Local packages
+from fynance.features.horizon import horizon_returns
+from fynance.metrics.correlation import information_coefficient
+
+__all__ = [
+    'QuantileResult',
+    'quantile_returns',
+    'roll_information_coefficient',
+    'ic_decay',
+    'ic_summary',
+    'factor_rank_autocorr',
+]
+
+
+@dataclass
+class QuantileResult:
+    """ Per-bar quantile-portfolio returns of a factor.
+
+    Returned by :func:`quantile_returns`. On each bar the valid assets are
+    bucketed into ``n_quantiles`` equal-count quantiles by factor value (bucket
+    ``0`` is the lowest factor value, bucket ``n_quantiles - 1`` the highest) and
+    the equal-weighted mean forward return of each bucket is recorded.
+
+    Attributes
+    ----------
+    quantile_returns : np.ndarray[np.float64, ndim=2]
+        Shape ``(T, Q)``. Mean forward return per per-bar factor quantile. Bars
+        with fewer than ``Q`` valid assets are a full row of ``np.nan``.
+    spread : np.ndarray[np.float64, ndim=1]
+        Shape ``(T,)``. Top-minus-bottom quantile return
+        (``quantile_returns[:, -1] - quantile_returns[:, 0]``), the long-short
+        return of the factor.
+    counts : np.ndarray[np.int64, ndim=2]
+        Shape ``(T, Q)``. Number of assets in each bucket (``0`` on invalid
+        bars).
+    n_quantiles : int
+        Number of quantiles ``Q``.
+
+    """
+
+    quantile_returns: NDArray
+    spread: NDArray
+    counts: NDArray
+    n_quantiles: int
+
+
+def quantile_returns(
+    factor: NDArray,
+    fwd: NDArray,
+    n_quantiles: int = 5,
+) -> QuantileResult:
+    r""" Equal-count quantile-portfolio returns of a factor.
+
+    On each bar the assets valid in *both* ``factor`` and ``fwd`` (finite on both
+    sides) are sorted by factor value and split into ``n_quantiles`` equal-count
+    buckets — ties are broken by rank order (a stable sort), bucket ``0`` holding
+    the lowest factor values and bucket ``n_quantiles - 1`` the highest. Each
+    bucket's return is the equal-weighted mean of its assets' forward returns.
+    Bars with fewer than ``n_quantiles`` valid assets yield a row of ``np.nan``
+    (and zero counts).
+
+    **Alignment.** ``factor[t]`` is the score known at bar ``t`` and ``fwd[t]``
+    the return realized *after* ``t`` (built by the caller, e.g. via
+    :func:`fynance.features.horizon_returns`), so a positive top-minus-bottom
+    :attr:`~QuantileResult.spread` means high-factor assets out-earned
+    low-factor assets.
+
+    Parameters
+    ----------
+    factor : np.ndarray[dtype, ndim=2]
+        Factor panel ``(T, N)`` — the per-bar cross-sectional score.
+    fwd : np.ndarray[dtype, ndim=2]
+        Forward-return panel ``(T, N)`` aligned with ``factor``.
+    n_quantiles : int, optional
+        Number of equal-count buckets ``Q`` (default ``5``), a positive integer
+        of at least ``2``.
+
+    Returns
+    -------
+    QuantileResult
+        The per-bar bucket returns, long-short spread, bucket counts and
+        ``n_quantiles``.
+
+    Examples
+    --------
+    A two-bar, four-asset panel split into two buckets; the factor ranking is
+    ascending on the first bar and descending on the second:
+
+    >>> import numpy as np
+    >>> factor = np.array([[1., 2., 3., 4.], [4., 3., 2., 1.]])
+    >>> fwd = np.array([[1., 2., 3., 4.], [1., 2., 3., 4.]])
+    >>> res = quantile_returns(factor, fwd, n_quantiles=2)
+    >>> res.quantile_returns
+    array([[1.5, 3.5],
+           [3.5, 1.5]])
+    >>> res.spread
+    array([ 2., -2.])
+    >>> res.counts
+    array([[2, 2],
+           [2, 2]])
+
+    See Also
+    --------
+    fynance.metrics.information_coefficient, ic_summary
+
+    """
+    if not isinstance(n_quantiles, (int, np.integer)) or n_quantiles < 2:
+
+        raise ValueError(
+            f"n_quantiles must be an integer >= 2, got {n_quantiles!r}"
+        )
+
+    factor = np.asarray(factor, dtype=np.float64)
+    fwd = np.asarray(fwd, dtype=np.float64)
+
+    if factor.shape != fwd.shape:
+
+        raise ValueError(
+            f"factor and fwd must have the same shape, got {factor.shape} and "
+            f"{fwd.shape}"
+        )
+
+    if factor.ndim != 2:
+
+        raise ValueError(
+            f"factor and fwd must be 2-D (T, N) panels, got ndim={factor.ndim}"
+        )
+
+    Q = int(n_quantiles)
+    T = factor.shape[0]
+    qret = np.full((T, Q), np.nan, dtype=np.float64)
+    counts = np.zeros((T, Q), dtype=np.int64)
+    spread = np.full(T, np.nan, dtype=np.float64)
+
+    for t in range(T):
+        valid = np.isfinite(factor[t]) & np.isfinite(fwd[t])
+        n_valid = int(valid.sum())
+
+        if n_valid < Q:
+            # Too few assets to fill every bucket -> leave the NaN row.
+            continue
+
+        f_valid = factor[t, valid]
+        r_valid = fwd[t, valid]
+
+        # Ordinal ranks 0..n_valid-1 (ties broken by original order via a stable
+        # sort), then equal-count buckets rank * Q // n_valid in [0, Q-1].
+        order = np.argsort(f_valid, kind='stable')
+        ranks = np.empty(n_valid, dtype=np.int64)
+        ranks[order] = np.arange(n_valid)
+        buckets = ranks * Q // n_valid
+
+        for q in range(Q):
+            in_q = buckets == q
+            counts[t, q] = int(in_q.sum())
+            qret[t, q] = float(r_valid[in_q].mean())
+
+        spread[t] = qret[t, Q - 1] - qret[t, 0]
+
+    return QuantileResult(
+        quantile_returns=qret,
+        spread=spread,
+        counts=counts,
+        n_quantiles=Q,
+    )
+
+
+def roll_information_coefficient(
+    pred: NDArray,
+    real: NDArray,
+    w: int = 63,
+    method: str = 'spearman',
+) -> NDArray:
+    r""" Trailing-window Information Coefficient.
+
+    A rolling view of the :func:`fynance.metrics.information_coefficient`: rather
+    than one number over the whole sample, it reports how the predictive power
+    evolves through time over a trailing window of ``w`` bars. It is strictly
+    causal — the value at ``t`` uses only data on ``[t - w + 1, t]`` — so the
+    first ``w - 1`` entries are ``np.nan``.
+
+    Two input shapes are supported:
+
+    - **1-D** ``(T,)`` — a single aligned ``(pred, real)`` time series; the value
+      at ``t`` is the IC computed over the trailing window ``[t - w + 1, t]``.
+    - **2-D** ``(T, N)`` panel — the per-bar *cross-sectional* IC is computed
+      first (across the ``N`` assets, one value per bar, reusing
+      :func:`information_coefficient`), then smoothed by a trailing mean over
+      ``w`` bars (NaN bars are ignored within the window).
+
+    **Alignment.** ``pred[t]`` is the score known at ``t`` and ``real[t]`` the
+    outcome realized after ``t``.
+
+    Parameters
+    ----------
+    pred : np.ndarray[dtype, ndim=1 or 2]
+        Predictions/scores. Same shape as ``real``.
+    real : np.ndarray[dtype, ndim=1 or 2]
+        Realized outcomes (e.g. forward returns).
+    w : int, optional
+        Trailing window length in bars (default ``63``), a positive integer.
+    method : {'spearman', 'pearson'}, optional
+        Correlation used for the IC — ``'spearman'`` (default) for the rank-IC,
+        ``'pearson'`` for the linear IC.
+
+    Returns
+    -------
+    np.ndarray[np.float64, ndim=1]
+        Trailing IC of shape ``(T,)``; the first ``w - 1`` entries are
+        ``np.nan``.
+
+    Examples
+    --------
+    On a monotone 1-D series every trailing window is perfectly ordered, so the
+    rank-IC is ``1`` once the window is full:
+
+    >>> import numpy as np
+    >>> pred = np.arange(10.)
+    >>> real = np.arange(10.)
+    >>> ic = roll_information_coefficient(pred, real, w=5)
+    >>> bool(np.isnan(ic[:4]).all())
+    True
+    >>> bool(np.allclose(ic[4:], 1.0))
+    True
+
+    See Also
+    --------
+    fynance.metrics.information_coefficient, ic_summary
+
+    """
+    if not isinstance(w, (int, np.integer)) or w < 1:
+
+        raise ValueError(f"w must be a positive integer, got {w!r}")
+
+    pred = np.asarray(pred, dtype=np.float64)
+    real = np.asarray(real, dtype=np.float64)
+
+    if pred.shape != real.shape:
+
+        raise ValueError(
+            f"pred and real must have the same shape, got {pred.shape} and "
+            f"{real.shape}"
+        )
+
+    if pred.ndim not in (1, 2):
+
+        raise ValueError(
+            f"only 1-D and 2-D arrays are supported, got ndim={pred.ndim}"
+        )
+
+    w = int(w)
+    T = pred.shape[0]
+    out = np.full(T, np.nan, dtype=np.float64)
+
+    if pred.ndim == 1:
+        for t in range(w - 1, T):
+            out[t] = information_coefficient(
+                pred[t - w + 1:t + 1], real[t - w + 1:t + 1], method=method,
+            )
+
+        return out
+
+    # 2-D: per-bar cross-sectional IC, then trailing mean over w (NaN-robust).
+    ic_bar = np.asarray(
+        information_coefficient(pred, real, method=method), dtype=np.float64,
+    )
+
+    for t in range(w - 1, T):
+        window = ic_bar[t - w + 1:t + 1]
+
+        if np.any(np.isfinite(window)):
+            out[t] = float(np.nanmean(window))
+
+    return out
+
+
+def ic_decay(
+    factor: NDArray,
+    prices: NDArray,
+    horizons: tuple[int, ...] = (1, 5, 10, 21),
+    method: str = 'spearman',
+) -> NDArray:
+    r""" Information Coefficient decay across forward horizons.
+
+    Measures how quickly a factor's predictive power fades as the prediction
+    horizon lengthens. For each horizon ``h`` the mean per-bar cross-sectional IC
+    is computed between the factor and the ``h``-bar **non-overlapping** forward
+    return from :func:`fynance.features.horizon_returns` (non-overlapping so the
+    labels do not share price moves and inflate the IC). A signal with real
+    short-horizon edge shows a high IC at ``h = 1`` that decays toward zero as
+    ``h`` grows.
+
+    **Alignment.** ``factor[t]`` is aligned with the forward return starting at
+    ``t``; both share the same time index (the first axis of ``prices``).
+
+    Parameters
+    ----------
+    factor : np.ndarray[dtype, ndim=2]
+        Factor panel ``(T, N)``.
+    prices : np.ndarray[dtype, ndim=2]
+        Price panel ``(T, N)`` from which the forward returns are built; same
+        time index as ``factor``.
+    horizons : tuple of int, optional
+        Forward horizons in bars (default ``(1, 5, 10, 21)``). A horizon that is
+        not shorter than ``T`` yields ``np.nan``.
+    method : {'spearman', 'pearson'}, optional
+        Correlation used for the IC (default ``'spearman'``).
+
+    Returns
+    -------
+    np.ndarray[np.float64, ndim=1]
+        Mean IC per horizon, shape ``(len(horizons),)``.
+
+    Examples
+    --------
+    A factor equal to the realized one-bar forward return is a perfect
+    one-bar predictor, so its IC at horizon 1 is ``1``:
+
+    >>> import numpy as np
+    >>> rng = np.random.default_rng(0)
+    >>> prices = 100. * np.cumprod(1. + rng.normal(0., 0.01, (200, 5)), axis=0)
+    >>> fwd1 = prices[1:] / prices[:-1] - 1.
+    >>> factor = np.vstack([fwd1, np.full((1, 5), np.nan)])
+    >>> decay = ic_decay(factor, prices, horizons=(1, 5))
+    >>> bool(decay[0] > 0.99)
+    True
+
+    See Also
+    --------
+    fynance.features.horizon_returns, fynance.metrics.information_coefficient
+
+    """
+    factor = np.asarray(factor, dtype=np.float64)
+    prices = np.asarray(prices, dtype=np.float64)
+
+    if factor.shape != prices.shape:
+
+        raise ValueError(
+            f"factor and prices must have the same shape, got {factor.shape} "
+            f"and {prices.shape}"
+        )
+
+    if factor.ndim != 2:
+
+        raise ValueError(
+            f"factor and prices must be 2-D (T, N) panels, got "
+            f"ndim={factor.ndim}"
+        )
+
+    T = factor.shape[0]
+    decay = np.full(len(horizons), np.nan, dtype=np.float64)
+
+    for i, h in enumerate(horizons):
+        if T <= h:
+            # horizon_returns needs strictly more than h bars; leave NaN.
+            continue
+
+        fwd = horizon_returns(prices, h)
+        # Non-overlapping labels keep one sample every h bars starting at 0; the
+        # factor is sampled on the very same base indices to stay aligned.
+        base_idx = np.arange(0, T - h, h)
+        ic_bar = np.asarray(
+            information_coefficient(factor[base_idx], fwd, method=method),
+            dtype=np.float64,
+        )
+
+        if np.any(np.isfinite(ic_bar)):
+            decay[i] = float(np.nanmean(ic_bar))
+
+    return decay
+
+
+def ic_summary(
+    pred: NDArray,
+    real: NDArray,
+    method: str = 'spearman',
+) -> dict[str, float]:
+    r""" Summary statistics of the per-bar cross-sectional Information Coefficient.
+
+    Reduces a ``(T, N)`` panel to the headline numbers of a factor tear-sheet.
+    The per-bar cross-sectional IC (one value per bar, across the ``N`` assets)
+    is computed with :func:`fynance.metrics.information_coefficient`, then
+    summarized. ``icir`` (the IC information ratio) and ``t_stat`` gauge whether
+    the mean IC is distinguishable from zero given its bar-to-bar variability.
+
+    **Alignment.** ``pred[t]`` is the score known at ``t`` and ``real[t]`` the
+    outcome realized after ``t``.
+
+    Parameters
+    ----------
+    pred : np.ndarray[dtype, ndim=2]
+        Factor/score panel ``(T, N)``.
+    real : np.ndarray[dtype, ndim=2]
+        Aligned forward-return panel ``(T, N)``.
+    method : {'spearman', 'pearson'}, optional
+        Correlation used for the IC (default ``'spearman'``).
+
+    Returns
+    -------
+    dict of str to float
+        ``mean_ic`` (mean per-bar IC), ``icir`` (mean / std of the per-bar IC),
+        ``t_stat`` (``icir * sqrt(n_bars)``), ``hit_rate`` (share of bars with a
+        positive IC) and ``n_bars`` (number of bars with a finite IC). ``icir``
+        and ``t_stat`` are ``nan`` when the IC has zero variance.
+
+    Notes
+    -----
+    With :math:`IC_t` the per-bar IC over the :math:`n` bars with a finite value,
+
+    .. math::
+
+        \mathrm{ICIR} = \frac{\overline{IC}}{\sigma_{IC}}, \qquad
+        t = \mathrm{ICIR}\,\sqrt{n}
+
+    where :math:`\sigma_{IC}` is the sample standard deviation (``ddof=1``).
+
+    Examples
+    --------
+    A factor equal to the realized outcome has a perfect per-bar IC:
+
+    >>> import numpy as np
+    >>> rng = np.random.default_rng(1)
+    >>> real = rng.normal(size=(100, 10))
+    >>> pred = real.copy()
+    >>> s = ic_summary(pred, real)
+    >>> round(s['mean_ic'], 6)
+    1.0
+    >>> round(s['hit_rate'], 2)
+    1.0
+    >>> s['n_bars']
+    100
+
+    See Also
+    --------
+    fynance.metrics.information_coefficient, roll_information_coefficient
+
+    """
+    pred = np.asarray(pred, dtype=np.float64)
+    real = np.asarray(real, dtype=np.float64)
+
+    if pred.shape != real.shape:
+
+        raise ValueError(
+            f"pred and real must have the same shape, got {pred.shape} and "
+            f"{real.shape}"
+        )
+
+    if pred.ndim != 2:
+
+        raise ValueError(
+            f"pred and real must be 2-D (T, N) panels, got ndim={pred.ndim}"
+        )
+
+    ic_bar = np.asarray(
+        information_coefficient(pred, real, method=method), dtype=np.float64,
+    )
+    finite = ic_bar[np.isfinite(ic_bar)]
+    n_bars = int(finite.size)
+
+    if n_bars == 0:
+
+        return {
+            'mean_ic': float('nan'),
+            'icir': float('nan'),
+            't_stat': float('nan'),
+            'hit_rate': float('nan'),
+            'n_bars': 0,
+        }
+
+    mean_ic = float(finite.mean())
+    std_ic = float(finite.std(ddof=1)) if n_bars > 1 else 0.0
+    icir = mean_ic / std_ic if std_ic > 0.0 else float('nan')
+    t_stat = icir * np.sqrt(n_bars) if std_ic > 0.0 else float('nan')
+    hit_rate = float(np.mean(finite > 0.0))
+
+    return {
+        'mean_ic': mean_ic,
+        'icir': float(icir),
+        't_stat': float(t_stat),
+        'hit_rate': hit_rate,
+        'n_bars': n_bars,
+    }
+
+
+def factor_rank_autocorr(factor: NDArray, lag: int = 1) -> NDArray:
+    r""" Cross-sectional rank autocorrelation of a factor (turnover proxy).
+
+    At each bar the Spearman (rank) correlation between the factor's
+    cross-section at ``t`` and at ``t - lag`` measures how much the ranking is
+    preserved from one bar to the next. A value near ``1`` means a stable
+    ranking (low turnover); a value near ``0`` means the ranking is reshuffled
+    each bar (high turnover). It is the standard turnover proxy of a factor
+    tear-sheet.
+
+    Parameters
+    ----------
+    factor : np.ndarray[dtype, ndim=2]
+        Factor panel ``(T, N)``.
+    lag : int, optional
+        Lag in bars between the two cross-sections (default ``1``), a positive
+        integer.
+
+    Returns
+    -------
+    np.ndarray[np.float64, ndim=1]
+        Rank autocorrelation per bar, shape ``(T,)``. The first ``lag`` entries
+        are ``np.nan``, as is any bar where either cross-section has fewer than
+        three finite entries.
+
+    Examples
+    --------
+    A factor whose ranking never changes has a rank autocorrelation of ``1``:
+
+    >>> import numpy as np
+    >>> factor = np.tile(np.arange(5.), (4, 1))
+    >>> ac = factor_rank_autocorr(factor, lag=1)
+    >>> float(ac[0])
+    nan
+    >>> bool(np.allclose(ac[1:], 1.0))
+    True
+
+    See Also
+    --------
+    fynance.metrics.information_coefficient
+
+    """
+    if not isinstance(lag, (int, np.integer)) or lag < 1:
+
+        raise ValueError(f"lag must be a positive integer, got {lag!r}")
+
+    factor = np.asarray(factor, dtype=np.float64)
+
+    if factor.ndim != 2:
+
+        raise ValueError(
+            f"factor must be a 2-D (T, N) panel, got ndim={factor.ndim}"
+        )
+
+    lag = int(lag)
+    T = factor.shape[0]
+    out = np.full(T, np.nan, dtype=np.float64)
+
+    for t in range(lag, T):
+        now = factor[t]
+        past = factor[t - lag]
+
+        if np.isfinite(now).sum() < 3 or np.isfinite(past).sum() < 3:
+            # Too few ranks on either side for a meaningful rank correlation.
+            continue
+
+        out[t] = information_coefficient(now, past, method='spearman')
+
+    return out

--- a/fynance/plot/__init__.py
+++ b/fynance/plot/__init__.py
@@ -15,6 +15,12 @@ API the notebook workflow and the optional Streamlit app both build on.
 from .attribution import plot_contribution, plot_turnover
 from .costs import plot_cost_decomposition
 from .equity import plot_drawdown, plot_equity
+from .factor import (
+    factor_tearsheet,
+    plot_ic_decay,
+    plot_ic_series,
+    plot_quantile_returns,
+)
 from .returns import plot_returns_hist, plot_rolling_sharpe
 from .tearsheet import tearsheet, tearsheet_text
 
@@ -26,6 +32,10 @@ __all__ = [
     'plot_contribution',
     'plot_turnover',
     'plot_cost_decomposition',
+    'plot_quantile_returns',
+    'plot_ic_series',
+    'plot_ic_decay',
+    'factor_tearsheet',
     'tearsheet',
     'tearsheet_text',
 ]

--- a/fynance/plot/factor.py
+++ b/fynance/plot/factor.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Factor tear-sheet figures (Alphalens-style).
+
+Composable matplotlib panels for the factor-evaluation metrics in
+:mod:`fynance.metrics.factor`, plus a one-call :func:`factor_tearsheet`. Each
+panel returns an ``Axes`` (and :func:`factor_tearsheet` a ``Figure``) and never
+calls ``show`` — usable headless, in a notebook or an app. Matplotlib is
+imported lazily inside each function so ``import fynance`` stays
+matplotlib-free.
+
+"""
+
+from __future__ import annotations
+
+# Built-in packages
+from typing import Any
+
+# Third-party packages
+import numpy as np
+
+# Local packages
+from fynance.features.horizon import horizon_returns
+from fynance.metrics.factor import (
+    QuantileResult,
+    ic_decay,
+    quantile_returns,
+    roll_information_coefficient,
+)
+
+__all__ = [
+    'plot_quantile_returns',
+    'plot_ic_series',
+    'plot_ic_decay',
+    'factor_tearsheet',
+]
+
+
+def _compound(returns: Any) -> Any:
+    """ Cumulative compounded growth of a return series (NaN treated as flat). """
+    r = np.nan_to_num(np.asarray(returns, dtype=np.float64), nan=0.0)
+
+    return np.cumprod(1.0 + r)
+
+
+def plot_quantile_returns(result: QuantileResult, ax: Any = None,
+                          **kw: Any) -> Any:
+    """ Plot the cumulative compounded return of each factor quantile.
+
+    Each bucket's per-bar mean forward return
+    (:attr:`~fynance.metrics.factor.QuantileResult.quantile_returns`) is
+    compounded into a growth curve, so a monotone fan (bottom bucket lowest, top
+    bucket highest) is the signature of a working factor. Returns the ``Axes``.
+
+    Parameters
+    ----------
+    result : fynance.metrics.factor.QuantileResult
+        Output of :func:`fynance.metrics.quantile_returns`.
+    ax : matplotlib.axes.Axes, optional
+        Axis to draw on; a new one is created when omitted.
+    **kw
+        Forwarded to :meth:`matplotlib.axes.Axes.plot`.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+
+    """
+    import matplotlib.pyplot as plt
+
+    qret = np.asarray(result.quantile_returns, dtype=np.float64)
+    Q = result.n_quantiles
+
+    if ax is None:
+        _, ax = plt.subplots()
+
+    for q in range(Q):
+        ax.plot(_compound(qret[:, q]), lw=1.3, label=f"Q{q + 1}", **kw)
+    ax.set_title(f"Quantile cumulative returns (Q={Q})")
+    ax.set_ylabel("Growth of 1")
+    ax.grid(alpha=0.3)
+    ax.legend(loc="best", fontsize=8, ncol=2)
+
+    return ax
+
+
+def plot_ic_series(ic: Any, w_smooth: int = 21, ax: Any = None,
+                   **kw: Any) -> Any:
+    """ Plot a rolling Information Coefficient with a smoothed overlay.
+
+    Draws the raw IC series (thin) and a trailing moving average over
+    ``w_smooth`` bars (bold), plus a zero reference line. Returns the ``Axes``.
+
+    Parameters
+    ----------
+    ic : array-like
+        Rolling IC series, e.g. from
+        :func:`fynance.metrics.roll_information_coefficient`.
+    w_smooth : int, optional
+        Window of the smoothing moving average (default ``21``).
+    ax : matplotlib.axes.Axes, optional
+        Axis to draw on; a new one is created when omitted.
+    **kw
+        Forwarded to :meth:`matplotlib.axes.Axes.plot` for the raw series.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+
+    """
+    import matplotlib.pyplot as plt
+
+    ic = np.asarray(ic, dtype=np.float64)
+    T = ic.shape[0]
+    w = max(1, min(int(w_smooth), T))
+
+    # Trailing NaN-robust moving average of the IC series.
+    smooth = np.full(T, np.nan, dtype=np.float64)
+    for t in range(w - 1, T):
+        window = ic[t - w + 1:t + 1]
+        if np.any(np.isfinite(window)):
+            smooth[t] = np.nanmean(window)
+
+    if ax is None:
+        _, ax = plt.subplots()
+
+    ax.plot(ic, color="#9ecae1", lw=0.9, label="IC", **kw)
+    ax.plot(smooth, color="#08519c", lw=1.6, label=f"IC (MA {w})")
+    ax.axhline(0.0, color="k", lw=0.8)
+    ax.set_title("Rolling information coefficient")
+    ax.set_ylabel("IC")
+    ax.grid(alpha=0.3)
+    ax.legend(loc="best", fontsize=8)
+
+    return ax
+
+
+def plot_ic_decay(decay: Any, horizons: tuple[int, ...], ax: Any = None,
+                  **kw: Any) -> Any:
+    """ Bar chart of the Information Coefficient across forward horizons.
+
+    Plots the mean IC (e.g. from :func:`fynance.metrics.ic_decay`) at each
+    horizon; a signal with genuine short-horizon edge shows a tall first bar
+    that decays with the horizon. Returns the ``Axes``.
+
+    Parameters
+    ----------
+    decay : array-like
+        Mean IC per horizon, aligned with ``horizons``.
+    horizons : tuple of int
+        Forward horizons in bars (the x-axis labels).
+    ax : matplotlib.axes.Axes, optional
+        Axis to draw on; a new one is created when omitted.
+    **kw
+        Forwarded to :meth:`matplotlib.axes.Axes.bar`.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+
+    """
+    import matplotlib.pyplot as plt
+
+    decay = np.asarray(decay, dtype=np.float64)
+    x = np.arange(len(horizons))
+
+    if ax is None:
+        _, ax = plt.subplots()
+
+    ax.bar(x, decay, color="#3182bd", alpha=0.85, **kw)
+    ax.axhline(0.0, color="k", lw=0.8)
+    ax.set_xticks(x)
+    ax.set_xticklabels([str(h) for h in horizons])
+    ax.set_title("IC decay by horizon")
+    ax.set_xlabel("Horizon (bars)")
+    ax.set_ylabel("Mean IC")
+    ax.grid(alpha=0.3, axis="y")
+
+    return ax
+
+
+def factor_tearsheet(
+    factor: Any,
+    prices: Any,
+    n_quantiles: int = 5,
+    horizons: tuple[int, ...] = (1, 5, 10, 21),
+    w: int = 63,
+    figsize: tuple[float, float] | None = None,
+    save: str | None = None,
+) -> Any:
+    """ Build a full Alphalens-style factor tear-sheet figure.
+
+    Composes four panels into a 2x2 ``Figure`` from a factor panel and its price
+    panel: quantile cumulative returns, the long-short spread equity, the
+    rolling Information Coefficient and the IC decay by horizon. The one-bar
+    forward return (built from ``prices``) is the target for the quantile and
+    rolling-IC panels; the decay panel uses non-overlapping ``horizons`` returns.
+
+    **Alignment.** ``factor[t]`` is the score known at bar ``t``; the forward
+    returns are built from ``prices`` so no future information leaks in.
+
+    Parameters
+    ----------
+    factor : array-like
+        Factor panel ``(T, N)``.
+    prices : array-like
+        Price panel ``(T, N)`` with the same time index as ``factor``.
+    n_quantiles : int, optional
+        Number of factor quantiles (default ``5``).
+    horizons : tuple of int, optional
+        Forward horizons for the IC-decay panel (default ``(1, 5, 10, 21)``).
+    w : int, optional
+        Trailing window of the rolling IC (default ``63``).
+    figsize : tuple of float, optional
+        Figure size; defaults to ``(11, 7)``.
+    save : str, optional
+        If given, the figure is written to this path with
+        :meth:`~matplotlib.figure.Figure.savefig`.
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+
+    """
+    import matplotlib.pyplot as plt
+
+    factor = np.asarray(factor, dtype=np.float64)
+    prices = np.asarray(prices, dtype=np.float64)
+
+    # One-bar forward return aligned with the factor (drop the last, unlabelled
+    # bar): fwd[t] is realized after factor[t] is known.
+    fwd = horizon_returns(prices, 1, overlapping=True)
+    factor_aligned = factor[:-1]
+
+    qres = quantile_returns(factor_aligned, fwd, n_quantiles=n_quantiles)
+    ic = roll_information_coefficient(factor_aligned, fwd, w=w)
+    decay = ic_decay(factor, prices, horizons=horizons)
+
+    fig = plt.figure(figsize=figsize or (11, 7))
+    gs = fig.add_gridspec(2, 2)
+
+    plot_quantile_returns(qres, ax=fig.add_subplot(gs[0, 0]))
+
+    ax_spread = fig.add_subplot(gs[0, 1])
+    ax_spread.plot(_compound(qres.spread), color="#54278f", lw=1.4)
+    ax_spread.axhline(1.0, color="k", lw=0.8)
+    ax_spread.set_title("Long-short spread equity")
+    ax_spread.set_ylabel("Growth of 1")
+    ax_spread.grid(alpha=0.3)
+
+    plot_ic_series(ic, ax=fig.add_subplot(gs[1, 0]))
+    plot_ic_decay(decay, horizons, ax=fig.add_subplot(gs[1, 1]))
+
+    fig.tight_layout()
+
+    if save is not None:
+        fig.savefig(save)
+
+    return fig

--- a/fynance/tests/metrics/test_factor.py
+++ b/fynance/tests/metrics/test_factor.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for the Alphalens-style factor-evaluation suite. """
+
+# Third-party packages
+import numpy as np
+import pytest
+
+# Local packages
+import fynance as fy
+from fynance.metrics import (
+    QuantileResult,
+    factor_rank_autocorr,
+    ic_decay,
+    ic_summary,
+    information_coefficient,
+    quantile_returns,
+    roll_information_coefficient,
+)
+
+# ---------------------------------------------------------------------------
+# quantile_returns
+# ---------------------------------------------------------------------------
+
+def test_quantile_returns_hand_built_panel():
+    # Two-bar, six-asset panel, three equal-count buckets. Bar 0 has a monotone
+    # factor so the buckets are {a0,a1}, {a2,a3}, {a4,a5}; bar 1 has only two
+    # valid assets (< Q=3) so it must be a NaN row.
+    factor = np.array([[1., 2., 3., 4., 5., 6.],
+                       [5., 6., np.nan, np.nan, np.nan, np.nan]])
+    fwd = np.array([[10., 20., 30., 40., 50., 60.],
+                    [1., 1., 1., 1., 1., 1.]])
+    res = quantile_returns(factor, fwd, n_quantiles=3)
+
+    assert isinstance(res, QuantileResult)
+    assert res.n_quantiles == 3
+    # Bar 0 bucket means and counts.
+    assert np.allclose(res.quantile_returns[0], [15., 35., 55.])
+    assert res.spread[0] == pytest.approx(40.0)
+    assert np.array_equal(res.counts[0], [2, 2, 2])
+    # Bar 1: fewer than Q valid assets -> NaN row, zero counts, NaN spread.
+    assert np.all(np.isnan(res.quantile_returns[1]))
+    assert np.array_equal(res.counts[1], [0, 0, 0])
+    assert np.isnan(res.spread[1])
+
+
+def test_quantile_returns_ties_broken_by_rank_order():
+    # All-equal factor: a stable sort keeps original order, filling buckets
+    # left-to-right, so counts stay balanced even under total ties.
+    factor = np.zeros((1, 6))
+    fwd = np.arange(6.).reshape(1, 6)
+    res = quantile_returns(factor, fwd, n_quantiles=3)
+    assert np.array_equal(res.counts[0], [2, 2, 2])
+
+
+def test_quantile_returns_rejects_bad_n_quantiles():
+    panel = np.zeros((2, 5))
+    with pytest.raises(ValueError):
+        quantile_returns(panel, panel, n_quantiles=1)
+
+
+def test_quantile_returns_rejects_shape_mismatch():
+    with pytest.raises(ValueError):
+        quantile_returns(np.zeros((2, 5)), np.zeros((2, 4)))
+
+
+# ---------------------------------------------------------------------------
+# Perfect foresight: factor == forward return
+# ---------------------------------------------------------------------------
+
+def _gbm_panel(T=300, N=20, seed=0):
+    """ Seeded GBM price panel and the aligned one-bar forward return. """
+    rng = np.random.default_rng(seed)
+    prices = 100. * np.cumprod(1. + rng.normal(0., 0.01, (T, N)), axis=0)
+    fwd = np.full((T, N), np.nan)
+    fwd[:-1] = prices[1:] / prices[:-1] - 1.
+
+    return prices, fwd
+
+
+def test_perfect_foresight_top_beats_bottom_every_bar():
+    _, fwd = _gbm_panel()
+    factor = fwd.copy()
+    res = quantile_returns(factor, fwd, n_quantiles=5)
+    valid = np.isfinite(res.spread)
+    # Sorting by the factor sorts by the realized return, so the top bucket
+    # out-earns the bottom bucket on every valid bar.
+    assert np.all(res.quantile_returns[valid, -1] > res.quantile_returns[valid, 0])
+    assert np.all(res.spread[valid] > 0.0)
+
+
+def test_perfect_foresight_ic_summary_mean_ic_is_one():
+    _, fwd = _gbm_panel()
+    factor = fwd.copy()
+    s = ic_summary(factor, fwd, method='spearman')
+    assert s['mean_ic'] == pytest.approx(1.0)
+    assert s['hit_rate'] == pytest.approx(1.0)
+    assert s['n_bars'] == 299  # last bar is all-NaN and dropped
+    assert isinstance(s['n_bars'], int)
+
+
+def test_perfect_foresight_ic_decay_is_one_at_horizon_one():
+    prices, fwd = _gbm_panel()
+    factor = fwd.copy()
+    decay = ic_decay(factor, prices, horizons=(1, 5, 10, 21))
+    assert decay.shape == (4,)
+    assert decay[0] == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# Noise factor: no signal
+# ---------------------------------------------------------------------------
+
+def test_noise_factor_has_no_signal():
+    rng = np.random.default_rng(7)
+    factor = rng.standard_normal((500, 30))
+    fwd = rng.standard_normal((500, 30))  # independent of factor
+    s = ic_summary(factor, fwd, method='spearman')
+    assert abs(s['mean_ic']) < 0.1
+    assert 0.35 <= s['hit_rate'] <= 0.65
+
+
+def test_ic_summary_empty_panel_returns_nan():
+    factor = np.full((5, 4), np.nan)
+    s = ic_summary(factor, factor)
+    assert s['n_bars'] == 0
+    assert np.isnan(s['mean_ic'])
+
+
+# ---------------------------------------------------------------------------
+# roll_information_coefficient
+# ---------------------------------------------------------------------------
+
+def test_roll_ic_1d_matches_slow_loop():
+    rng = np.random.default_rng(3)
+    pred = rng.standard_normal(200)
+    real = pred + 0.5 * rng.standard_normal(200)
+    w = 30
+    fast = roll_information_coefficient(pred, real, w=w, method='spearman')
+
+    slow = np.full(200, np.nan)
+    for t in range(w - 1, 200):
+        slow[t] = information_coefficient(
+            pred[t - w + 1:t + 1], real[t - w + 1:t + 1], method='spearman')
+
+    assert np.allclose(fast[w - 1:], slow[w - 1:], rtol=1e-10, atol=0.0)
+    assert np.all(np.isnan(fast[:w - 1]))
+
+
+def test_roll_ic_2d_has_nan_head():
+    rng = np.random.default_rng(4)
+    pred = rng.standard_normal((100, 10))
+    real = rng.standard_normal((100, 10))
+    w = 20
+    ic = roll_information_coefficient(pred, real, w=w)
+    assert ic.shape == (100,)
+    assert np.all(np.isnan(ic[:w - 1]))
+    assert np.all(np.isfinite(ic[w - 1:]))
+
+
+def test_roll_ic_is_causal():
+    # Perturbing a future bar must not change any earlier trailing-window IC.
+    rng = np.random.default_rng(5)
+    pred = rng.standard_normal(300)
+    real = pred + 0.3 * rng.standard_normal(300)
+    w = 40
+    before = roll_information_coefficient(pred, real, w=w)
+
+    t0 = 200
+    pred2 = pred.copy()
+    pred2[t0:] += 5.0  # corrupt the future only
+    after = roll_information_coefficient(pred2, real, w=w)
+
+    assert np.allclose(before[:t0], after[:t0], equal_nan=True)
+
+
+def test_roll_ic_rejects_bad_window():
+    with pytest.raises(ValueError):
+        roll_information_coefficient(np.arange(10.), np.arange(10.), w=0)
+
+
+# ---------------------------------------------------------------------------
+# ic_decay
+# ---------------------------------------------------------------------------
+
+def test_ic_decay_nan_for_horizon_longer_than_sample():
+    prices, fwd = _gbm_panel(T=30, N=8, seed=2)
+    factor = fwd.copy()
+    decay = ic_decay(factor, prices, horizons=(1, 100))
+    assert np.isfinite(decay[0])
+    assert np.isnan(decay[1])
+
+
+# ---------------------------------------------------------------------------
+# factor_rank_autocorr
+# ---------------------------------------------------------------------------
+
+def test_rank_autocorr_persistent_factor_is_one():
+    # A ranking that never changes has a rank autocorrelation of 1.
+    rng = np.random.default_rng(6)
+    base = rng.standard_normal(30)
+    factor = np.tile(base, (100, 1))
+    ac = factor_rank_autocorr(factor, lag=1)
+    assert np.isnan(ac[0])
+    assert np.allclose(ac[1:], 1.0)
+
+
+def test_rank_autocorr_independent_shuffles_is_zero():
+    # Independently reshuffling the cross-section each bar destroys persistence.
+    rng = np.random.default_rng(8)
+    base = np.arange(40.)
+    factor = np.array([rng.permutation(base) for _ in range(300)])
+    ac = factor_rank_autocorr(factor, lag=1)
+    assert abs(np.nanmean(ac[1:])) < 0.1
+
+
+def test_rank_autocorr_nan_when_too_few_valid():
+    factor = np.array([[1., 2., np.nan, np.nan],
+                       [1., 2., 3., 4.]])
+    ac = factor_rank_autocorr(factor, lag=1)
+    # Bar 1's predecessor (bar 0) has only two finite entries -> NaN.
+    assert np.isnan(ac[1])
+
+
+def test_rank_autocorr_rejects_bad_lag():
+    with pytest.raises(ValueError):
+        factor_rank_autocorr(np.zeros((5, 5)), lag=0)
+
+
+# ---------------------------------------------------------------------------
+# Top-level exposure
+# ---------------------------------------------------------------------------
+
+def test_factor_helpers_exposed_on_top_level_package():
+    assert fy.quantile_returns is quantile_returns
+    assert fy.roll_information_coefficient is roll_information_coefficient
+    assert fy.ic_decay is ic_decay
+    assert fy.ic_summary is ic_summary
+    assert fy.factor_rank_autocorr is factor_rank_autocorr
+    assert fy.QuantileResult is QuantileResult
+
+
+def test_factor_helpers_not_in_metrics_registry():
+    # The two-input factor helpers must not leak into the single-series METRICS
+    # registry that drives `summary`.
+    from fynance.metrics import METRICS
+    for name in ('quantile_returns', 'roll_information_coefficient',
+                 'ic_decay', 'ic_summary', 'factor_rank_autocorr'):
+        assert name not in METRICS

--- a/fynance/tests/plot/test_plot_factor.py
+++ b/fynance/tests/plot/test_plot_factor.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Headless tests for the factor tear-sheet figures. """
+
+# Third-party packages
+import matplotlib
+import numpy as np
+
+matplotlib.use("Agg")  # noqa: E402
+
+import matplotlib.pyplot as plt  # noqa: E402
+
+# Local packages
+from fynance.metrics import quantile_returns, roll_information_coefficient  # noqa: E402
+from fynance.plot import (  # noqa: E402
+    factor_tearsheet,
+    plot_ic_decay,
+    plot_ic_series,
+    plot_quantile_returns,
+)
+
+
+def _panel(T=250, N=20, seed=0):
+    """ Seeded GBM price panel and a trailing-return factor aligned to it. """
+    rng = np.random.default_rng(seed)
+    prices = 100. * np.cumprod(1. + rng.normal(0., 0.01, (T, N)), axis=0)
+    # A simple 21-bar trailing return as the factor (NaN head).
+    factor = np.full((T, N), np.nan)
+    factor[21:] = prices[21:] / prices[:-21] - 1.
+
+    return factor, prices
+
+
+def test_plot_quantile_returns_returns_axes():
+    factor, prices = _panel()
+    fwd = prices[1:] / prices[:-1] - 1.
+    res = quantile_returns(factor[:-1], fwd, n_quantiles=5)
+    ax = plot_quantile_returns(res)
+    assert ax is not None
+    # One line per quantile.
+    assert len(ax.get_lines()) == 5
+    plt.close("all")
+
+
+def test_plot_ic_series_returns_axes_with_overlay():
+    factor, prices = _panel()
+    fwd = prices[1:] / prices[:-1] - 1.
+    ic = roll_information_coefficient(factor[:-1], fwd, w=63)
+    ax = plot_ic_series(ic, w_smooth=21)
+    assert ax is not None
+    # Raw IC line + smoothed overlay both present (plus the zero reference).
+    labels = [ln.get_label() for ln in ax.get_lines()]
+    assert "IC" in labels
+    assert any(lab.startswith("IC (MA") for lab in labels)
+    plt.close("all")
+
+
+def test_plot_ic_decay_returns_axes():
+    decay = np.array([0.05, 0.03, 0.01, 0.0])
+    ax = plot_ic_decay(decay, horizons=(1, 5, 10, 21))
+    assert ax is not None
+    assert len(ax.patches) == 4  # one bar per horizon
+    plt.close("all")
+
+
+def test_factor_tearsheet_builds_2x2_grid():
+    factor, prices = _panel()
+    fig = factor_tearsheet(factor, prices)
+    assert len(fig.axes) == 4
+    plt.close(fig)
+
+
+def test_factor_tearsheet_save_writes_file(tmp_path):
+    factor, prices = _panel()
+    out = tmp_path / "factor.png"
+    fig = factor_tearsheet(factor, prices, save=str(out))
+    assert out.is_file()
+    assert out.stat().st_size > 0
+    plt.close(fig)
+
+
+def test_factor_tearsheet_respects_custom_grid_params():
+    factor, prices = _panel()
+    fig = factor_tearsheet(factor, prices, n_quantiles=3,
+                           horizons=(1, 5), w=40, figsize=(8, 5))
+    assert len(fig.axes) == 4
+    plt.close(fig)
+
+
+def test_import_fynance_plot_factor_stays_matplotlib_free():
+    import subprocess
+    import sys
+
+    code = ("import fynance.plot.factor, sys; "
+            "print('matplotlib' in sys.modules)")
+    out = subprocess.check_output([sys.executable, "-c", code], text=True)
+    assert out.strip() == "False"


### PR DESCRIPTION
## Summary
- `fynance.metrics.factor`: `quantile_returns` (per-bar equal-count bucketing → `QuantileResult` with per-quantile returns, top-minus-bottom spread, counts), `roll_information_coefficient` (1-D trailing IC / 2-D per-bar-then-trailing), `ic_decay` (via `horizon_returns`, non-overlapping), `ic_summary` (mean IC, ICIR, t-stat, hit rate), `factor_rank_autocorr` (turnover proxy).
- `fynance.plot.factor`: `plot_quantile_returns` / `plot_ic_series` / `plot_ic_decay` + composed 2×2 `factor_tearsheet` (lazy matplotlib, house tearsheet style).
- Alignment convention shared with `information_coefficient` (factor[t] vs fwd[t]); two-input functions deliberately NOT in the scalar METRICS registry (guarded by test).
- Leaf 03/06 of the `factor-research` epic (executed on opus).

## Verification (synthetic signal-free GBM panel, T=750, N=40, momentum factor)
Robust null correctly reported: mean IC −0.004, ICIR −0.024, t-stat −0.66, hit rate 0.489; decay ≈ 0 at all horizons; 4-panel tearsheet PNG rendered (160 KB). Perfect-foresight and noise-factor unit tests bound the two extremes.

## Changelog
Added under [Unreleased]: factor analysis suite. Epic ADR PR list updated.

## Test plan
- [x] `pytest` — passed (hand-checked buckets, perfect-foresight/noise bounds, IC parity vs slow loop, causality, Agg-backend plot tests)
- [x] `ruff` / `mypy` / interrogate / Sphinx -W
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)