### PR TITLE
feat: add CSCV probability-of-backtest-overfitting diagnostic (research.overfit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Probability of backtest overfitting.** `pbo` in
+  `fynance.research.overfit`: CSCV diagnostic over a `(T, n_configs)`
+  returns panel (rank logits, `prob_oos_loss`, IS→OOS degradation slope),
+  plus `returns_panel()` to build the input from `Experiment` objects.
 - **Combinatorial purged cross-validation.** `combinatorial_purged_cv` in
   `fynance.data.split`: every C(n_groups, n_test_groups) group combination
   becomes an out-of-sample path, with purge windows around test-group

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -72,7 +72,7 @@ Template:
 
 <!-- new entries below, newest first -->
 
-### 2026-07-06 — Anti-overfitting guards epic (PRs #249–#250, epic)  [accepted]
+### 2026-07-06 — Anti-overfitting guards epic (PRs #249–#251, epic)  [accepted]
 
 - **Choice**: complete the overfitting-guard triad as four parallel bricks —
   purged walk-forward HP search (`models.tuning`, grid/random only) exposing

--- a/doc/source/research.rst
+++ b/doc/source/research.rst
@@ -23,5 +23,8 @@ adapters live downstream.
    deflated_sharpe_ratio
    ImportanceResult
    walk_forward_mda
+   PBOResult
+   pbo
+   returns_panel
    gbm
    regime_switching

--- a/fynance/research/__init__.py
+++ b/fynance/research/__init__.py
@@ -21,6 +21,7 @@ from . import (
     guards,
     importance,
     ledger,
+    overfit,
     report,
     runner,
     synthetic,
@@ -30,6 +31,7 @@ from .experiment import *
 from .guards import *
 from .importance import *
 from .ledger import *
+from .overfit import *
 from .report import *
 from .runner import *
 from .synthetic import *
@@ -41,5 +43,6 @@ __all__ += runner.__all__
 __all__ += report.__all__
 __all__ += guards.__all__
 __all__ += importance.__all__
+__all__ += overfit.__all__
 __all__ += compare.__all__
 __all__ += ledger.__all__

--- a/fynance/research/overfit.py
+++ b/fynance/research/overfit.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Combinatorially symmetric cross-validation (CSCV) overfitting guard.
+
+Complements :mod:`fynance.research.guards`: where the permutation test and
+the (deflated) Sharpe ratio ask *"is this one strategy's edge real?"*, the
+**probability of backtest overfitting** (PBO) asks *"across everything I
+tried, did I just pick the best-in-sample fluke?"*. It implements the CSCV
+procedure of Bailey, Borwein, Lopez de Prado & Zhu, "The probability of
+backtest overfitting", Journal of Computational Finance (2015): split the
+track record into blocks, replay every balanced in-sample/out-of-sample split,
+and measure how often the in-sample winner turns out to be an out-of-sample
+laggard.
+
+All functions are data-agnostic and pure numpy; nothing here reads real data
+or stores results.
+
+"""
+
+# Built-in
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from itertools import combinations
+from typing import Callable
+
+# Third-party
+import numpy as np
+from numpy.typing import NDArray
+
+# Local
+from fynance.research.experiment import Experiment
+
+__all__ = ['PBOResult', 'pbo', 'returns_panel']
+
+# CSCV enumerates C(n_blocks, n_blocks / 2) IS/OOS splits; this is the value
+# at the recommended n_blocks=16 ceiling (Bailey et al. run 16 blocks in their
+# reference examples) — beyond it the combinatorics explode silently.
+_MAX_COMBINATIONS = 12870
+
+
+def returns_panel(experiments: list[Experiment]) -> NDArray[np.float64]:
+    """ Build a ``(T, n_configs)`` returns panel from research experiments.
+
+    One column per :class:`~fynance.research.Experiment`, taken from its
+    stored ``series["returns"]`` (the per-period net returns
+    :func:`~fynance.research.run_experiment` records). When an experiment
+    carries only ``series["equity"]`` (e.g. a hand-built record), the column
+    is derived as the equity curve's percentage change, ``R_t = E_t / E_{t-1}
+    - 1`` for ``t = 1..T-1`` — one observation shorter than the equity curve,
+    since the first equity point has no preceding value to return from.
+
+    Parameters
+    ----------
+    experiments : list of Experiment
+        The configurations to stack into a panel (>= 1).
+
+    Returns
+    -------
+    numpy.ndarray, shape (T, n_configs)
+        Per-period returns, one config per column.
+
+    Raises
+    ------
+    ValueError
+        If ``experiments`` is empty, an experiment carries neither a
+        ``"returns"`` nor an ``"equity"`` series (or an equity curve too
+        short to derive a return from), or the resulting columns have
+        mismatched lengths.
+
+    Examples
+    --------
+    >>> from fynance.research import Experiment, returns_panel
+    >>> a = Experiment(name="a", series={"returns": [0.01, -0.02, 0.03]})
+    >>> b = Experiment(name="b", series={"equity": [100.0, 101.0, 99.0, 102.0]})
+    >>> returns_panel([a, b]).shape
+    (3, 2)
+
+    """
+    if not experiments:
+        raise ValueError("returns_panel needs at least one experiment")
+
+    columns: list[NDArray[np.float64]] = []
+    for exp in experiments:
+        series = exp.series or {}
+        if series.get("returns") is not None:
+            col = np.asarray(series["returns"], dtype=np.float64)
+        elif series.get("equity") is not None:
+            equity = np.asarray(series["equity"], dtype=np.float64)
+            if equity.shape[0] < 2:
+                raise ValueError(
+                    f"experiment {exp.name!r} equity curve is too short "
+                    f"({equity.shape[0]} point(s)) to derive returns from"
+                )
+            col = equity[1:] / equity[:-1] - 1.0
+        else:
+            raise ValueError(
+                f"experiment {exp.name!r} carries neither a 'returns' nor an "
+                f"'equity' series"
+            )
+        columns.append(col)
+
+    lengths = {col.shape[0] for col in columns}
+    if len(lengths) > 1:
+        details = {exp.name: col.shape[0] for exp, col in zip(experiments, columns)}
+        raise ValueError(
+            f"experiments have mismatched curve lengths, cannot form a panel: "
+            f"{details}"
+        )
+
+    return np.column_stack(columns)
+
+
+def _default_metric(returns: NDArray[np.float64]) -> float:
+    """ Annualization-free Sharpe: mean over std of the per-period returns.
+
+    Deliberately does not annualize by a ``period`` (CSCV only compares
+    in-sample vs. out-of-sample *ranks* across configs, so a constant scale
+    factor cancels) and does not assume ``returns`` is a price/equity curve
+    the way :func:`fynance.metrics.sharpe` does — here it is already the
+    per-period return series of one config's block-concatenated stretch.
+    """
+    if returns.size < 2:
+        return 0.0
+
+    std = float(np.std(returns, ddof=1))
+    if std == 0.0:
+        # Degenerate (constant) stretch: no dispersion to divide by. Return a
+        # large, finite, sign-carrying value rather than 0 or inf so a
+        # genuinely constant-positive stretch still outranks noisy ones
+        # without poisoning downstream arithmetic (OLS, rank ties) with inf.
+        mean = float(np.mean(returns))
+        return 0.0 if mean == 0.0 else math.copysign(1.0e6, mean)
+
+    return float(np.mean(returns)) / std
+
+
+def _rankdata_average(x: NDArray[np.float64]) -> NDArray[np.float64]:
+    """ Ascending, 1-indexed ranks with ties averaged (pure-numpy).
+
+    A minimal analogue of ``scipy.stats.rankdata(x, method="average")`` —
+    written locally to avoid adding a ``scipy.stats`` dependency for a single
+    small helper on arrays sized ``n_configs``.
+    """
+    order = np.argsort(x, kind="mergesort")
+    sorted_x = x[order]
+    ranks = np.empty(x.shape[0], dtype=np.float64)
+    n = x.shape[0]
+    i = 0
+    while i < n:
+        j = i
+        while j + 1 < n and sorted_x[j + 1] == sorted_x[i]:
+            j += 1
+        # Ranks i+1..j+1 (1-indexed) tied -> their average.
+        ranks[order[i:j + 1]] = (i + j) / 2.0 + 1.0
+        i = j + 1
+
+    return ranks
+
+
+def _ols(x: NDArray[np.float64], y: NDArray[np.float64]) -> tuple[float, float]:
+    """ OLS slope/intercept of ``y`` on ``x``; flat line if ``x`` has no spread. """
+    x_mean, y_mean = float(np.mean(x)), float(np.mean(y))
+    var_x = float(np.sum((x - x_mean) ** 2))
+    if var_x == 0.0:
+        return 0.0, y_mean
+
+    slope = float(np.sum((x - x_mean) * (y - y_mean)) / var_x)
+
+    return slope, y_mean - slope * x_mean
+
+
+@dataclass
+class PBOResult:
+    """ Result of a :func:`pbo` run.
+
+    Attributes
+    ----------
+    pbo : float
+        Probability of backtest overfitting: the share of IS/OOS splits
+        where the in-sample winner's out-of-sample relative rank falls at or
+        below the median (``logit <= 0``).
+    logits : numpy.ndarray, shape (n_combinations,)
+        Rank logit ``ln(r / (1 - r))`` of the IS winner's OOS performance,
+        one per split.
+    prob_oos_loss : float
+        Share of splits where the IS winner's OOS performance is negative.
+    slope : float
+        OLS slope of OOS performance on IS performance (of the IS winner)
+        across splits — a robust-performing selection procedure has a
+        positive slope; near-zero or negative indicates the IS ranking
+        carries no out-of-sample information.
+    intercept : float
+        OLS intercept of the same regression.
+    is_perf : numpy.ndarray, shape (n_combinations,)
+        The IS winner's own in-sample metric value, one per split.
+    oos_perf : numpy.ndarray, shape (n_combinations,)
+        The IS winner's out-of-sample metric value, one per split.
+
+    """
+
+    pbo: float
+    logits: NDArray[np.float64]
+    prob_oos_loss: float
+    slope: float
+    intercept: float
+    is_perf: NDArray[np.float64]
+    oos_perf: NDArray[np.float64]
+
+
+def pbo(
+    returns_panel: NDArray[np.float64],
+    n_blocks: int = 16,
+    metric: Callable[[NDArray[np.float64]], float] | None = None,
+) -> PBOResult:
+    r""" Probability of backtest overfitting via combinatorially symmetric CV.
+
+    Implements the CSCV procedure of Bailey, Borwein, Lopez de Prado & Zhu
+    (2015): split the ``T`` periods into ``n_blocks`` contiguous blocks; for
+    every way to assign half the blocks to an in-sample (IS) half and the
+    other half to the complementary out-of-sample (OOS) half
+    (:math:`\binom{n\_blocks}{n\_blocks / 2}` splits total), pick the config
+    that scores best on the IS half by ``metric``, then locate that same
+    config's OOS-half performance among *all* configs' OOS performances as a
+    relative rank :math:`r \in (0, 1)` (average-tie rank divided by
+    ``n_configs + 1``, so the best OOS config sits close to 1 and the worst
+    close to 0). The rank logit is :math:`\lambda = \ln(r / (1 - r))`; ``pbo``
+    is the share of splits with :math:`\lambda \le 0`, i.e. where the
+    in-sample winner performs at or below the OOS median — a config search
+    that overfits systematically sends the IS winner to the bottom half OOS.
+
+    Parameters
+    ----------
+    returns_panel : numpy.ndarray, shape (T, n_configs)
+        Per-period returns, one column per configuration tried (see
+        :func:`returns_panel` to build this from
+        :class:`~fynance.research.Experiment` runs).
+    n_blocks : int
+        Number of contiguous blocks to split ``T`` into. Must be even (a
+        balanced IS/OOS split) and no greater than 16 — beyond that
+        :math:`\binom{n\_blocks}{n\_blocks/2}` exceeds 12,870 splits.
+    metric : callable, optional
+        ``metric(returns) -> float`` scoring a 1-D per-period return stretch,
+        higher is better. Defaults to an annualization-free Sharpe (mean over
+        std of the returns) — deliberately not :func:`fynance.metrics.sharpe`,
+        which assumes a price/equity curve rather than a returns series.
+
+    Returns
+    -------
+    PBOResult
+        The overfitting diagnostics (see :class:`PBOResult`).
+
+    Raises
+    ------
+    ValueError
+        If ``returns_panel`` is not 2-D, ``n_blocks`` is odd, ``n_blocks``
+        implies more than 12,870 IS/OOS splits, or ``T < n_blocks``.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from fynance.research import pbo
+    >>> rng = np.random.default_rng(0)
+    >>> panel = rng.normal(0.0, 0.01, size=(400, 8))  # pure noise, no edge
+    >>> result = pbo(panel, n_blocks=8)
+    >>> 0.0 <= result.pbo <= 1.0
+    True
+    >>> result.logits.shape
+    (70,)
+
+    """
+    panel = np.asarray(returns_panel, dtype=np.float64)
+    if panel.ndim != 2:
+        raise ValueError(
+            f"returns_panel must be 2-D (T, n_configs); got ndim={panel.ndim}"
+        )
+
+    n_periods, n_configs = panel.shape
+    if n_blocks % 2 != 0:
+        raise ValueError(f"n_blocks must be even for a balanced split; got {n_blocks}")
+
+    half = n_blocks // 2
+    n_combinations = math.comb(n_blocks, half)
+    if n_combinations > _MAX_COMBINATIONS:
+        raise ValueError(
+            f"n_blocks={n_blocks} implies C({n_blocks}, {half})={n_combinations} "
+            f"IS/OOS splits (> {_MAX_COMBINATIONS}, i.e. n_blocks > 16) — lower "
+            f"n_blocks"
+        )
+
+    if n_periods < n_blocks:
+        raise ValueError(
+            f"returns_panel has T={n_periods} periods, fewer than n_blocks="
+            f"{n_blocks}"
+        )
+
+    fn = metric if metric is not None else _default_metric
+    blocks = np.array_split(np.arange(n_periods), n_blocks)
+    all_blocks = set(range(n_blocks))
+
+    logits = np.empty(n_combinations, dtype=np.float64)
+    is_perf = np.empty(n_combinations, dtype=np.float64)
+    oos_perf = np.empty(n_combinations, dtype=np.float64)
+
+    for k, is_combo in enumerate(combinations(range(n_blocks), half)):
+        oos_combo = sorted(all_blocks - set(is_combo))
+        is_idx = np.concatenate([blocks[b] for b in is_combo])
+        oos_idx = np.concatenate([blocks[b] for b in oos_combo])
+
+        is_metrics = np.array(
+            [fn(panel[is_idx, c]) for c in range(n_configs)], dtype=np.float64
+        )
+        winner = int(np.argmax(is_metrics))
+
+        oos_metrics = np.array(
+            [fn(panel[oos_idx, c]) for c in range(n_configs)], dtype=np.float64
+        )
+
+        is_perf[k] = is_metrics[winner]
+        oos_perf[k] = oos_metrics[winner]
+
+        ranks = _rankdata_average(oos_metrics)
+        r = ranks[winner] / (n_configs + 1)
+        logits[k] = np.log(r / (1.0 - r))
+
+    slope, intercept = _ols(is_perf, oos_perf)
+
+    return PBOResult(
+        pbo=float(np.mean(logits <= 0.0)),
+        logits=logits,
+        prob_oos_loss=float(np.mean(oos_perf < 0.0)),
+        slope=slope,
+        intercept=intercept,
+        is_perf=is_perf,
+        oos_perf=oos_perf,
+    )

--- a/fynance/tests/research/test_overfit.py
+++ b/fynance/tests/research/test_overfit.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Tests for :mod:`fynance.research.overfit` (CSCV / probability of backtest
+overfitting).
+
+"""
+
+# Built-in
+import math
+
+# Third-party
+import numpy as np
+import pytest
+
+# Local
+from fynance.research import Experiment, gbm, pbo, returns_panel, run_experiment
+from fynance.strategy import Strategy
+
+# -- returns_panel -----------------------------------------------------------
+
+def test_returns_panel_prefers_returns_series():
+    a = Experiment(name="a", series={"returns": [0.01, -0.02, 0.03]})
+    b = Experiment(name="b", series={"returns": [0.02, 0.0, -0.01]})
+
+    panel = returns_panel([a, b])
+
+    assert panel.shape == (3, 2)
+    np.testing.assert_allclose(panel[:, 0], [0.01, -0.02, 0.03])
+    np.testing.assert_allclose(panel[:, 1], [0.02, 0.0, -0.01])
+
+
+def test_returns_panel_falls_back_to_equity_pct_change():
+    a = Experiment(name="a", series={"equity": [100.0, 101.0, 99.0, 102.0]})
+
+    panel = returns_panel([a])
+
+    assert panel.shape == (3, 1)
+    expected = np.array([101.0 / 100.0, 99.0 / 101.0, 102.0 / 99.0]) - 1.0
+    np.testing.assert_allclose(panel[:, 0], expected)
+
+
+def test_returns_panel_from_real_experiments():
+    # Integration with the actual harness: run_experiment always populates both
+    # 'equity' and 'returns', so a real Experiment feeds straight into the panel.
+    strat = Strategy(features=lambda p: np.diff(p, prepend=p[0]))
+    exps = [
+        run_experiment(strat, gbm(300, seed=s), name=f"run-{s}", seed=s)
+        for s in range(4)
+    ]
+
+    panel = returns_panel(exps)
+
+    assert panel.shape == (299, 4)
+    assert np.all(np.isfinite(panel))
+
+
+def test_returns_panel_empty_raises():
+    with pytest.raises(ValueError, match="at least one experiment"):
+        returns_panel([])
+
+
+def test_returns_panel_missing_series_raises():
+    with pytest.raises(ValueError, match="neither a 'returns' nor an 'equity'"):
+        returns_panel([Experiment(name="a")])
+
+
+def test_returns_panel_short_equity_raises():
+    with pytest.raises(ValueError, match="too short"):
+        returns_panel([Experiment(name="a", series={"equity": [100.0]})])
+
+
+def test_returns_panel_length_mismatch_raises():
+    a = Experiment(name="a", series={"returns": [0.01, -0.02, 0.03]})
+    b = Experiment(name="b", series={"returns": [0.01, -0.02]})
+
+    with pytest.raises(ValueError, match="mismatched curve lengths"):
+        returns_panel([a, b])
+
+
+# -- pbo: shape / determinism -------------------------------------------------
+
+def test_logits_length_matches_binomial_coefficient():
+    rng = np.random.default_rng(0)
+    panel = rng.normal(0.0, 0.01, size=(160, 6))
+
+    result = pbo(panel, n_blocks=8)
+
+    assert result.logits.shape == (math.comb(8, 4),)
+    assert result.is_perf.shape == (math.comb(8, 4),)
+    assert result.oos_perf.shape == (math.comb(8, 4),)
+
+
+# -- pbo: statistical behaviour -----------------------------------------------
+
+def test_pure_noise_panel_gives_pbo_near_half():
+    # Pure noise, no config has a real edge: the IS winner should be an OOS
+    # coin flip, so pbo should sit close to (but not required to equal) 0.5.
+    rng = np.random.default_rng(0)
+    panel = rng.normal(0.0, 0.01, size=(200, 20))
+
+    result = pbo(panel, n_blocks=16)
+
+    assert 0.35 <= result.pbo <= 0.65
+
+
+def test_dominant_config_lowers_pbo_and_oos_loss():
+    rng = np.random.default_rng(0)
+    sigma = 0.01
+    panel = rng.normal(0.0, sigma, size=(200, 20))
+    noise_pbo = pbo(panel, n_blocks=16).pbo
+
+    # A clearly dominant edge on one config: a per-period mean shift of 1
+    # sigma is a large, unambiguous edge relative to the noise columns (whose
+    # population mean is 0), so it should win in-sample AND hold up
+    # out-of-sample almost every split.
+    dominant = panel.copy()
+    dominant[:, 0] += sigma
+    result = pbo(dominant, n_blocks=16)
+
+    assert result.pbo < noise_pbo
+    assert result.prob_oos_loss < 0.05
+
+
+def test_adversarial_construction_gives_high_pbo():
+    # Block-alternating mean sign per config: each config performs well on
+    # even blocks and poorly on odd blocks, or vice versa, depending on its
+    # fixed rank. Whichever half of the blocks dominates the IS combination,
+    # the complementary OOS half is dominated by the *other* parity almost
+    # always (its blocks are the fixed-size complement of the IS blocks per
+    # parity class) -- so the IS winner systematically becomes an OOS loser.
+    seed = 42
+    n_blocks, periods_per_block, n_configs = 16, 25, 12
+    amplitude, sigma = 0.05, 0.01
+    rank_signal = np.linspace(-1.0, 1.0, n_configs)
+
+    rng = np.random.default_rng(seed)
+    panel = np.empty((n_blocks * periods_per_block, n_configs))
+    for b in range(n_blocks):
+        parity = 1.0 if b % 2 == 0 else -1.0
+        sl = slice(b * periods_per_block, (b + 1) * periods_per_block)
+        panel[sl, :] = amplitude * parity * rank_signal[None, :]
+    panel += rng.normal(0.0, sigma, size=panel.shape)
+
+    result = pbo(panel, n_blocks=n_blocks)
+
+    assert result.pbo > 0.7
+
+
+def test_custom_metric_is_used():
+    # Flipping the ranking direction (favor the lowest-mean config instead of
+    # the highest) must change which config wins each split, and so the
+    # resulting logits -- proof the callable actually drives the selection
+    # rather than being ignored in favor of the default metric.
+    rng = np.random.default_rng(3)
+    panel = rng.normal(0.0, 0.01, size=(160, 6))
+
+    calls = []
+
+    def _spy_inverted_metric(returns):
+        calls.append(returns.shape[0])
+        return -float(np.mean(returns))
+
+    default_result = pbo(panel, n_blocks=8)
+    inverted_result = pbo(panel, n_blocks=8, metric=_spy_inverted_metric)
+
+    # Called for both IS and OOS halves, for every config, every split.
+    assert len(calls) == math.comb(8, 4) * 2 * 6
+    assert not np.allclose(default_result.logits, inverted_result.logits)
+
+
+# -- pbo: validation -----------------------------------------------------------
+
+def test_odd_n_blocks_raises():
+    panel = np.zeros((100, 5))
+    with pytest.raises(ValueError, match="even"):
+        pbo(panel, n_blocks=15)
+
+
+def test_too_many_blocks_raises():
+    panel = np.zeros((100, 5))
+    with pytest.raises(ValueError, match="n_blocks > 16"):
+        pbo(panel, n_blocks=18)
+
+
+def test_n_blocks_of_16_is_allowed():
+    rng = np.random.default_rng(0)
+    panel = rng.normal(0.0, 0.01, size=(64, 4))
+    result = pbo(panel, n_blocks=16)
+    assert result.logits.shape == (math.comb(16, 8),)
+
+
+def test_too_few_periods_raises():
+    panel = np.zeros((10, 5))
+    with pytest.raises(ValueError, match="fewer than n_blocks"):
+        pbo(panel, n_blocks=16)
+
+
+def test_1d_panel_raises():
+    panel = np.zeros(100)
+    with pytest.raises(ValueError, match="must be 2-D"):
+        pbo(panel, n_blocks=8)


### PR DESCRIPTION
## Summary
- `pbo(returns_panel, n_blocks=16)` — Combinatorially Symmetric Cross-Validation (Bailey/López de Prado 2015): every C(n, n/2) IS/OOS half-split ranks the IS winner out-of-sample; returns `PBOResult` (pbo, rank logits, prob_oos_loss, IS→OOS degradation OLS).
- `returns_panel(experiments)` builds the `(T, n_configs)` input from Ledger `Experiment` objects (returns preferred, equity fallback).
- Leaf 02/04 of the `anti-overfitting` epic — completes the guard triad with #249/#250.

## Verification (24-config noise panel, T=500, 12 870 splits)
Noise: pbo 0.570, prob_oos_loss 0.547. Same panel + one +1σ-edge config: pbo 0.000, prob_oos_loss 0.000 — the diagnostic discriminates cleanly.

## Test plan
- [x] `pytest` — 1268 passed (17 new tests: noise/dominant/adversarial constructions, Experiment integration, error paths)
- [x] `ruff` / `mypy` / interrogate / Sphinx -W
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)