### PR TITLE
feat: add GJR-GARCH and EGARCH Numba kernels with normal/Student-t log-likelihoods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **GJR-GARCH / EGARCH kernels.** Numba filters `_gjr_garch` / `_egarch`
+  and `loglik_garch(params, y, model, dist)` (Gaussian and Student-t
+  innovations, distribution-correct E|z| centering for EGARCH) in
+  `models.econometric_models` — the likelihood layer for the upcoming
+  `fit_volatility` MLE driver.
 - **Tail-risk metrics.** New `fynance.metrics.risk`: `var` / `cvar`
   (historical, Gaussian, Cornish-Fisher), `cdar` (mean of the α worst
   drawdowns), causal `roll_var`/`roll_cvar`, and pairwise lower-tail

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -72,6 +72,24 @@ Template:
 
 <!-- new entries below, newest first -->
 
+### 2026-07-06 — GARCH family epic (PRs #255, epic)  [accepted]
+
+- **Choice**: extend the volatility family inside
+  `models.econometric_models` (single-implementation policy): GJR-GARCH and
+  EGARCH Numba filters + `loglik_garch` with Gaussian/Student-t innovations
+  (kernels return `-inf` on inadmissible regions instead of raising); the
+  scipy MLE driver, `VolatilityResult` (std errors, AIC/BIC, forecast,
+  simulate) and the `features/garch.py` `model=`/`dist=` passthrough land as
+  a second leaf on top.
+- **Why**: GARCH(1,1)-normal systematically underestimates tail vol on
+  equity-like series; `estimator.estimation()` was an explicit stub with no
+  working MLE path anywhere; asymmetry (GJR/EGARCH) and fat tails
+  (Student-t) are the two standard remedies.
+- **Rejected alternatives**: depending on `arch` (heavy, duplicates the
+  house kernels); exceptions inside kernels (breaks nopython + optimizer
+  workflows); a separate garch subpackage (violates the no-duplication
+  policy).
+
 ### 2026-07-06 — Metrics & trade analytics epic (PRs #253–#254, epic)  [accepted]
 
 - **Choice**: four additive metric families — benchmark-relative two-curve

--- a/fynance/models/econometric_models.py
+++ b/fynance/models/econometric_models.py
@@ -21,10 +21,14 @@ Main entry points
 - :func:`ARMA_GARCH` — ARMA with GARCH(p, q) conditional variance.
 - :func:`ARMAX_GARCH` — ARMA-GARCH with exogenous regressors.
 - :func:`get_parameters` — fit the parameters of any of the above.
