### PR TITLE
feat: add tail-risk metrics (VaR/CVaR/CDaR, rolling variants, tail dependence)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Tail-risk metrics.** New `fynance.metrics.risk`: `var` / `cvar`
+  (historical, Gaussian, Cornish-Fisher), `cdar` (mean of the α worst
+  drawdowns), causal `roll_var`/`roll_cvar`, and pairwise lower-tail
+  `tail_dependence` on `(T, N)` panels; scalar metrics registered in
+  `summary()`.
 - **Benchmark-relative metrics.** New `fynance.metrics.benchmark`:
   `beta`, `alpha` (annualized Jensen), `tracking_error`,
   `information_ratio`, up/down `capture_ratio`, `benchmark_summary` and

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -72,7 +72,7 @@ Template:
 
 <!-- new entries below, newest first -->
 
-### 2026-07-06 — Metrics & trade analytics epic (PRs #253, epic)  [accepted]
+### 2026-07-06 — Metrics & trade analytics epic (PRs #253–#254, epic)  [accepted]
 
 - **Choice**: four additive metric families — benchmark-relative two-curve
   metrics (`metrics.benchmark`, kept OUT of the scalar `METRICS` registry:

--- a/doc/source/metrics.rst
+++ b/doc/source/metrics.rst
@@ -34,6 +34,23 @@ Drawdown
    drawdown
    mdd
 
+Tail risk
+=========
+
+Value-at-Risk, Conditional Value-at-Risk (Expected Shortfall) and Conditional
+Drawdown-at-Risk. Like the ratios above, ``var``/``cvar``/``cdar`` take a
+price/equity curve (returns are derived internally); ``tail_dependence`` is the
+exception — it takes a ``(T, N)`` returns panel directly, mirroring
+:func:`information_coefficient`'s pair convention.
+
+.. autosummary::
+   :toctree: generated/
+
+   var
+   cvar
+   cdar
+   tail_dependence
+
 Rolling versions
 ================
 
@@ -46,6 +63,8 @@ Rolling versions
    roll_annual_volatility
    roll_drawdown
    roll_mdd
+   roll_var
+   roll_cvar
 
 Benchmark-relative
 ==================
@@ -97,7 +116,8 @@ Aggregated report
 
 :func:`summary` is driven by the ``METRICS`` registry — a name → callable
 mapping (``annual_return``, ``annual_volatility``, ``sharpe``, ``sortino``,
-``calmar``, ``max_drawdown``) you can read or extend.
+``calmar``, ``max_drawdown``, ``var``, ``cvar``, ``cdar``) you can read or
+extend.
 
 .. autodata:: METRICS
    :no-value:

--- a/fynance/metrics/__init__.py
+++ b/fynance/metrics/__init__.py
@@ -22,6 +22,7 @@ from .factor import *
 from .ratios import *
 from .returns import *
 from .returns import perf_strat, returns_strat  # noqa: F401
+from .risk import *
 from .summary import METRICS, summary  # noqa: F401
 from .trading import *
 
@@ -30,17 +31,20 @@ from .trading import *
 # ``information_coefficient``, the factor-analysis helpers (``quantile_returns``,
 # ``roll_information_coefficient``, ``ic_decay``, ``ic_summary``,
 # ``factor_rank_autocorr``), the trade-profile metrics (``sign_changes`` /
-# ``trades_per_year``) and the benchmark-relative metrics (``beta``, ``alpha``,
+# ``trades_per_year``), the benchmark-relative metrics (``beta``, ``alpha``,
 # ``tracking_error``, ``information_ratio``, ``capture_ratio``,
-# ``benchmark_summary``, ``roll_beta_benchmark``) are exported here but
-# intentionally NOT added to the ``METRICS`` registry: that registry maps a name
-# to a callable taking a single equity/price curve (see ``summary``), whereas
-# the IC and factor helpers take an aligned (pred, real) / (factor, fwd) pair,
-# the trade-profile metrics take a position series, and the benchmark metrics
-# take an aligned (strategy, benchmark) pair, so none fit that single-series
-# contract.
+# ``benchmark_summary``, ``roll_beta_benchmark``) and ``tail_dependence`` are
+# exported here but intentionally NOT added to the ``METRICS`` registry: that
+# registry maps a name to a callable taking a single equity/price curve (see
+# ``summary``), whereas the IC and factor helpers take an aligned
+# (pred, real) / (factor, fwd) pair, the trade-profile metrics take a position
+# series, the benchmark metrics take an aligned (strategy, benchmark) pair,
+# and ``tail_dependence`` takes a ``(T, N)`` returns panel, so none fit that
+# single-series contract. ``var``/``cvar``/``cdar`` (from ``risk``) do fit it
+# and are registered (see ``summary.METRICS``); their rolling variants
+# (``roll_var``/``roll_cvar``) are not, same as ``roll_sharpe``/``roll_calmar``.
 __all__ = []
-for _m in ("benchmark", "correlation", "returns", "ratios", "drawdown", "factor", "trading"):
+for _m in ("benchmark", "correlation", "returns", "ratios", "drawdown", "factor", "risk", "trading"):
     __all__ += _sys.modules[f"{__name__}.{_m}"].__all__
 __all__ += ['perf_strat', 'returns_strat', 'METRICS', 'summary']
 

