### PR TITLE
feat: add combinatorial purged cross-validation splitter (data.split)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Combinatorial purged cross-validation.** `combinatorial_purged_cv` in
+  `fynance.data.split`: every C(n_groups, n_test_groups) group combination
+  becomes an out-of-sample path, with purge windows around test-group
+  boundaries and post-test embargo (AFML) — many OOS paths instead of one.
 - **Purged walk-forward hyperparameter search.** `walk_forward_search` in
   `fynance.models.tuning`: grid/random search evaluated out-of-fold on the
   purged walk-forward splitter, returning a `SearchResult` whose `n_trials`

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -72,7 +72,7 @@ Template:
 
 <!-- new entries below, newest first -->
 
-### 2026-07-06 — Anti-overfitting guards epic (PRs #249, epic)  [accepted]
+### 2026-07-06 — Anti-overfitting guards epic (PRs #249–#250, epic)  [accepted]
 
 - **Choice**: complete the overfitting-guard triad as four parallel bricks —
   purged walk-forward HP search (`models.tuning`, grid/random only) exposing

--- a/doc/source/data.rst
+++ b/doc/source/data.rst
@@ -17,6 +17,7 @@ alignment/resampling, and no-lookahead temporal splits.
    resample
    train_test_split
    walk_forward
+   combinatorial_purged_cv
 
 Custom sources
 ==============

--- a/fynance/data/__init__.py
+++ b/fynance/data/__init__.py
@@ -7,8 +7,8 @@
 
 The only I/O boundary of the library. File adapters turn local CSV/Parquet into
 :class:`~fynance.core.PriceSeries`; :func:`align`/:func:`resample` reconcile
-multiple series; :func:`train_test_split`/:func:`walk_forward` build no-lookahead
-evaluation indices.
+multiple series; :func:`train_test_split`/:func:`walk_forward`/
+:func:`combinatorial_purged_cv` build no-lookahead evaluation indices.
 
 """
 
@@ -17,7 +17,7 @@ from .align import align, resample
 from .base import BaseDataSource, get_source, load, register
 from .csv import CSVSource
 from .parquet import ParquetSource
-from .split import train_test_split, walk_forward
+from .split import combinatorial_purged_cv, train_test_split, walk_forward
 
 __all__ = [
     'BaseDataSource',
@@ -30,4 +30,5 @@ __all__ = [
     'resample',
     'train_test_split',
     'walk_forward',
+    'combinatorial_purged_cv',
 ]

--- a/fynance/data/split.py
+++ b/fynance/data/split.py
@@ -3,9 +3,11 @@
 
 """ Strictly time-ordered splits for ML evaluation.
 