+- :func:`loglik_garch` — GARCH-family (GARCH / GJR / EGARCH) log-likelihood
+  under normal or standardized Student-t innovations, the objective for a
+  maximum-likelihood fit driver.
 
 """
 
 # Built-in packages
+import math
 
 # External packages
 import numpy as np
@@ -121,6 +125,91 @@ def _armax_garch(y, x, phi, psi, theta, alpha, beta, c, omega, p, q, Q, P):
         u[t] = y[t] - c - armax
         h[t] = np.sqrt(omega + arch)
     return u, h
+
+
+@njit(cache=True)
+def _gjr_garch(y, omega, alpha, gamma, beta):
+    """ GJR-GARCH(1, 1) conditional std recursion (numba kernel).
+
+    Variance recursion
+    ``sigma_t^2 = omega + (alpha + gamma * 1[y_{t-1} < 0]) * y_{t-1}^2
+    + beta * sigma_{t-1}^2`` with ``sigma_0^2 = omega`` (only the constant
+    survives at t=0, matching the `_arma_garch` convention). ``y`` is used
+    as the mean-zero innovation series. Returns the conditional standard
+    deviation ``h_t = sigma_t``. With ``gamma == 0`` the ``h`` path is
+    identical to the vanilla `_arma_garch` filter.
+    """
+    T = y.size
+    h = np.zeros(T)
+    h[0] = np.sqrt(omega)
+    for t in range(1, T):
+        ind = 1.0 if y[t - 1] < 0.0 else 0.0
+        arch = (alpha + gamma * ind) * y[t - 1] ** 2 + beta * h[t - 1] ** 2
+        h[t] = np.sqrt(omega + arch)
+    return h
+
+
+@njit(cache=True)
+def _egarch(y, omega, alpha, gamma, beta, mean_abs_z):
+    """ EGARCH(1, 1) conditional std recursion (numba kernel).
+
+    Log-variance recursion
+    ``ln sigma_t^2 = omega + beta * ln sigma_{t-1}^2
+    + alpha * (|z_{t-1}| - mean_abs_z) + gamma * z_{t-1}`` with
+    ``z_t = y_t / sigma_t`` and ``ln sigma_0^2 = omega`` (only the constant
+    survives at t=0, matching the `_arma_garch` convention). ``mean_abs_z``
+    is E|z| for the innovation distribution, supplied by the caller
+    (``sqrt(2 / pi)`` for the normal, :func:`_mean_abs_standardized_t` for a
+    standardized Student-t). Returns the conditional standard deviation
+    ``h_t = sigma_t``.
+    """
+    T = y.size
+    h = np.zeros(T)
+    log_var = omega
+    h[0] = np.exp(0.5 * log_var)
+    for t in range(1, T):
+        z = y[t - 1] / h[t - 1]
+        log_var = (omega + beta * log_var
+                   + alpha * (abs(z) - mean_abs_z) + gamma * z)
+        h[t] = np.exp(0.5 * log_var)
+    return h
+
+
+@njit(cache=True)
+def _mean_abs_standardized_t(nu):
+    """ E|z| for a unit-variance Student-t (nu > 2) innovation (numba kernel).
+
+    ``E|z| = 2 * sqrt(nu - 2) * Gamma((nu + 1) / 2)
+    / ((nu - 1) * sqrt(pi) * Gamma(nu / 2))``.
+    """
+    ratio = math.exp(math.lgamma((nu + 1.0) / 2.0) - math.lgamma(nu / 2.0))
+    return 2.0 * math.sqrt(nu - 2.0) * ratio / ((nu - 1.0) * math.sqrt(math.pi))
+
+
+@njit(cache=True)
+def _loglik_normal(y, h):
+    """ Gaussian log-likelihood given conditional std ``h`` (numba kernel). """
+    T = y.size
+    const = -0.5 * math.log(2.0 * math.pi)
+    ll = 0.0
+    for t in range(T):
+        ll += const - math.log(h[t]) - 0.5 * (y[t] / h[t]) ** 2
+    return ll
+
+
+@njit(cache=True)
+def _loglik_t(y, h, nu):
+    """ Standardized Student-t (nu > 2) log-likelihood given ``h`` (numba). """
+    T = y.size
+    const = (math.lgamma((nu + 1.0) / 2.0) - math.lgamma(nu / 2.0)
+             - 0.5 * math.log(math.pi * (nu - 2.0)))
+    ll = 0.0
+    for t in range(T):
+        z2 = (y[t] / h[t]) ** 2
+        ll += (const - math.log(h[t])
+               - 0.5 * (nu + 1.0) * math.log(1.0 + z2 / (nu - 2.0)))
+    return ll
+
 
 __all__ = [
     'get_parameters', 'MA', 'ARMA', 'ARMA_GARCH', 'ARMAX_GARCH'
@@ -453,3 +542,144 @@ def ARMAX_GARCH(y, x, phi, psi, theta, alpha, beta, c, omega, p, q, Q, P):
     )
 
     return u, h
+
+
+# =========================================================================== #
+#                        GARCH-FAMILY LOG-LIKELIHOODS                         #
+# =========================================================================== #
+
+
+_SQRT_2_OVER_PI = math.sqrt(2.0 / math.pi)
+
+
+def loglik_garch(
+    params: np.ndarray,
+    y: np.ndarray,
+    model: str = 'garch',
+    dist: str = 'normal',
+) -> float:
+    r""" Log-likelihood of a GARCH-family volatility model.
+
+    Runs the conditional-variance recursion of the selected ``model`` over the
+    mean-zero series ``y`` and returns the total log-likelihood of the
+    innovations under the chosen ``dist``. The value is a *log-likelihood*
+    (higher is better, to be **maximised**); invalid parameter regions map to
+    ``-np.inf`` so a maximiser (or a minimiser of its negative) is repelled
+    from them without exceptions being raised. Intended as the objective for a
+    scipy maximum-likelihood driver (built in a later step).
+
+    Parameters
+    ----------
+    params : np.ndarray[np.float64, ndim=1]
+        Flat parameter vector, laid out per ``model`` (all variance
+        parameters first, ``nu`` appended last when ``dist='t'``):
+
+        - ``model='garch'`` : ``(omega, alpha, beta)``
+        - ``model='gjr'``   : ``(omega, alpha, gamma, beta)``
+        - ``model='egarch'``: ``(omega, alpha, gamma, beta)``
+
+        With ``dist='t'`` the degrees of freedom ``nu`` (``> 2``) is appended
+        as the final element.
+    y : np.ndarray[np.float64, ndim=1]
+        Mean-zero innovation (return) series.
+    model : {'garch', 'gjr', 'egarch'}, optional
+        Conditional-variance specification. ``'garch'`` is the vanilla
+        GARCH(1, 1); ``'gjr'`` adds a leverage term
+        ``gamma * 1[y_{t-1} < 0] * y_{t-1}^2``; ``'egarch'`` models the
+        log-variance. Default is ``'garch'``.
+    dist : {'normal', 't'}, optional
+        Innovation density: Gaussian, or standardized (unit-variance)
+        Student-t with ``nu > 2`` degrees of freedom. Default is ``'normal'``.
+
+    Returns
+    -------
+    float
+        Total log-likelihood (higher is better), or ``-np.inf`` when the
+        parameters leave the admissible region (see Notes).
+
+    Notes
+    -----
+    Admissible regions (outside them the return is ``-np.inf``):
+
+    - ``garch`` : ``omega > 0``, ``alpha >= 0``, ``beta >= 0``,
+      ``alpha + beta < 1`` (stationarity).
+    - ``gjr`` : ``omega > 0``, ``alpha >= 0``, ``beta >= 0``,
+      ``alpha + gamma >= 0`` (variance non-negativity),
+      ``alpha + beta + gamma / 2 < 1`` (stationarity, symmetric innovations).
+    - ``egarch`` : ``|beta| < 1`` only (the log-variance form needs no
+      non-negativity constraint).
+    - ``dist='t'`` : ``nu > 2`` (finite variance).
+
+    The conditional variance is initialised at ``sigma_0^2 = omega`` (GARCH,
+    GJR) or ``ln sigma_0^2 = omega`` (EGARCH): only the constant survives at
+    ``t = 0``, matching the :func:`_arma_garch` convention. The EGARCH
+    ``E|z|`` term is ``sqrt(2 / pi)`` for the normal and
+    ``2 * sqrt(nu - 2) * Gamma((nu + 1) / 2) / ((nu - 1) * sqrt(pi)
+    * Gamma(nu / 2))`` for the standardized Student-t.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> rng = np.random.default_rng(0)
+    >>> y = rng.standard_normal(500)
+    >>> ll = loglik_garch([0.1, 0.05, 0.9], y, model='garch', dist='normal')
+    >>> bool(ll < 0.0)
+    True
+    >>> loglik_garch([-1.0, 0.05, 0.9], y, model='garch')  # omega <= 0
+    -inf
+
+    """
+    y = np.asarray(y, dtype=np.float64).reshape(-1)
+    params = np.asarray(params, dtype=np.float64).reshape(-1)
+    model = model.lower()
+    dist = dist.lower()
+
+    # Split off the Student-t degrees of freedom, if any.
+    if dist == 't':
+        nu = float(params[-1])
+        core = params[:-1]
+        if nu <= 2.0:
+            return -np.inf
+    elif dist == 'normal':
+        nu = 0.0
+        core = params
+    else:
+        raise ValueError(f"Unknown dist: {dist!r}")
+
+    # Parse per model, validate the admissible region, run the filter.
+    if model == 'garch':
+        omega, alpha, beta = core[0], core[1], core[2]
+        if omega <= 0.0 or alpha < 0.0 or beta < 0.0 or alpha + beta >= 1.0:
+            return -np.inf
+        h = _gjr_garch(y, omega, alpha, 0.0, beta)
+
+    elif model == 'gjr':
+        omega, alpha, gamma, beta = core[0], core[1], core[2], core[3]
+        if (omega <= 0.0 or alpha < 0.0 or beta < 0.0 or alpha + gamma < 0.0
+                or alpha + beta + 0.5 * gamma >= 1.0):
+            return -np.inf
+        h = _gjr_garch(y, omega, alpha, gamma, beta)
+
+    elif model == 'egarch':
+        omega, alpha, gamma, beta = core[0], core[1], core[2], core[3]
+        if abs(beta) >= 1.0:
+            return -np.inf
+        if dist == 't':
+            mean_abs_z = _mean_abs_standardized_t(nu)
+        else:
+            mean_abs_z = _SQRT_2_OVER_PI
+        h = _egarch(y, omega, alpha, gamma, beta, mean_abs_z)
+
+    else:
+        raise ValueError(f"Unknown model: {model!r}")
+
+    # Innovation log-density.
+    if dist == 't':
+        ll = _loglik_t(y, h, nu)
+    else:
+        ll = _loglik_normal(y, h)
+
+    if not np.isfinite(ll):
+        return -np.inf
+
+    return float(ll)

--- a/fynance/tests/models/test_econometric_models.py
+++ b/fynance/tests/models/test_econometric_models.py
@@ -7,13 +7,24 @@
 # @Last modified time: 2019-10-15 16:39:37
 
 # Built-in packages
+import warnings
 
 # Third party packages
 import numpy as np
 import pytest
+from scipy.special import gammaln
 
 # local packages
 import fynance as fy
+from fynance.models.econometric_models import (
+    _arma_garch,
+    _egarch,
+    _gjr_garch,
+    _loglik_normal,
+    _loglik_t,
+    _mean_abs_standardized_t,
+    loglik_garch,
+)
 
 
 @pytest.fixture()
@@ -160,3 +171,197 @@ def test_ARMAX_GARCH_accepts_list():
     )
     assert np.allclose(np.asarray(u_l), np.asarray(u_a))
     assert np.allclose(np.asarray(h_l), np.asarray(h_a))
+
+
+# =========================================================================== #
+#                  GJR-GARCH / EGARCH kernels & log-likelihood                #
+# =========================================================================== #
+
+
+# --- Slow pure-Python references (independent of the numba kernels) -------- #
+
+
+def _gjr_ref(y, omega, alpha, gamma, beta):
+    """ Reference GJR-GARCH(1, 1) conditional std recursion. """
+    y = np.asarray(y, dtype=np.float64)
+    h = np.zeros(y.size)
+    h[0] = np.sqrt(omega)
+    for t in range(1, y.size):
+        ind = 1.0 if y[t - 1] < 0.0 else 0.0
+        var_t = omega + (alpha + gamma * ind) * y[t - 1] ** 2 + beta * h[t - 1] ** 2
+        h[t] = np.sqrt(var_t)
+    return h
+
+
+def _egarch_ref(y, omega, alpha, gamma, beta, mean_abs_z):
+    """ Reference EGARCH(1, 1) conditional std recursion. """
+    y = np.asarray(y, dtype=np.float64)
+    h = np.zeros(y.size)
+    log_var = omega
+    h[0] = np.exp(0.5 * log_var)
+    for t in range(1, y.size):
+        z = y[t - 1] / h[t - 1]
+        log_var = omega + beta * log_var + alpha * (abs(z) - mean_abs_z) + gamma * z
+        h[t] = np.exp(0.5 * log_var)
+    return h
+
+
+def _mean_abs_std_t_ref(nu):
+    """ Reference E|z| for a unit-variance Student-t via scipy gammaln. """
+    ratio = np.exp(gammaln((nu + 1.0) / 2.0) - gammaln(nu / 2.0))
+    return 2.0 * np.sqrt(nu - 2.0) * ratio / ((nu - 1.0) * np.sqrt(np.pi))
+
+
+def _loglik_normal_ref(y, h):
+    """ Reference Gaussian log-likelihood given conditional std ``h``. """
+    return float(np.sum(-0.5 * np.log(2.0 * np.pi) - np.log(h) - 0.5 * (y / h) ** 2))
+
+
+def _loglik_t_ref(y, h, nu):
+    """ Reference standardized Student-t log-likelihood given ``h``. """
+    const = gammaln((nu + 1.0) / 2.0) - gammaln(nu / 2.0) \
+        - 0.5 * np.log(np.pi * (nu - 2.0))
+    z2 = (y / h) ** 2
+    return float(np.sum(const - np.log(h) - 0.5 * (nu + 1.0) * np.log(1.0 + z2 / (nu - 2.0))))
+
+
+# --- Filter golden parity -------------------------------------------------- #
+
+
+def test_gjr_garch_parity_reference():
+    rng = np.random.default_rng(1234)
+    y = rng.standard_normal(500)
+    omega, alpha, gamma, beta = 0.05, 0.06, 0.08, 0.85
+    h_kernel = _gjr_garch(y, omega, alpha, gamma, beta)
+    h_ref = _gjr_ref(y, omega, alpha, gamma, beta)
+    assert np.allclose(h_kernel, h_ref, rtol=1e-12, atol=0.0)
+
+
+def test_egarch_parity_reference():
+    rng = np.random.default_rng(5678)
+    y = rng.standard_normal(500)
+    omega, alpha, gamma, beta = -0.1, 0.12, -0.08, 0.9
+    e_abs = np.sqrt(2.0 / np.pi)
+    h_kernel = _egarch(y, omega, alpha, gamma, beta, e_abs)
+    h_ref = _egarch_ref(y, omega, alpha, gamma, beta, e_abs)
+    assert np.allclose(h_kernel, h_ref, rtol=1e-12, atol=0.0)
+
+
+def test_gjr_gamma_zero_equals_vanilla_garch():
+    # With gamma == 0 the GJR filter must reproduce the vanilla GARCH h path
+    # produced by the existing _arma_garch kernel, bit for bit.
+    rng = np.random.default_rng(3)
+    y = rng.standard_normal(300)
+    omega, alpha, beta = 0.05, 0.08, 0.88
+    h_gjr = _gjr_garch(y, omega, alpha, 0.0, beta)
+    zeros = np.array([0.0])
+    _, h_ag = _arma_garch(
+        y, zeros, zeros, np.array([alpha]), np.array([beta]),
+        0.0, omega, 0, 0, 1, 1,
+    )
+    assert np.array_equal(h_gjr, h_ag)
+
+
+def test_egarch_three_step_recursion():
+    # Hand-computed 3-step EGARCH recursion.
+    omega, alpha, gamma, beta = -0.1, 0.12, -0.08, 0.9
+    e_abs = np.sqrt(2.0 / np.pi)
+    y = np.array([0.5, -0.7, 0.3, 0.9])
+    h = _egarch(y, omega, alpha, gamma, beta, e_abs)
+
+    lv0 = omega
+    h0 = np.exp(0.5 * lv0)
+    z0 = y[0] / h0
+    lv1 = omega + beta * lv0 + alpha * (abs(z0) - e_abs) + gamma * z0
+    h1 = np.exp(0.5 * lv1)
+    z1 = y[1] / h1
+    lv2 = omega + beta * lv1 + alpha * (abs(z1) - e_abs) + gamma * z1
+    h2 = np.exp(0.5 * lv2)
+
+    assert np.isclose(h[0], h0, rtol=1e-12)
+    assert np.isclose(h[1], h1, rtol=1e-12)
+    assert np.isclose(h[2], h2, rtol=1e-12)
+
+
+# --- Log-likelihood parity ------------------------------------------------- #
+
+
+def test_loglik_garch_normal_matches_reference():
+    rng = np.random.default_rng(11)
+    y = rng.standard_normal(300)
+    omega, alpha, beta = 0.04, 0.06, 0.88
+    h = _gjr_ref(y, omega, alpha, 0.0, beta)
+    ll_ref = _loglik_normal_ref(y, h)
+    ll = loglik_garch(np.array([omega, alpha, beta]), y, 'garch', 'normal')
+    assert np.isclose(ll, ll_ref, rtol=1e-12)
+
+
+def test_loglik_gjr_normal_matches_reference():
+    rng = np.random.default_rng(12)
+    y = rng.standard_normal(300)
+    omega, alpha, gamma, beta = 0.04, 0.06, 0.05, 0.85
+    h = _gjr_ref(y, omega, alpha, gamma, beta)
+    ll_ref = _loglik_normal_ref(y, h)
+    ll = loglik_garch(np.array([omega, alpha, gamma, beta]), y, 'gjr', 'normal')
+    assert np.isclose(ll, ll_ref, rtol=1e-12)
+
+
+def test_loglik_egarch_t_matches_reference():
+    rng = np.random.default_rng(13)
+    y = rng.standard_normal(300)
+    omega, alpha, gamma, beta, nu = -0.1, 0.1, -0.05, 0.9, 6.0
+    e_abs = _mean_abs_std_t_ref(nu)
+    h = _egarch_ref(y, omega, alpha, gamma, beta, e_abs)
+    ll_ref = _loglik_t_ref(y, h, nu)
+    ll = loglik_garch(
+        np.array([omega, alpha, gamma, beta, nu]), y, 'egarch', 't',
+    )
+    assert np.isclose(ll, ll_ref, rtol=1e-12)
+
+
+def test_loglik_t_approaches_normal_large_nu():
+    # As nu -> inf the standardized Student-t density collapses onto the
+    # normal, so both log-likelihoods must agree (atol scaled to T ~ 400).
+    rng = np.random.default_rng(7)
+    y = rng.standard_normal(400)
+    params_n = np.array([0.05, 0.08, 0.85])
+    ll_n = loglik_garch(params_n, y, 'garch', 'normal')
+    ll_t = loglik_garch(np.append(params_n, 1e6), y, 'garch', 't')
+    assert np.isclose(ll_t, ll_n, atol=1e-2)
+
+
+def test_mean_abs_z_t_vs_numerical_integration():
+    # The closed-form E|z| for a standardized Student-t must match a direct
+    # numerical integration of |z| * f(z) on a fine grid.
+    for nu in (3.0, 5.0, 8.0, 30.0):
+        z = np.linspace(-3000.0, 3000.0, 6_000_001)
+        const = np.exp(gammaln((nu + 1.0) / 2.0) - gammaln(nu / 2.0)) \
+            / np.sqrt(np.pi * (nu - 2.0))
+        f = const * (1.0 + z ** 2 / (nu - 2.0)) ** (-(nu + 1.0) / 2.0)
+        num = np.trapezoid(np.abs(z) * f, z)
+        assert np.isclose(_mean_abs_standardized_t(nu), num, rtol=1e-6)
+
+
+def test_loglik_invalid_params_return_minus_inf_without_warnings():
+    rng = np.random.default_rng(99)
+    y = rng.standard_normal(200)
+    cases = [
+        (np.array([-0.1, 0.05, 0.9]), 'garch', 'normal'),        # omega <= 0
+        (np.array([0.1, -0.05, 0.9]), 'garch', 'normal'),        # alpha < 0
+        (np.array([0.1, 0.2, 0.9]), 'garch', 'normal'),          # non-stationary
+        (np.array([0.1, 0.05, 0.9, 1.5]), 'garch', 't'),         # nu <= 2
+        (np.array([0.1, 0.05, -0.3, 0.9]), 'gjr', 'normal'),     # alpha + gamma < 0
+        (np.array([0.1, 0.05, 0.1, 0.95]), 'gjr', 'normal'),     # non-stationary
+        (np.array([-0.1, 0.1, -0.05, 1.2]), 'egarch', 'normal'),  # |beta| >= 1
+    ]
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        for params, model, dist in cases:
+            assert loglik_garch(params, y, model, dist) == -np.inf
+
+
+def test_garch_kernels_are_numba_compiled():
+    for fn in (
+        _gjr_garch, _egarch, _mean_abs_standardized_t, _loglik_normal, _loglik_t,
+    ):
+        assert hasattr(fn, 'py_func')


### PR DESCRIPTION
## Summary
- Numba `@njit` filters `_gjr_garch` (leverage term on negative shocks) and `_egarch` (log-variance recursion, distribution-correct E|z| centering: √(2/π) normal, closed-form standardized-t verified against numerical integration), + `loglik_garch(params, y, model='garch'|'gjr'|'egarch', dist='normal'|'t')`.
- Inadmissible parameter regions → −inf (no exceptions in kernels); h₀ convention matches `_arma_garch` exactly; `_gjr_garch(γ=0)` equals the vanilla filter **bit-for-bit**.
- Private/likelihood layer only — the MLE driver, `VolatilityResult` and the `features.garch` passthrough land next leaf. Leaf 01/02 of the `garch-family` epic (new epic ADR entry).

## Verification (simulated T=3000, true vs ±20% params)
loglik at TRUE params wins in all 4 (model × dist) combos — e.g. gjr-t: −2111.5 vs −2445.2/−2360.5.

## Test plan
- [x] `pytest` — passed (slow-loop parity rtol 1e-12 both filters/dists, γ=0 bit-for-bit, 3-step EGARCH hand recursion, E|z| vs integration, t→normal limit)
- [x] `ruff` / `mypy` / interrogate / Sphinx -W
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)