--- a/fynance/metrics/risk.py
+++ b/fynance/metrics/risk.py
@@ -1,0 +1,663 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tail-risk metrics — Value-at-Risk, Conditional VaR (Expected Shortfall),
+Conditional Drawdown-at-Risk and a pairwise lower-tail dependence estimator.
+
+Like :mod:`fynance.metrics.ratios`, ``var``/``cvar``/``cdar`` (and their rolling
+variants) take a single equity/price curve and derive returns internally, so
+they slot into the :data:`~fynance.metrics.summary.METRICS` registry alongside
+``sharpe``/``sortino``/``calmar``. Unlike those ratios, the returns used here
+are the *un-padded* per-period returns (see :func:`_returns_from_prices`): a
+quantile or moment estimator must not see the placeholder zero return that
+:func:`~fynance.features._metrics_helpers._compute_returns` prepends for the
+unobserved period before ``X[0]``, or the tail estimate would be biased.
+``tail_dependence`` is the one exception — it scores co-exceedance of two
+series and so takes a ``(T, N)`` **returns panel** directly, mirroring
+:func:`fynance.metrics.information_coefficient`'s (pred, real)-pair convention
+rather than the single-curve one.
+
+"""
+
+from __future__ import annotations
+
+# Built-in packages
+from functools import lru_cache
+
+# Third-party packages
+import numpy as np
+from numba import njit
+from numpy.typing import NDArray
+from scipy.stats import norm
+
+# Local packages
+from fynance.features._metrics_helpers import _drawdown
+
+__all__ = ['var', 'cvar', 'cdar', 'roll_var', 'roll_cvar', 'tail_dependence']
+
+_METHODS = ('historical', 'gaussian', 'cornish_fisher')
+_CF_GRID_SIZE = 5000
+
+
+def _check_alpha(alpha: float) -> None:
+    if not (0. < alpha < 1.):
+
+        raise ValueError(f"alpha must be in (0, 1), got {alpha!r}")
+
+
+def _check_method(method: str) -> None:
+    if method not in _METHODS:
+
+        raise ValueError(f"unknown method {method!r}, must be one of {_METHODS}")
+
+
+def _returns_from_prices(X: NDArray) -> NDArray:
+    """ Per-period returns of a 1-D price curve, ``R[i] = X[i+1] / X[i] - 1``.
+
+    Deliberately **not** :func:`~fynance.features._metrics_helpers._compute_returns`
+    (used by :func:`~fynance.metrics.sharpe` / :func:`~fynance.metrics.annual_volatility`):
+    that helper prepends a placeholder ``R[0] = 0`` for the unobserved period
+    before ``X[0]`` so the output keeps length ``T`` — harmless for a mean/std
+    over a long series, but a fabricated zero return would bias a quantile or a
+    skew/kurtosis estimate, especially on short samples. Tail-risk estimators
+    use only the ``T - 1`` really observed returns.
+    """
+    X = np.asarray(X, dtype=np.float64)
+
+    return X[1:] / X[:-1] - 1.
+
+
+def _tail_k(alpha: float, n: int) -> int:
+    """ Number of tail observations for confidence level ``alpha`` over ``n`` obs.
+
+    ``k = max(1, floor(alpha * n))``: a deterministic count (no interpolation
+    between two observations), so the ``k``-th smallest value is always an
+    actually realized observation — the standard historical-simulation
+    convention, and what keeps :func:`tail_dependence` symmetric (see there).
+    """
+    return max(1, int(np.floor(alpha * n)))
+
+
+def _moments(R: NDArray) -> tuple[float, float, float, float]:
+    """ Mean, population std, skewness and excess kurtosis of ``R``. """
+    mu = float(np.mean(R))
+    sigma = float(np.std(R))
+
+    if sigma > 0.:
+        z = (R - mu) / sigma
+        skew = float(np.mean(z ** 3))
+        kurt = float(np.mean(z ** 4) - 3.)
+    else:
+        skew = 0.
+        kurt = 0.
+
+    return mu, sigma, skew, kurt
+
+
+def _cf_quantile(z, skew, kurt):
+    """ Cornish-Fisher adjusted quantile (Favre & Galeano 2002), elementwise. """
+    return (
+        z + (z ** 2 - 1.) * skew / 6. + (z ** 3 - 3. * z) * kurt / 24.
+        - (2. * z ** 3 - 5. * z) * skew ** 2 / 36.
+    )
+
+
+@lru_cache(maxsize=32)
+def _cf_tail_constants(alpha: float, n_grid: int = _CF_GRID_SIZE) -> tuple[float, float, float, float]:
+    """ Fixed coefficients (c1, c2, c3, c4) of the Cornish-Fisher tail mean.
+
+    The Cornish-Fisher CVaR is defined as the tail mean of the CF-adjusted
+    quantile function over the tail probability ``p in (0, alpha]``:
+
+    .. math::
+
+        CVaR_{CF} = -\\frac{1}{\\alpha}\\int_0^{\\alpha}
+        \\left(\\mu + \\sigma \\, z_{CF}(p)\\right) dp
+
+    Since ``z_CF(p) = z(p) + (z(p)^2-1) s/6 + (z(p)^3-3z(p)) k/24 -
+    (2z(p)^3-5z(p)) s^2/36`` is *linear* in ``(s, k, s^2)`` for a fixed grid of
+    ``z(p) = Phi^{-1}(p)``, the integral collapses to four constants — depending
+    only on ``alpha`` and the grid, not on the sample — so both :func:`cvar` and
+    :func:`roll_cvar` reduce to a cheap closed-form combination
+    ``c1 + c2*skew + c3*kurt + c4*skew**2`` instead of a per-window numerical
+    integration. Approximated by a fine midpoint grid on ``(0, alpha]``
+    (``n_grid`` points); accurate to ~3e-4 relative error at the default size
+    against the closed-form Gaussian limit (``skew = kurt = 0``).
+    """
+    p = np.linspace(alpha / n_grid, alpha, n_grid)
+    z = norm.ppf(p)
+    c1 = float(np.mean(z))
+    c2 = float(np.mean(z ** 2 - 1.) / 6.)
+    c3 = float(np.mean(z ** 3 - 3. * z) / 24.)
+    c4 = float(-np.mean(2. * z ** 3 - 5. * z) / 36.)
+
+    return c1, c2, c3, c4
+
+
+# --------------------------------------------------------------------------- #
+#   numba rolling kernels                                                     #
+# --------------------------------------------------------------------------- #
+
+
+@njit(cache=True)
+def _roll_window_moments_1d(R, w):
+    """ Rolling mean/std/skew/excess-kurtosis of ``R`` over trailing window ``w``.
+
+    NaN before the window is full (``t < w - 1``).
+    """
+    n = R.shape[0]
+    mean = np.full(n, np.nan)
+    std = np.full(n, np.nan)
+    skew = np.full(n, np.nan)
+    kurt = np.full(n, np.nan)
+
+    for t in range(w - 1, n):
+        m = 0.0
+        for i in range(t - w + 1, t + 1):
+            m += R[i]
+        m /= w
+
+        v = 0.0
+        m3 = 0.0
+        m4 = 0.0
+        for i in range(t - w + 1, t + 1):
+            d = R[i] - m
+            v += d * d
+            m3 += d ** 3
+            m4 += d ** 4
+        v /= w
+        m3 /= w
+        m4 /= w
+
+        s = np.sqrt(v)
+        mean[t] = m
+        std[t] = s
+
+        if s > 0.0:
+            skew[t] = m3 / s ** 3
+            kurt[t] = m4 / s ** 4 - 3.0
+        else:
+            skew[t] = 0.0
+            kurt[t] = 0.0
+
+    return mean, std, skew, kurt
+
+
+@njit(cache=True)
+def _roll_hist_quantile_1d(R, w, alpha):
+    """ Rolling ``k``-th smallest return of ``R`` over trailing window ``w``. """
+    n = R.shape[0]
+    out = np.full(n, np.nan)
+    k = max(1, int(np.floor(alpha * w)))
+
+    for t in range(w - 1, n):
+        window = np.sort(R[t - w + 1: t + 1])
+        out[t] = window[k - 1]
+
+    return out
+
+
+@njit(cache=True)
+def _roll_hist_tail_mean_1d(R, w, alpha):
+    """ Rolling mean of the ``k`` smallest returns of ``R`` over window ``w``. """
+    n = R.shape[0]
+    out = np.full(n, np.nan)
+    k = max(1, int(np.floor(alpha * w)))
+
+    for t in range(w - 1, n):
+        window = np.sort(R[t - w + 1: t + 1])
+        s = 0.0
+        for i in range(k):
+            s += window[i]
+        out[t] = s / k
+
+    return out
+
+
+# --------------------------------------------------------------------------- #
+#   public API                                                                #
+# --------------------------------------------------------------------------- #
+
+
+def var(X: NDArray, alpha: float = 0.05, method: str = 'historical') -> float:
+    r""" Value-at-Risk of a price/equity curve's per-period returns.
+
+    The loss quantile at confidence level ``1 - alpha``: with probability
+    ``alpha``, a period's return falls below ``-VaR``. Reported as a **positive**
+    number (the magnitude of the loss quantile), following the usual risk-desk
+    convention.
+
+    Notes
+    -----
+    Let :math:`R` be the per-period returns of ``X`` (see
+    :func:`_returns_from_prices`) and :math:`n` their count.
+
+    - ``method='historical'``: the empirical quantile, taken as the ``k``-th
+      smallest observed return (:func:`_tail_k`, ``k = max(1, floor(alpha n))``)
+      — an actually realized scenario, no interpolation between two
+      observations.
+    - ``method='gaussian'``: :math:`VaR = -(\mu + \sigma z_\alpha)` with
+      :math:`z_\alpha = \Phi^{-1}(\alpha)` the standard normal quantile,
+      :math:`\mu, \sigma` the sample mean/std of :math:`R`.
+    - ``method='cornish_fisher'``: as ``'gaussian'`` but with :math:`z_\alpha`
+      replaced by the Cornish-Fisher expansion [1]_ that corrects for sample
+      skewness :math:`s` and excess kurtosis :math:`k`:
+
+      .. math::
+
+          z_{CF} = z + \frac{z^2 - 1}{6}s + \frac{z^3 - 3z}{24}k
+          - \frac{2z^3 - 5z}{36}s^2
+
+      Reduces to the Gaussian quantile when :math:`s = k = 0`.
+
+    Parameters
+    ----------
+    X : array_like
+        Time-series of price, performance or index (a single curve).
+    alpha : float, optional
+        Tail probability, in ``(0, 1)``. Default is 0.05 (95% VaR).
+    method : {'historical', 'gaussian', 'cornish_fisher'}, optional
+        Estimation method. Default is 'historical'.
+
+    Returns
+    -------
+    float
+        Value-at-Risk, positive for a typical loss-bearing distribution.
+
+    References
+    ----------
+    .. [1] Favre, L., and Galeano, J.-A., 2002, Mean-Modified Value-at-Risk
+       Optimization with Hedge Funds, Journal of Alternative Investments.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> X = np.array([100., 99., 103., 95., 101., 98., 104., 90., 108., 97.,
+    ...                102.])
+    >>> round(var(X, alpha=0.2, method='historical'), 4)
+    0.1019
+    >>> round(var(X, alpha=0.2, method='gaussian'), 4)
+    0.0723
+
+    See Also
+    --------
+    cvar, cdar, roll_var, tail_dependence
+
+    """
+    _check_alpha(alpha)
+    _check_method(method)
+    R = _returns_from_prices(X)
+
+    if method == 'historical':
+        k = _tail_k(alpha, R.shape[0])
+        q = np.sort(R)[k - 1]
+    elif method == 'gaussian':
+        mu, sigma, _, _ = _moments(R)
+        q = mu + sigma * norm.ppf(alpha)
+    else:
+        mu, sigma, skew, kurt = _moments(R)
+        q = mu + sigma * _cf_quantile(norm.ppf(alpha), skew, kurt)
+
+    return float(-q)
+
+
+def cvar(X: NDArray, alpha: float = 0.05, method: str = 'historical') -> float:
+    r""" Conditional Value-at-Risk (Expected Shortfall) of a price/equity curve.
+
+    The expected loss *beyond* the VaR threshold — the mean of the returns in
+    the ``alpha``-tail — a coherent risk measure (unlike VaR, which is not
+    subadditive). Reported as a **positive** number, same convention as
+    :func:`var`.
+
+    Notes
+    -----
+    Let :math:`R` be the per-period returns of ``X`` (see
+    :func:`_returns_from_prices`), :math:`n` their count and :math:`\mu,\sigma`
+    their sample mean/std.
+
+    - ``method='historical'``: mean of the ``k = max(1, floor(alpha n))``
+      smallest observed returns (:func:`_tail_k`) — the tail mean underlying
+      :func:`var`'s historical quantile.
+    - ``method='gaussian'``: closed form [2]_
+      :math:`CVaR = -\mu + \sigma \frac{\varphi(z_\alpha)}{\alpha}`, with
+      :math:`\varphi` the standard normal pdf and :math:`z_\alpha =
+      \Phi^{-1}(\alpha)`.
+    - ``method='cornish_fisher'``: the tail mean of the Cornish-Fisher [1]_
+      -adjusted quantile function over :math:`p \in (0, \alpha]`,
+
+      .. math::
+
+          CVaR_{CF} = -\frac{1}{\alpha}\int_0^{\alpha}
+          \left(\mu + \sigma \, z_{CF}(p)\right) dp
+
+      approximated on a fixed probability grid (see
+      :func:`_cf_tail_constants`); collapses to the same value as
+      ``'gaussian'`` when sample skewness and excess kurtosis are both zero.
+
+    Parameters
+    ----------
+    X : array_like
+        Time-series of price, performance or index (a single curve).
+    alpha : float, optional
+        Tail probability, in ``(0, 1)``. Default is 0.05.
+    method : {'historical', 'gaussian', 'cornish_fisher'}, optional
+        Estimation method. Default is 'historical'.
+
+    Returns
+    -------
+    float
+        Conditional Value-at-Risk, positive for a typical loss-bearing
+        distribution. Always :math:`\geq` :func:`var` at the same ``alpha``.
+
+    References
+    ----------
+    .. [1] Favre, L., and Galeano, J.-A., 2002, Mean-Modified Value-at-Risk
+       Optimization with Hedge Funds, Journal of Alternative Investments.
+    .. [2] Rockafellar, R.T., and Uryasev, S., 2000, Optimization of
+       Conditional Value-at-Risk, Journal of Risk, 2, 21-42.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> X = np.array([100., 99., 103., 95., 101., 98., 104., 90., 108., 97.,
+    ...                102.])
+    >>> round(cvar(X, alpha=0.2, method='historical'), 4)
+    0.1182
+    >>> cvar(X, alpha=0.2, method='historical') >= var(X, alpha=0.2, method='historical')
+    True
+
+    See Also
+    --------
+    var, cdar, roll_cvar, tail_dependence
+
+    """
+    _check_alpha(alpha)
+    _check_method(method)
+    R = _returns_from_prices(X)
+
+    if method == 'historical':
+        k = _tail_k(alpha, R.shape[0])
+        raw = float(np.mean(np.sort(R)[:k]))
+    elif method == 'gaussian':
+        mu, sigma, _, _ = _moments(R)
+        z = norm.ppf(alpha)
+        raw = mu - sigma * norm.pdf(z) / alpha
+    else:
+        mu, sigma, skew, kurt = _moments(R)
+        c1, c2, c3, c4 = _cf_tail_constants(alpha)
+        raw = mu + sigma * (c1 + c2 * skew + c3 * kurt + c4 * skew ** 2)
+
+    return float(-raw)
+
+
+def cdar(X: NDArray, alpha: float = 0.05) -> float:
+    r""" Conditional Drawdown-at-Risk of a price/equity curve.
+
+    Mean of the ``alpha`` worst drawdown depths [3]_ observed over the series —
+    the drawdown analogue of :func:`cvar`: while :func:`~fynance.metrics.mdd`
+    reports only the single worst drawdown, CDaR averages the whole worst tail,
+    making it less sensitive to a single outlier path.
+
+    Notes
+    -----
+    Let :math:`DD` be the percentage drawdown path of ``X`` (see
+    :func:`~fynance.metrics.drawdown`) and :math:`T` its length:
+
+    .. math::
+
+        CDaR_\alpha = \frac{1}{k}\sum_{i=1}^{k} DD_{(T + 1 - i)}
+
+    where :math:`DD_{(1)} \leq \dots \leq DD_{(T)}` is :math:`DD` sorted
+    ascending and :math:`k = \max(1, \lfloor \alpha T \rfloor)`
+    (:func:`_tail_k`) — the same tail-count convention as :func:`var`/:func:`cvar`.
+
+    Parameters
+    ----------
+    X : array_like
+        Time-series of price, performance or index (a single curve). Must be
+        positive values (see :func:`~fynance.metrics.drawdown`).
+    alpha : float, optional
+        Tail fraction, in ``(0, 1)``. Default is 0.05.
+
+    Returns
+    -------
+    float
+        Conditional Drawdown-at-Risk, in ``[0, 1]``. Always :math:`\geq`
+        :func:`~fynance.metrics.mdd` divided by 1 (it is a tail *mean*, so
+        :math:`\leq` the maximum drawdown).
+
+    References
+    ----------
+    .. [3] Chekhlov, A., Uryasev, S., and Zabarankin, M., 2005, Drawdown
+       Measure in Portfolio Optimization, International Journal of Theoretical
+       and Applied Finance, 8(1), 13-58.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> X = np.array([100., 90., 95., 80., 110., 70., 120., 60., 130.])
+    >>> round(cdar(X, alpha=0.3), 4)
+    0.4318
+
+    See Also
+    --------
+    cvar, var, mdd, drawdown
+
+    """
+    _check_alpha(alpha)
+    X = np.asarray(X, dtype=np.float64)
+    dd = _drawdown(X, False)
+    k = _tail_k(alpha, dd.shape[0])
+    worst = np.sort(dd)[::-1][:k]
+
+    return float(np.mean(worst))
+
+
+def roll_var(X: NDArray, alpha: float = 0.05, w: int = 252, method: str = 'historical') -> NDArray:
+    r""" Rolling Value-at-Risk of a price/equity curve over a trailing window.
+
+    Causal trailing estimate of :func:`var`: each output point uses only the
+    ``w`` returns observed up to and including that point, so the output has a
+    ``w``-point NaN head (there is no well-defined estimate before the window
+    fills).
+
+    Parameters
+    ----------
+    X : array_like
+        Time-series of price, performance or index (a single curve), shape
+        ``(T,)``.
+    alpha : float, optional
+        Tail probability, in ``(0, 1)``. Default is 0.05.
+    w : int, optional
+        Size of the trailing window, in number of returns. Default is 252.
+    method : {'historical', 'gaussian', 'cornish_fisher'}, optional
+        Estimation method, see :func:`var`. Default is 'historical'.
+
+    Returns
+    -------
+    np.ndarray[np.float64, ndim=1] of shape (T,)
+        Rolling Value-at-Risk; the first ``w`` values are NaN.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> X = np.array([100., 99., 103., 95., 101., 98., 104., 90., 108., 97.,
+    ...                102.])
+    >>> out = roll_var(X, alpha=0.4, w=5, method='historical')
+    >>> np.isnan(out[:5]).all()
+    True
+    >>> round(out[5], 4)
+    0.0297
+
+    See Also
+    --------
+    var, roll_cvar, roll_mdd
+
+    """
+    _check_alpha(alpha)
+    _check_method(method)
+    X = np.asarray(X, dtype=np.float64)
+    T = X.shape[0]
+    R = _returns_from_prices(X)
+
+    if method == 'historical':
+        q = _roll_hist_quantile_1d(R, w, alpha)
+    elif method == 'gaussian':
+        mean, std, _, _ = _roll_window_moments_1d(R, w)
+        q = mean + std * norm.ppf(alpha)
+    else:
+        mean, std, skew, kurt = _roll_window_moments_1d(R, w)
+        q = mean + std * _cf_quantile(norm.ppf(alpha), skew, kurt)
+
+    out = np.full(T, np.nan)
+    out[1:] = -q
+
+    return out
+
+
+def roll_cvar(X: NDArray, alpha: float = 0.05, w: int = 252, method: str = 'historical') -> NDArray:
+    r""" Rolling Conditional Value-at-Risk of a price/equity curve.
+
+    Causal trailing estimate of :func:`cvar`: each output point uses only the
+    ``w`` returns observed up to and including that point, so the output has a
+    ``w``-point NaN head.
+
+    Parameters
+    ----------
+    X : array_like
+        Time-series of price, performance or index (a single curve), shape
+        ``(T,)``.
+    alpha : float, optional
+        Tail probability, in ``(0, 1)``. Default is 0.05.
+    w : int, optional
+        Size of the trailing window, in number of returns. Default is 252.
+    method : {'historical', 'gaussian', 'cornish_fisher'}, optional
+        Estimation method, see :func:`cvar`. Default is 'historical'.
+
+    Returns
+    -------
+    np.ndarray[np.float64, ndim=1] of shape (T,)
+        Rolling Conditional Value-at-Risk; the first ``w`` values are NaN.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> X = np.array([100., 99., 103., 95., 101., 98., 104., 90., 108., 97.,
+    ...                102.])
+    >>> out = roll_cvar(X, alpha=0.4, w=5, method='historical')
+    >>> np.isnan(out[:5]).all()
+    True
+    >>> round(out[5], 4)
+    0.0537
+
+    See Also
+    --------
+    cvar, roll_var, roll_mdd
+
+    """
+    _check_alpha(alpha)
+    _check_method(method)
+    X = np.asarray(X, dtype=np.float64)
+    T = X.shape[0]
+    R = _returns_from_prices(X)
+
+    if method == 'historical':
+        raw = _roll_hist_tail_mean_1d(R, w, alpha)
+    elif method == 'gaussian':
+        mean, std, _, _ = _roll_window_moments_1d(R, w)
+        z = norm.ppf(alpha)
+        raw = mean - std * norm.pdf(z) / alpha
+    else:
+        mean, std, skew, kurt = _roll_window_moments_1d(R, w)
+        c1, c2, c3, c4 = _cf_tail_constants(alpha)
+        raw = mean + std * (c1 + c2 * skew + c3 * kurt + c4 * skew ** 2)
+
+    out = np.full(T, np.nan)
+    out[1:] = -raw
+
+    return out
+
+
+def tail_dependence(X: NDArray, q: float = 0.05) -> NDArray:
+    r""" Pairwise lower-tail dependence of a ``(T, N)`` returns panel.
+
+    Unlike :func:`var`/:func:`cvar`/:func:`cdar`, this takes returns directly
+    (see the module docstring): tail dependence is a *co*-exceedance property of
+    two series, not a summary of one equity curve, so it does not fit the
+    single-curve ``METRICS`` contract (mirroring
+    :func:`~fynance.metrics.information_coefficient`'s (pred, real)-pair
+    convention).
+
+    Estimates, for each pair of assets :math:`(i, j)`, the empirical
+    probability [4]_ that asset :math:`i` is in its own lower ``q``-tail given
+    that asset :math:`j` is in its own lower ``q``-tail:
+
+    .. math::
+
+        \lambda_{ij} = P\left(x_i \leq Q_i(q) \mid x_j \leq Q_j(q)\right)
+
+    Notes
+    -----
+    :math:`Q_i(q)` is the empirical ``q``-quantile of column ``i`` (the same
+    ``k``-th-smallest-observation convention as :func:`var`, :func:`_tail_k`),
+    so by construction exactly :math:`k = \max(1, \lfloor qT \rfloor)`
+    observations of every column are ``<= `` its own threshold. The estimator
+    is then
+
+    .. math::
+
+        \lambda_{ij} = \frac{\#\{t : x_{ti} \leq Q_i(q) \text{ and } x_{tj}
+        \leq Q_j(q)\}}{k}
+
+    Because the denominator ``k`` is the same for both conditioning directions
+    (it only depends on ``q`` and ``T``, not on which column conditions on
+    which), :math:`\lambda_{ij} = \lambda_{ji}`: the matrix is symmetric by
+    construction, unlike a generic conditional probability. The diagonal is
+    exactly 1 (an event's exceedance is always joint with itself).
+
+    Parameters
+    ----------
+    X : array_like of shape (T, N)
+        Returns panel (not prices), one column per asset.
+    q : float, optional
+        Tail probability, in ``(0, 1)``. Default is 0.05.
+
+    Returns
+    -------
+    np.ndarray[np.float64, ndim=2] of shape (N, N)
+        Symmetric lower-tail dependence matrix, diagonal 1.
+
+    References
+    ----------
+    .. [4] Longin, F., and Solnik, B., 2001, Extreme Correlation of
+       International Equity Markets, Journal of Finance, 56(2), 649-676.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> rng = np.random.default_rng(0)
+    >>> comonotone = rng.standard_normal(2000)
+    >>> R = np.stack([comonotone, comonotone], axis=1)
+    >>> lam = tail_dependence(R, q=0.05)
+    >>> bool(lam[0, 1] > 0.95)
+    True
+    >>> np.diag(lam)
+    array([1., 1.])
+
+    See Also
+    --------
+    var, information_coefficient
+
+    """
+    _check_alpha(q)
+    X = np.asarray(X, dtype=np.float64)
+    T, N = X.shape
+    k = _tail_k(q, T)
+
+    thresholds = np.sort(X, axis=0)[k - 1, :]
+    exceed = (X <= thresholds).astype(np.float64)
+
+    out = (exceed.T @ exceed) / k
+    np.fill_diagonal(out, 1.0)
+
+    return out

--- a/fynance/metrics/summary.py
+++ b/fynance/metrics/summary.py
@@ -26,17 +26,21 @@ from fynance.metrics.ratios import (
     sortino,
 )
 from fynance.metrics.returns import annual_return
+from fynance.metrics.risk import cdar, cvar, var
 
 __all__ = ['METRICS', 'summary']
 
 # Registry of scalar metrics taking an equity/price curve -> float.
-METRICS: dict[str, Callable[..., NDArray]] = {
+METRICS: dict[str, Callable[..., NDArray | float]] = {
     'annual_return': annual_return,
     'annual_volatility': annual_volatility,
     'sharpe': sharpe,
     'sortino': sortino,
     'calmar': calmar,
     'max_drawdown': mdd,
+    'var': var,
+    'cvar': cvar,
+    'cdar': cdar,
 }
 
 
@@ -56,7 +60,10 @@ def summary(prices: NDArray, period: int = 252, rf: float = 0.0) -> dict[str, fl
     -------
     dict of str to float
         ``annual_return``, ``annual_volatility``, ``sharpe``, ``sortino``,
-        ``calmar`` and ``max_drawdown``.
+        ``calmar``, ``max_drawdown``, ``var``, ``cvar`` and ``cdar`` (the last
+        three at the default ``alpha=0.05``, historical method — call
+        :func:`~fynance.metrics.var` / :func:`~fynance.metrics.cvar` /
+        :func:`~fynance.metrics.cdar` directly for other tail parameters).
 
     Examples
     --------
@@ -64,7 +71,7 @@ def summary(prices: NDArray, period: int = 252, rf: float = 0.0) -> dict[str, fl
     >>> eq = np.array([100., 101., 103., 102., 105., 107.])
     >>> s = summary(eq)
     >>> sorted(s)
-    ['annual_return', 'annual_volatility', 'calmar', 'max_drawdown', 'sharpe', 'sortino']
+    ['annual_return', 'annual_volatility', 'calmar', 'cdar', 'cvar', 'max_drawdown', 'sharpe', 'sortino', 'var']
 
     """
     p = np.asarray(prices, dtype=np.float64)
@@ -81,4 +88,7 @@ def summary(prices: NDArray, period: int = 252, rf: float = 0.0) -> dict[str, fl
         'sortino': float(sortino(p, period=period, log=log)),
         'calmar': float(calmar(p, period=period)),
         'max_drawdown': float(mdd(p)),
+        'var': float(var(p)),
+        'cvar': float(cvar(p)),
+        'cdar': float(cdar(p)),
     }

--- a/fynance/tests/metrics/test_risk.py
+++ b/fynance/tests/metrics/test_risk.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for the tail-risk metrics (VaR, CVaR, CDaR, tail dependence). """
+
+# Third-party packages
+import numpy as np
+import pytest
+from scipy.stats import norm
+
+# Local packages
+from fynance.metrics import METRICS, cdar, cvar, summary, tail_dependence, var
+from fynance.metrics.risk import _cf_quantile, _cf_tail_constants, roll_cvar, roll_var
+
+# --------------------------------------------------------------------------- #
+# Gaussian closed forms
+# --------------------------------------------------------------------------- #
+
+
+def _sigma_scaled_normal(sigma, T=5000, seed=7):
+    # Exactly demeaned and rescaled so the *sample* mean/std equal 0/sigma:
+    # removes sampling noise from the closed-form comparison below, so the
+    # only source of discrepancy is the rounding of the hardcoded constants.
+    rng = np.random.default_rng(seed)
+    r = rng.standard_normal(T)
+    r -= r.mean()
+    r *= sigma / r.std()
+    X = np.empty(T + 1)
+    X[0] = 100.
+    X[1:] = 100. * np.cumprod(1. + r)
+
+    return X
+
+
+def test_var_gaussian_closed_form_matches_hardcoded_constant():
+    sigma = 0.01
+    X = _sigma_scaled_normal(sigma)
+    assert var(X, alpha=0.05, method='gaussian') == pytest.approx(sigma * 1.6449, rel=1e-3)
+
+
+def test_cvar_gaussian_closed_form_matches_hardcoded_constant():
+    sigma = 0.01
+    X = _sigma_scaled_normal(sigma)
+    assert cvar(X, alpha=0.05, method='gaussian') == pytest.approx(sigma * 2.0627, rel=1e-3)
+
+
+# --------------------------------------------------------------------------- #
+# Historical method, hand-built series -> exact empirical quantile / tail mean
+# --------------------------------------------------------------------------- #
+
+
+def _hand_built_returns_and_prices():
+    # 100 clean, distinct per-period returns from -0.50 to +0.49 (step 0.01):
+    # sorted ascending by construction, so the k-th smallest is a plain index.
+    R = 0.01 * (np.arange(100) - 50)
+    X = np.empty(101)
+    X[0] = 100.
+    for i in range(100):
+        X[i + 1] = X[i] * (1. + R[i])
+
+    return R, X
+
+
+def test_var_historical_hand_built_exact_quantile():
+    R, X = _hand_built_returns_and_prices()
+    # alpha=0.05, n=100 -> k = floor(5.0) = 5 -> the 5th smallest observed return.
+    expected_q = np.sort(R)[4]
+    assert var(X, alpha=0.05, method='historical') == pytest.approx(-expected_q, abs=1e-9)
+
+
+def test_cvar_historical_hand_built_exact_tail_mean():
+    R, X = _hand_built_returns_and_prices()
+    expected_tail_mean = np.mean(np.sort(R)[:5])
+    assert cvar(X, alpha=0.05, method='historical') == pytest.approx(-expected_tail_mean, abs=1e-9)
+
+
+def test_cvar_historical_at_least_var_historical():
+    _, X = _hand_built_returns_and_prices()
+    assert cvar(X, alpha=0.05, method='historical') >= var(X, alpha=0.05, method='historical')
+
+
+# --------------------------------------------------------------------------- #
+# Cornish-Fisher reduces to the Gaussian formula when skew = kurt_excess = 0
+# --------------------------------------------------------------------------- #
+
+
+def test_cf_quantile_reduces_to_gaussian_at_zero_moments():
+    z = norm.ppf(0.05)
+    assert _cf_quantile(z, 0., 0.) == pytest.approx(z)
+
+
+def test_cf_tail_mean_reduces_to_gaussian_closed_form_at_zero_moments():
+    alpha = 0.05
+    c1, c2, c3, c4 = _cf_tail_constants(alpha)
+    z = norm.ppf(alpha)
+    gaussian_raw_tail_mean = -norm.pdf(z) / alpha  # mu=0, sigma=1 tail mean
+    cf_raw_tail_mean = c1 + c2 * 0. + c3 * 0. + c4 * 0. ** 2
+    assert cf_raw_tail_mean == pytest.approx(gaussian_raw_tail_mean, rel=1e-3)
+
+
+# --------------------------------------------------------------------------- #
+# CDaR, hand-built drawdown path
+# --------------------------------------------------------------------------- #
+
+
+def test_cdar_hand_built_known_drawdowns():
+    # Drawdown path (percentage): [0, .1, .05, .2, 0, 40/110, 0, .5, 0].
+    X = np.array([100., 90., 95., 80., 110., 70., 120., 60., 130.])
+    # alpha=0.3, n=9 -> k = floor(2.7) = 2 -> mean of the 2 worst drawdowns.
+    expected = (0.5 + 40. / 110.) / 2.
+    assert cdar(X, alpha=0.3) == pytest.approx(expected, abs=1e-9)
+
+
+# --------------------------------------------------------------------------- #
+# Rolling variants: causality (no future leakage) and NaN head
+# --------------------------------------------------------------------------- #
+
+
+def _rolling_price_curve(T=300, seed=3):
+    rng = np.random.default_rng(seed)
+    X = np.empty(T + 1)
+    X[0] = 100.
+    X[1:] = 100. * np.cumprod(1. + rng.normal(0., 0.01, T))
+
+    return X
+
+
+@pytest.mark.parametrize('method', ['historical', 'gaussian', 'cornish_fisher'])
+@pytest.mark.parametrize('func', [roll_var, roll_cvar])
+def test_roll_var_cvar_nan_head_and_causality(func, method):
+    X = _rolling_price_curve()
+    w = 50
+    out = func(X, alpha=0.05, w=w, method=method)
+
+    assert np.isnan(out[:w]).all()
+    assert not np.isnan(out[w:]).any()
+
+    t0 = 150
+    X_perturbed = X.copy()
+    X_perturbed[t0:] *= 1.5  # corrupt the future only
+    out_perturbed = func(X_perturbed, alpha=0.05, w=w, method=method)
+    assert np.allclose(out[:t0], out_perturbed[:t0], equal_nan=True), \
+        f"{func.__name__}({method}) leaks future data"
+
+
+# --------------------------------------------------------------------------- #
+# tail_dependence
+# --------------------------------------------------------------------------- #
+
+
+def test_tail_dependence_comonotonic_pair_is_near_one():
+    rng = np.random.default_rng(0)
+    comonotone = rng.standard_normal(2000)
+    R = np.stack([comonotone, comonotone], axis=1)
+    lam = tail_dependence(R, q=0.05)
+    assert lam[0, 1] > 0.95
+    assert lam[1, 0] > 0.95
+
+
+def test_tail_dependence_independent_large_t_is_near_q():
+    rng = np.random.default_rng(11)
+    T = 20000
+    R = np.stack([rng.standard_normal(T), rng.standard_normal(T)], axis=1)
+    lam = tail_dependence(R, q=0.05)
+    assert abs(lam[0, 1] - 0.05) < 0.03
+
+
+def test_tail_dependence_diagonal_and_symmetry():
+    rng = np.random.default_rng(5)
+    R = rng.standard_normal((500, 4))
+    lam = tail_dependence(R, q=0.05)
+    assert np.allclose(np.diag(lam), 1.)
+    assert np.allclose(lam, lam.T)
+
+
+# --------------------------------------------------------------------------- #
+# Registry: var / cvar / cdar are single-curve scalar metrics, mirroring how
+# the METRICS registry drives `summary` (see test_summary.py).
+# --------------------------------------------------------------------------- #
+
+
+def test_var_cvar_cdar_registered_in_metrics():
+    assert {'var', 'cvar', 'cdar'} <= set(METRICS)
+    eq = np.array([100., 101., 103., 102., 105., 107.])
+    assert np.isclose(float(METRICS['var'](eq)), float(var(eq)))
+    assert np.isclose(float(METRICS['cvar'](eq)), float(cvar(eq)))
+    assert np.isclose(float(METRICS['cdar'](eq)), float(cdar(eq)))
+
+
+def test_var_cvar_cdar_appear_in_summary_output():
+    eq = np.array([100., 101., 103., 102., 105., 107.])
+    s = summary(eq)
+    assert {'var', 'cvar', 'cdar'} <= set(s)
+    assert np.isclose(s['var'], float(var(eq)))
+    assert np.isclose(s['cvar'], float(cvar(eq)))
+    assert np.isclose(s['cdar'], float(cdar(eq)))
+
+
+# --------------------------------------------------------------------------- #
+# Input validation
+# --------------------------------------------------------------------------- #
+
+
+def test_var_rejects_unknown_method():
+    X = np.array([100., 101., 99., 102.])
+    with pytest.raises(ValueError):
+        var(X, method='not-a-method')
+
+
+def test_var_rejects_invalid_alpha():
+    X = np.array([100., 101., 99., 102.])
+    with pytest.raises(ValueError):
+        var(X, alpha=0.)
+    with pytest.raises(ValueError):
+        var(X, alpha=1.)

--- a/fynance/tests/metrics/test_summary.py
+++ b/fynance/tests/metrics/test_summary.py
@@ -20,7 +20,8 @@ def test_summary_keys():
     eq = np.array([100., 101., 103., 102., 105., 107.])
     s = summary(eq)
     assert set(s) == {"annual_return", "annual_volatility", "sharpe",
-                      "sortino", "calmar", "max_drawdown"}
+                      "sortino", "calmar", "max_drawdown", "var", "cvar",
+                      "cdar"}
     for v in s.values():
         assert np.isfinite(v)
 


### PR DESCRIPTION
## Summary
- New `fynance.metrics.risk`: `var`/`cvar` with three estimators (historical order-statistic, Gaussian closed form, Cornish-Fisher 4-moment), `cdar`, causal `roll_var`/`roll_cvar` (Numba), `tail_dependence` on (T,N) returns panels.
- `var`/`cvar`/`cdar` registered in METRICS → `summary()`; registry comment block merged with #253's (rebase resolution).
- Leaf 01/04 of the `metrics-analytics` epic.

## Verification (Student-t(4) returns, T=5000)
CVaR 5%: historical 0.0225 / CF 0.0343 > gaussian 0.0205. VaR 1%: historical 0.0276 / CF 0.0450 > gaussian 0.0232 (the 5% VaR crossover of variance-matched t(4) is real statistics, documented). Tail dependence intra-block 0.382 ≫ inter 0.050.

## Test plan
- [x] `pytest` — 1353 passed post-rebase (Gaussian constants, exact order statistics, CF≡gaussian at zero moments, rolling causality, registry integration)
- [x] `ruff` / `mypy` / interrogate / Sphinx -W
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)