### PR TITLE
feat: add purged walk-forward hyperparameter search (models.tuning)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Purged walk-forward hyperparameter search.** `walk_forward_search` in
+  `fynance.models.tuning`: grid/random search evaluated out-of-fold on the
+  purged walk-forward splitter, returning a `SearchResult` whose `n_trials`
+  feeds `deflated_sharpe_ratio` — trial accounting honest by construction.
+
 - **AFML labeling stack.** New `fynance.features.labels` module:
   `triple_barrier` (path-aware profit-take / stop-loss / vertical-barrier
   labels on a Numba scan, volatility-scaled barriers), `meta_labels`

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -72,6 +72,23 @@ Template:
 
 <!-- new entries below, newest first -->
 
+### 2026-07-06 — Anti-overfitting guards epic (PRs #249, epic)  [accepted]
+
+- **Choice**: complete the overfitting-guard triad as four parallel bricks —
+  purged walk-forward HP search (`models.tuning`, grid/random only) exposing
+  `n_trials` straight into `deflated_sharpe_ratio`; CSCV/PBO diagnostic
+  (`research.overfit`); block/stationary bootstrap (`research.bootstrap`,
+  dependence-preserving null as a drop-in analogue of `permutation_test`);
+  CPCV splitter in `data.split`.
+- **Why**: the guards module had permutation + DSR but nothing diagnosing
+  selection bias across a *family* of tried configs, and every HP sweep was
+  a hand-rolled leak-prone loop hiding its trial count; the iid permutation
+  null destroys autocorrelation.
+- **Rejected alternatives**: an optuna dependency (grid/random suffice; no
+  heavy dep); modifying `permutation_test` in place (the block variant is
+  additive, old semantics preserved); White's Reality Check / SPA (PBO is
+  the assumption-light standard and fits the Ledger data we already have).
+
 ### 2026-07-05 — Cross-sectional factor research epic (PRs #243–#248, epic)  [accepted]
 
 Gives fynance the *input half* of the factor workflow the v2.11 panel harness

--- a/doc/source/models.rst
+++ b/doc/source/models.rst
@@ -72,6 +72,12 @@ architectures.
 
       Walk-forward evaluation wrappers for time-series models.
 
+   .. grid-item-card:: :octicon:`checklist;1.2em;sd-mr-1` Purged walk-forward tuning
+      :link: models.tuning
+      :link-type: doc
+
+      Grid/random hyperparameter search scored on purged walk-forward folds.
+
 .. toctree::
    :maxdepth: 1
    :hidden:
@@ -86,3 +92,4 @@ architectures.
    models.tcn
    models.training
    models.transformer
+   models.tuning

--- a/doc/source/models.tuning.rst
+++ b/doc/source/models.tuning.rst
@@ -1,0 +1,16 @@
+******************************
+Purged walk-forward tuning
+******************************
+
+Grid/random hyperparameter search scored on purged walk-forward folds (see
+:mod:`fynance.data.split`), so configurations are compared out-of-sample only.
+The trial count feeds :func:`fynance.research.guards.deflated_sharpe_ratio` to
+deflate the winning configuration's Sharpe by the number of trials.
+
+.. currentmodule:: fynance.models.tuning
+
+.. autosummary::
+   :toctree: generated/
+
+   SearchResult
+   walk_forward_search

--- a/fynance/models/__init__.py
+++ b/fynance/models/__init__.py
@@ -20,6 +20,7 @@
     models.econometric_models
     models.rolling
     models.loss