-No shuffling, ever. Provides a simple train/test split with an optional embargo
-and a purged walk-forward window generator. These are pure index generators,
-decoupled from any model (mirroring the walk-forward semantics of
+No shuffling, ever. Provides a simple train/test split with an optional embargo,
+a purged walk-forward window generator, and a combinatorial purged
+cross-validation (CPCV) splitter that yields many purged/embargoed train/test
+folds instead of a single path. These are pure index generators, decoupled from
+any model (mirroring the walk-forward semantics of
 :class:`fynance.models.rolling._RollingBasis`).
 
 """
@@ -13,13 +15,14 @@ decoupled from any model (mirroring the walk-forward semantics of
 from __future__ import annotations
 
 # Built-in packages
+import itertools
 from typing import Iterator
 
 # Third-party packages
 import numpy as np
 from numpy.typing import NDArray
 
-__all__ = ['train_test_split', 'walk_forward']
+__all__ = ['train_test_split', 'walk_forward', 'combinatorial_purged_cv']
 
 
 def train_test_split(
@@ -146,3 +149,124 @@ def walk_forward(
         yield train_idx, test_idx
 
         t += step
+
+
+def combinatorial_purged_cv(
+    T: int,
+    n_groups: int = 6,
+    n_test_groups: int = 2,
+    purge: int = 0,
+    embargo: int = 0,
+) -> Iterator[tuple[NDArray[np.int64], NDArray[np.int64]]]:
+    """ Generate combinatorial purged cross-validation (CPCV) folds.
+
+    A single walk-forward path (or a plain purged K-fold) gives exactly one
+    out-of-sample (OOS) performance estimate, so its variance from the
+    particular split chosen is never measured -- a lucky or unlucky path looks
+    identical to a robust one. CPCV instead splits ``[0, T)`` into
+    ``n_groups`` contiguous groups and, for **every** combination of
+    ``n_test_groups`` groups held out as test, purges/embargoes the remainder
+    and yields it as one train/test fold. That produces
+    ``n_splits = math.comb(n_groups, n_test_groups)`` folds -- versus the
+    single path of :func:`walk_forward` -- whose paths can be reassembled into
+    many distinct OOS return series, turning one backtest into a distribution
+    of OOS Sharpe ratios (and letting one estimate the probability of backtest
+    overfitting, PBO).
+
+    Parameters
+    ----------
+    T : int
+        Number of observations.
+    n_groups : int, optional
+        Number of contiguous groups to split ``[0, T)`` into (sizes as equal
+        as possible; any remainder bars go to the first groups, i.e. the same
+        convention as :func:`numpy.array_split`). Default 6.
+    n_test_groups : int, optional
+        Number of groups held out as test in each fold. Default 2.
+    purge : int, optional
+        Number of bars removed from train on **both sides** of every test
+        group's boundary (immediately before its start and immediately after
+        its end), so that no train observation straddles a test boundary.
+        Default 0.
+    embargo : int, optional
+        Number of bars *additionally* removed from train immediately after
+        each test group's end (beyond ``purge``), to absorb serial
+        correlation that would otherwise leak test information forward into
+        a subsequent train block. Default 0.
+
+    Yields
+    ------
+    (train_idx, test_idx) : tuple of numpy.ndarray
+        Sorted, unique ``int64`` index arrays, same convention as
+        :func:`walk_forward`. ``test_idx`` is the union of the chosen test
+        groups; ``train_idx`` is every other index minus the purge/embargo
+        windows.
+
+    Raises
+    ------
+    ValueError
+        If ``n_test_groups`` is not strictly between ``0`` and ``n_groups``,
+        or if ``n_groups`` exceeds ``T`` (a group would then be empty).
+
+    Notes
+    -----
+    Combinations are generated in the deterministic order of
+    :func:`itertools.combinations` applied to ``range(n_groups)``. By a
+    standard counting argument, each of the ``n_groups`` groups appears in
+    the test set of exactly ``math.comb(n_groups - 1, n_test_groups - 1)`` of
+    the ``math.comb(n_groups, n_test_groups)`` folds.
+
+    Examples
+    --------
+    >>> import math
+    >>> folds = list(combinatorial_purged_cv(12, n_groups=4, n_test_groups=1, purge=1))
+    >>> len(folds) == math.comb(4, 1)
+    True
+    >>> train_idx, test_idx = folds[0]
+    >>> test_idx
+    array([0, 1, 2])
+    >>> train_idx  # bar 3 purged (1 bar after the test group's end)
+    array([ 4,  5,  6,  7,  8,  9, 10, 11])
+
+    See Also
+    --------
+    train_test_split, walk_forward
+
+    References
+    ----------
+    .. [1] Lopez de Prado, M. (2018). *Advances in Financial Machine
+       Learning*. Wiley. Chapter 7, "Cross-Validation in Finance".
+
+    """
+    if not (0 < n_test_groups < n_groups):
+
+        raise ValueError(
+            "n_test_groups must satisfy 0 < n_test_groups < n_groups, got "
+            f"n_test_groups={n_test_groups}, n_groups={n_groups}"
+        )
+
+    if n_groups > T:
+
+        raise ValueError(f"n_groups ({n_groups}) exceeds T ({T})")
+
+    sizes = np.full(n_groups, T // n_groups, dtype=np.int64)
+    sizes[: T % n_groups] += 1
+    bounds = np.concatenate(([0], np.cumsum(sizes)))
+    starts, ends = bounds[:-1], bounds[1:]
+
+    for combo in itertools.combinations(range(n_groups), n_test_groups):
+        test_mask = np.zeros(T, dtype=bool)
+        excl_mask = np.zeros(T, dtype=bool)
+
+        for g in combo:
+            s, e = int(starts[g]), int(ends[g])
+            test_mask[s:e] = True
+            excl_mask[max(0, s - purge):s] = True
+            excl_mask[e:min(T, e + purge)] = True
+            excl_mask[e:min(T, e + embargo)] = True
+
+        train_mask = ~test_mask & ~excl_mask
+        train_idx = np.nonzero(train_mask)[0].astype(np.int64)
+        test_idx = np.nonzero(test_mask)[0].astype(np.int64)
+
+        yield train_idx, test_idx

--- a/fynance/tests/data/test_split.py
+++ b/fynance/tests/data/test_split.py
@@ -3,12 +3,15 @@
 
 """ Tests for time-ordered splits (no lookahead). """
 
+# Built-in packages
+import math
+
 # Third-party packages
 import numpy as np
 import pytest
 
 # Local packages
-from fynance.data import train_test_split, walk_forward
+from fynance.data import combinatorial_purged_cv, train_test_split, walk_forward
 
 
 def test_train_test_split_fraction():
@@ -97,3 +100,98 @@ def test_walk_forward_rejects_nonpositive_step():
         next(walk_forward(5, train=2, test=1, step=0))
     with pytest.raises(ValueError, match="step"):
         next(walk_forward(5, train=2, test=1, step=-1))
+
+
+# --------------------------------------------------------------------------- #
+#   combinatorial_purged_cv                                                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_cpcv_split_count():
+    folds = list(combinatorial_purged_cv(100, n_groups=6, n_test_groups=2))
+    assert len(folds) == math.comb(6, 2)
+
+
+def test_cpcv_each_group_appears_comb_times():
+    n_groups, n_test_groups = 6, 2
+    folds = list(combinatorial_purged_cv(120, n_groups=n_groups, n_test_groups=n_test_groups))
+
+    # sizes as equal as possible -> 120 / 6 = 20 per group, so group g owns
+    # indices [20*g, 20*g + 20).
+    group_size = 120 // n_groups
+    counts = np.zeros(n_groups, dtype=np.int64)
+    for _, test_idx in folds:
+        groups_in_test = {int(i) // group_size for i in test_idx}
+        assert len(groups_in_test) == n_test_groups  # groups are never split
+        for g in groups_in_test:
+            counts[g] += 1
+
+    assert np.all(counts == math.comb(n_groups - 1, n_test_groups - 1))
+
+
+def test_cpcv_train_test_disjoint():
+    for train_idx, test_idx in combinatorial_purged_cv(100, n_groups=6, n_test_groups=2, purge=3, embargo=2):
+        assert len(set(train_idx.tolist()) & set(test_idx.tolist())) == 0
+
+
+def test_cpcv_purge_removes_boundary_bars():
+    # Hand-checked: T=20, 4 groups (size 5 each) -> group 1 = [5, 10). With
+    # purge=2, train drops bars {3, 4} just before and {10, 11} just after.
+    folds = list(combinatorial_purged_cv(20, n_groups=4, n_test_groups=1, purge=2))
+    train_idx, test_idx = folds[1]  # combo (1,) -> test group [5, 10)
+    assert test_idx.tolist() == [5, 6, 7, 8, 9]
+    assert train_idx.tolist() == [0, 1, 2, 12, 13, 14, 15, 16, 17, 18, 19]
+    assert 3 not in train_idx and 4 not in train_idx
+    assert 10 not in train_idx and 11 not in train_idx
+
+
+def test_cpcv_embargo_removes_post_test_bars():
+    # Same layout, purge=0 this time: only the embargo trims the 2 bars
+    # {10, 11} immediately after the test group's end; nothing before it.
+    folds = list(combinatorial_purged_cv(20, n_groups=4, n_test_groups=1, purge=0, embargo=2))
+    train_idx, test_idx = folds[1]
+    assert test_idx.tolist() == [5, 6, 7, 8, 9]
+    assert train_idx.tolist() == [0, 1, 2, 3, 4, 12, 13, 14, 15, 16, 17, 18, 19]
+    assert 10 not in train_idx and 11 not in train_idx
+
+
+def test_cpcv_indices_in_range_sorted_unique():
+    for train_idx, test_idx in combinatorial_purged_cv(50, n_groups=5, n_test_groups=2, purge=2, embargo=1):
+        for idx in (train_idx, test_idx):
+            assert idx.dtype == np.int64
+            assert np.all(idx >= 0) and np.all(idx < 50)
+            assert np.all(np.diff(idx) > 0)  # strictly increasing -> sorted & unique
+
+
+def test_cpcv_rejects_bad_n_test_groups():
+    with pytest.raises(ValueError, match="n_test_groups"):
+        list(combinatorial_purged_cv(50, n_groups=5, n_test_groups=0))
+    with pytest.raises(ValueError, match="n_test_groups"):
+        list(combinatorial_purged_cv(50, n_groups=5, n_test_groups=5))
+    with pytest.raises(ValueError, match="n_test_groups"):
+        list(combinatorial_purged_cv(50, n_groups=5, n_test_groups=6))
+
+
+def test_cpcv_rejects_n_groups_over_T():
+    with pytest.raises(ValueError, match="n_groups"):
+        list(combinatorial_purged_cv(4, n_groups=5, n_test_groups=1))
+
+
+@pytest.mark.parametrize("h", [0, 3])
+def test_cpcv_purge_no_train_within_h_of_test_boundary(h):
+    # Property: with purge >= h, no train index lies within h bars before a
+    # test block start or after a test block end (no embargo confound: 0).
+    T, n_groups, n_test_groups = 60, 6, 2
+    group_size = T // n_groups
+    for train_idx, test_idx in combinatorial_purged_cv(
+        T, n_groups=n_groups, n_test_groups=n_test_groups, purge=h, embargo=0,
+    ):
+        # Recover contiguous test blocks' [start, end) boundaries from test_idx.
+        test_groups = sorted({int(i) // group_size for i in test_idx})
+        boundaries = [(g * group_size, (g + 1) * group_size) for g in test_groups]
+
+        train_set = set(train_idx.tolist())
+        for start, end in boundaries:
+            for offset in range(1, h + 1):
+                assert start - offset not in train_set
+                assert end + offset - 1 not in train_set


### PR DESCRIPTION
## Summary
- `combinatorial_purged_cv(T, n_groups=6, n_test_groups=2, purge=0, embargo=0)` in `fynance.data.split`: contiguous groups, every C(n, k) combination yields a (train_idx, test_idx) pair with purge on both sides of each test-group boundary and post-test embargo — same conventions as `walk_forward`.
- Leaf 04/04-numbered of the `anti-overfitting` epic.

## Verification (T=1000, 6 choose 2, purge=5, embargo=3)
15 splits; train sizes 646–663; boundary neighborhoods show exact 5-bar purge before test starts and max(purge, embargo) gap after test ends; hand-checked doctest case T=12/4 groups/purge=1.

## Test plan
- [x] `pytest` — 1260 passed (split-count, per-group appearance count comb(n−1,k−1), disjointness, purge/embargo hand checks, h∈{0,3} no-lookahead property)
- [x] `ruff` / `mypy` / interrogate / Sphinx -W
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)