+    models.tuning
 
 """
 
@@ -38,6 +39,7 @@ from . import (
     tcn,
     training,
     transformer,
+    tuning,
 )
 from ._base import BaseNeuralNet
 from .attention import MultiHeadAttention, ScaledDotProductAttention
@@ -62,6 +64,7 @@ from .rolling import CVResult, RollMultiLayerPerceptron, _RollingBasis
 from .tcn import TemporalConvNet
 from .training import EarlyStopping, exp_sample_weights
 from .transformer import PositionalEncoding, Transformer
+from .tuning import SearchResult, walk_forward_search
 
 # Frozen public surface for the 1.x series — names listed here are
 # guaranteed to remain importable from ``fynance.models`` until the
@@ -111,4 +114,7 @@ __all__ = [
     'OmegaLoss',
     'SharpeLoss',
     'SortinoLoss',
+    # tuning
+    'SearchResult',
+    'walk_forward_search',
 ]

--- a/fynance/models/tuning.py
+++ b/fynance/models/tuning.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Purged walk-forward hyperparameter search.
+
+Grid- or random-search over model hyperparameters, scored **out-of-sample**
+on :func:`fynance.data.split.walk_forward` folds (no lookahead, optional
+purge/embargo at each train/test boundary). This is the honest alternative to
+picking hyperparameters on a single in-sample fit: every configuration is
+scored on the same purged folds, and the number of configurations tried
+(``n_trials``) is tracked so it can be fed straight into
+:func:`fynance.research.guards.deflated_sharpe_ratio` to deflate the winning
+configuration's Sharpe by the multiple-testing cost of the search itself.
+
+"""
+
+from __future__ import annotations
+
+# Built-in packages
+import itertools
+from dataclasses import dataclass
+from typing import Any, Callable
+
+# Third-party packages
+import numpy as np
+from numpy.typing import NDArray
+
+# Local packages
+from fynance.data.split import walk_forward
+
+__all__ = ['SearchResult', 'walk_forward_search']
+
+
+def _neg_mse(y_true: NDArray, y_pred: NDArray) -> float:
+    """ Default metric: negative mean squared error (higher is better). """
+    y_true = np.asarray(y_true, dtype=np.float64)
+    y_pred = np.asarray(y_pred, dtype=np.float64)
+
+    return float(-np.mean((y_true - y_pred) ** 2))
+
+
+@dataclass
+class SearchResult:
+    """ Result of :func:`walk_forward_search`.
+
+    Attributes
+    ----------
+    table : numpy.ndarray
+        Out-of-sample scores, shape ``(n_configs, n_folds)`` -- row ``i``,
+        column ``j`` is the score of ``params[i]`` on fold ``j``.
+    params : list of dict
+        Parameter dict tried for each row of ``table`` (same order).
+    best_params : dict
+        The configuration with the highest mean OOS score (mean over folds).
+    best_model : Any
+        ``factory(**best_params)`` refit on the **last** (most recent) train
+        window -- the model to actually deploy.
+    n_trials : int
+        Number of configurations tried (``== len(params) == table.shape[0]``).
+        Feed this into :func:`fynance.research.guards.deflated_sharpe_ratio`
+        as ``n_trials`` so the winning configuration's Sharpe ratio is
+        deflated by the number of configurations the search tried, rather
+        than reported at face value.
+
+    """
+
+    table: NDArray
+    params: list[dict[str, Any]]
+    best_params: dict[str, Any]
+    best_model: Any
+    n_trials: int
+
+
+def walk_forward_search(
+    factory: Callable[..., Any],
+    param_grid: dict[str, list[Any]],
+    X: NDArray,
+    y: NDArray,
+    *,
+    train: int = 252,
+    test: int = 63,
+    step: int | None = None,
+    purge: int = 0,
+    metric: Callable[[NDArray, NDArray], float] | None = None,
+    n_iter: int | None = None,
+    seed: int = 0,
+) -> SearchResult:
+    r""" Purged walk-forward hyperparameter search.
+
+    Every configuration in ``param_grid`` is scored on the **same** purged
+    walk-forward folds (:func:`fynance.data.split.walk_forward`), so
+    configurations are compared honestly on out-of-sample data only -- no
+    configuration ever sees a fold's test window during its own fit.
+
+    Parameters
+    ----------
+    factory : callable
+        ``factory(**params)`` must return a **fresh** model exposing
+        ``fit(X, y)`` (returns the model, or ignored) and ``predict(X)``.
+    param_grid : dict of list
+        Maps parameter name to the list of candidate values. With ``n_iter``
+        ``None`` (default) the **full grid** is tried, in the deterministic
+        order of :func:`itertools.product` over ``param_grid.values()``
+        (insertion order of ``param_grid``'s keys). With ``n_iter`` set, a
+        size-``n_iter`` subsample of that same full grid is drawn without
+        replacement, seeded by ``seed``.
+    X, y : array_like
+        Full, time-ordered feature matrix and target, both of length ``n``
+        (the number of observations along axis 0).
+    train, test : int
+        Train and test window lengths forwarded to
+        :func:`~fynance.data.split.walk_forward`. Default 252/63 (roughly one
+        trading year / one quarter of daily bars).
+    step : int, optional
+        Roll step forwarded to :func:`~fynance.data.split.walk_forward`
+        (defaults to ``test``, i.e. non-overlapping test windows).
+    purge : int
+        Embargo forwarded to :func:`~fynance.data.split.walk_forward`
+        (observations dropped at the train/test boundary of every fold).
+    metric : callable, optional
+        ``metric(y_true, y_pred) -> float``, **higher is better**. Defaults
+        to negative mean squared error (``-mean((y_true - y_pred) ** 2)``),
+        so the default search maximizes prediction accuracy; pass a
+        Sharpe-like metric to search directly for OOS risk-adjusted return.
+    n_iter : int, optional
+        If given, draw this many configurations at random (without
+        replacement) from the full grid instead of trying every
+        configuration; capped at the full grid size. ``None`` (default)
+        tries the full grid.
+    seed : int
+        Seed for the ``n_iter`` random subsample. Ignored when ``n_iter`` is
+        ``None``. The same ``seed`` always draws the same subsample.
+
+    Returns
+    -------
+    SearchResult
+        See :class:`SearchResult`.
+
+    Raises
+    ------
+    ValueError
+        If ``param_grid`` is empty or any of its value lists is empty (there
+        would be nothing to search over), or if ``train + test`` exceeds the
+        number of observations in ``X`` (no walk-forward fold would ever be
+        produced, which would otherwise fail silently downstream with an
+        empty ``table``).
+
+    Examples
+    --------
+    A tiny closed-form ridge regression, searched over its regularization
+    strength; the data is (near) noiseless and linear, so the unregularized
+    fit (``alpha=0.0``) wins:
+
+    >>> import numpy as np
+    >>> from fynance.models.tuning import walk_forward_search
+    >>> class RidgeModel:
+    ...     ''' Closed-form ridge regression. '''
+    ...     def __init__(self, alpha=0.0):
+    ...         self.alpha = alpha
+    ...     def fit(self, X, y):
+    ...         n_features = X.shape[1]
+    ...         gram = X.T @ X + self.alpha * np.eye(n_features)
+    ...         self.coef_ = np.linalg.solve(gram, X.T @ y)
+    ...         return self
+    ...     def predict(self, X):
+    ...         return X @ self.coef_
+    >>> rng = np.random.default_rng(0)
+    >>> T, F = 400, 2
+    >>> X = rng.standard_normal((T, F))
+    >>> w_true = np.array([1.5, -0.5])
+    >>> y = X @ w_true + 0.01 * rng.standard_normal(T)
+    >>> result = walk_forward_search(
+    ...     RidgeModel, {"alpha": [0.0, 1.0, 10.0]}, X, y,
+    ...     train=200, test=50, step=50,
+    ... )
+    >>> result.table.shape
+    (3, 4)
+    >>> result.n_trials
+    3
+    >>> result.best_params
+    {'alpha': 0.0}
+    >>> pred = result.best_model.predict(X[:3])
+    >>> pred.shape
+    (3,)
+
+    The trial count plugs directly into the deflated Sharpe ratio, so the
+    winning configuration's Sharpe can be reported honestly rather than at
+    face value::
+
+        from fynance.research.guards import deflated_sharpe_ratio
+        dsr = deflated_sharpe_ratio(sr, n_obs, result.n_trials)
+
+    """
+    if not param_grid or any(len(v) == 0 for v in param_grid.values()):
+        raise ValueError(
+            "param_grid must be a non-empty dict of non-empty lists, got "
+            f"{param_grid!r}"
+        )
+
+    n = len(X)
+
+    if train + test > n:
+        raise ValueError(
+            f"train + test ({train + test}) exceeds the number of "
+            f"observations ({n}); no walk-forward fold would be produced"
+        )
+
+    keys = list(param_grid.keys())
+    all_combos = list(itertools.product(*(param_grid[k] for k in keys)))
+    all_params = [dict(zip(keys, combo)) for combo in all_combos]
+
+    if n_iter is None:
+        params = all_params
+    else:
+        rng = np.random.default_rng(seed)
+        n_draw = min(n_iter, len(all_params))
+        idx = rng.choice(len(all_params), size=n_draw, replace=False)
+        params = [all_params[i] for i in idx]
+
+    if metric is None:
+        metric = _neg_mse
+
+    folds = list(walk_forward(n, train, test, step=step, purge=purge))
+    n_folds = len(folds)
+
+    table = np.empty((len(params), n_folds), dtype=np.float64)
+    for i, p in enumerate(params):
+        for j, (train_idx, test_idx) in enumerate(folds):
+            model = factory(**p)
+            model.fit(X[train_idx], y[train_idx])
+            pred = model.predict(X[test_idx])
+            table[i, j] = metric(y[test_idx], pred)
+
+    mean_scores = table.mean(axis=1)
+    best_i = int(np.argmax(mean_scores))
+    best_params = params[best_i]
+
+    last_train_idx, _ = folds[-1]
+    best_model = factory(**best_params)
+    best_model.fit(X[last_train_idx], y[last_train_idx])
+
+    return SearchResult(
+        table=table,
+        params=params,
+        best_params=best_params,
+        best_model=best_model,
+        n_trials=len(params),
+    )

--- a/fynance/tests/models/test_tuning.py
+++ b/fynance/tests/models/test_tuning.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for purged walk-forward hyperparameter search (models.tuning). """
+
+# Built-in packages
+import itertools
+
+# Third-party packages
+import numpy as np
+import pytest
+
+# Local packages
+from fynance.models.tuning import SearchResult, walk_forward_search
+
+
+class RidgeModel:
+    """ Closed-form ridge regression: coef = (X^T X + alpha I)^-1 X^T y. """
+
+    def __init__(self, alpha=0.0):
+        self.alpha = alpha
+        self.coef_ = None
+
+    def fit(self, X, y):
+        n_features = X.shape[1]
+        gram = X.T @ X + self.alpha * np.eye(n_features)
+        self.coef_ = np.linalg.solve(gram, X.T @ y)
+        return self
+
+    def predict(self, X):
+        return X @ self.coef_
+
+
+def _linear_data(n=800, n_features=3, noise=0.01, seed=42):
+    """ Near-noiseless linear DGP: OLS (alpha=0) is the planted best config. """
+    rng = np.random.default_rng(seed)
+    X = rng.standard_normal((n, n_features))
+    w_true = np.array([1.0, -2.0, 0.5])
+    y = X @ w_true + noise * rng.standard_normal(n)
+    return X, y
+
+
+# ---------------------------------------------------------------------------
+# Planted best config
+# ---------------------------------------------------------------------------
+
+def test_recovers_planted_best_config():
+    X, y = _linear_data()
+    grid = {"alpha": [0.0, 0.01, 0.1, 1.0, 5.0, 10.0, 50.0, 100.0]}
+
+    result = walk_forward_search(RidgeModel, grid, X, y, train=252, test=63)
+
+    assert isinstance(result, SearchResult)
+    assert result.best_params == {"alpha": 0.0}
+
+
+def test_table_shape():
+    X, y = _linear_data()
+    grid = {"alpha": [0.0, 1.0, 10.0]}
+
+    result = walk_forward_search(RidgeModel, grid, X, y, train=252, test=63)
+
+    n_folds = 8  # (800 - 252) // 63 = 8 non-overlapping test windows
+    assert result.table.shape == (3, n_folds)
+
+
+def test_n_trials_matches_params():
+    X, y = _linear_data()
+    grid = {"alpha": [0.0, 1.0, 10.0, 100.0]}
+
+    result = walk_forward_search(RidgeModel, grid, X, y, train=252, test=63)
+
+    assert result.n_trials == len(result.params) == 4
+
+
+def test_best_model_is_fitted_and_predicts():
+    X, y = _linear_data()
+    grid = {"alpha": [0.0, 1.0]}
+
+    result = walk_forward_search(RidgeModel, grid, X, y, train=252, test=63)
+
+    assert result.best_model.coef_ is not None
+    pred = result.best_model.predict(X[:5])
+    assert pred.shape == (5,)
+
+
+# ---------------------------------------------------------------------------
+# n_iter random subsampling
+# ---------------------------------------------------------------------------
+
+def test_n_iter_subsample_is_deterministic_per_seed():
+    X, y = _linear_data()
+    grid = {"alpha": [0.0, 0.01, 0.1, 1.0, 5.0, 10.0, 50.0, 100.0]}
+
+    r1 = walk_forward_search(
+        RidgeModel, grid, X, y, train=252, test=63, n_iter=4, seed=7,
+    )
+    r2 = walk_forward_search(
+        RidgeModel, grid, X, y, train=252, test=63, n_iter=4, seed=7,
+    )
+
+    assert r1.params == r2.params
+    assert r1.n_trials == 4
+
+
+def test_n_iter_subsample_is_subset_of_full_grid():
+    X, y = _linear_data()
+    grid = {"alpha": [0.0, 0.01, 0.1, 1.0, 5.0, 10.0, 50.0, 100.0]}
+
+    result = walk_forward_search(
+        RidgeModel, grid, X, y, train=252, test=63, n_iter=3, seed=1,
+    )
+
+    full = [
+        dict(zip(grid.keys(), combo))
+        for combo in itertools.product(*grid.values())
+    ]
+    assert len(result.params) == 3
+    assert all(p in full for p in result.params)
+
+
+def test_n_iter_different_seed_can_change_subsample():
+    X, y = _linear_data()
+    grid = {"alpha": [0.0, 0.01, 0.1, 1.0, 5.0, 10.0, 50.0, 100.0]}
+
+    r1 = walk_forward_search(
+        RidgeModel, grid, X, y, train=252, test=63, n_iter=3, seed=0,
+    )
+    r2 = walk_forward_search(
+        RidgeModel, grid, X, y, train=252, test=63, n_iter=3, seed=123,
+    )
+
+    assert r1.params != r2.params
+
+
+# ---------------------------------------------------------------------------
+# ValueError paths
+# ---------------------------------------------------------------------------
+
+def test_rejects_empty_value_list():
+    X, y = _linear_data()
+
+    with pytest.raises(ValueError, match="param_grid"):
+        walk_forward_search(RidgeModel, {"alpha": []}, X, y)
+
+
+def test_rejects_empty_grid_dict():
+    X, y = _linear_data()
+
+    with pytest.raises(ValueError, match="param_grid"):
+        walk_forward_search(RidgeModel, {}, X, y)
+
+
+def test_rejects_train_plus_test_exceeding_n():
+    X, y = _linear_data(n=100)
+
+    with pytest.raises(ValueError, match="train \\+ test"):
+        walk_forward_search(
+            RidgeModel, {"alpha": [0.0]}, X, y, train=80, test=30,
+        )


### PR DESCRIPTION
## Summary
- New `fynance.models.tuning`: `walk_forward_search(factory, param_grid, X, y, ...)` — grid or seeded random search, every config scored out-of-fold on `data.split.walk_forward` (purge forwarded), one fresh model per fold.
- `SearchResult` carries the (n_configs, n_folds) score table, `best_params`, the refit `best_model`, and `n_trials` — designed to feed `research.guards.deflated_sharpe_ratio` so the winning config's Sharpe is deflated honestly.
- No optuna dependency. Leaf 01/04 of the `anti-overfitting` epic (new epic ADR entry).

## Verification (synthetic linear DGP, 12-config ridge grid, 8 folds)
best_params recovers the planted truth (alpha=0; scores degrade monotonically to alpha=100); refit coefficients [0.999, −2.001, 0.500] vs true [1, −2, 0.5]; DSR smoke: same Sharpe deflated with n_trials=12 → 0.000 vs n_trials=1 → 0.653.

## Test plan
- [x] `pytest` — 1260 passed (10 new tests + doctest)
- [x] `ruff` / `mypy` / interrogate 94.8% / Sphinx -W
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)