### PR TITLE
feat: add trade-level analytics (round-trip extraction, trade_summary)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Trade-level analytics.** New `fynance.metrics.trades`: `extract_trades`
+  (round-trip structured array — entry/exit/side/compounded return/bars,
+  Numba scan, per-asset on `(T, N)` books) and `trade_summary` (win rate,
+  profit factor, payoff, expectancy, streaks, holding stats);
+  `BacktestResult.trades()` / `.trade_summary()` conveniences.
 - **Turnover & exposure analytics.** `turnover_series`, `annual_turnover`,
   `gross_exposure`, `net_exposure`, `exposure_summary` in
   `fynance.metrics.trading`, plus `plot_exposure` and an opt-in

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -90,7 +90,7 @@ Template:
   workflows); a separate garch subpackage (violates the no-duplication
   policy).
 
-### 2026-07-06 — Metrics & trade analytics epic (PRs #253–#254 + #256, epic)  [accepted]
+### 2026-07-06 — Metrics & trade analytics epic (PRs #253–#254, #256–#257, epic)  [accepted]
 
 - **Choice**: four additive metric families — benchmark-relative two-curve
   metrics (`metrics.benchmark`, kept OUT of the scalar `METRICS` registry:

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -31,7 +31,11 @@ so an agent doesn't re-investigate settled ground or assume a known stub is a bu
   for purged splits).
 - **Metrics**: `fynance.metrics` (Sharpe/Sortino/Calmar/diversified-ratio,
   annual return/vol, drawdown/mdd, perf_*, roll_*, **`information_coefficient`**
-  rank-IC) + one-call `summary`.
+  rank-IC) + one-call `summary`; **2026-07 additions (PRs #253–#257)**:
+  benchmark-relative family (`benchmark` — alpha/beta/TE/IR/capture),
+  tail risk (`risk` — VaR/CVaR/CDaR + `tail_dependence`), turnover/exposure
+  analytics and round-trip **trade analytics** (`trades` +
+  `BacktestResult.trades()`).
 - **Multi-asset / panel harness**: `ObjectiveModel` trains a position book
   `(T, N)` from a panel `X`; book-aware ratio losses + `RankingLoss`;
   `Strategy`/`run_walk_forward`/`run_experiment` accept a `(T, N)` panel and return

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -46,16 +46,6 @@ Le harnais `fynance.research` est **livré** (S1–S3) : `Experiment`,
 - [ ] Explorateur **Streamlit** au-dessus du Ledger (parcourir / filtrer / comparer
   les runs persistés) — interactif, plus tardif.
 
-## 6. Metrics & trade analytics (épic `metrics-analytics`)
-
-- [ ] Métriques de queue : VaR/CVaR (historique, gaussien, Cornish-Fisher), CDaR,
-  tail dependence ; variantes roulantes causales ; registry `summary()`.
-- [ ] Métriques benchmark-relative (`metrics/benchmark.py`) : alpha/beta, tracking
-  error, IR, capture ratios + overlay tearsheet.
-- [ ] Analytics turnover & exposition (métriques + panneau tearsheet).
-- [ ] Analytics par trade : extraction round-trips (Numba) + `trade_summary()`
-  (win rate, profit factor, expectancy, streaks).
-
 ## 7. Backtest realism (épic `backtest-realism`)
 
 - [ ] Politiques de rebalancement + frictions : calendaire / no-trade band / budget

--- a/doc/source/metrics.rst
+++ b/doc/source/metrics.rst
@@ -123,6 +123,22 @@ of the ``METRICS`` registry.
    net_exposure
    exposure_summary
 
+Trade analytics
+===============
+
+Round-trip trade extraction from a position book -- distinct from the
+churn/turnover metrics above (:func:`sign_changes`, :func:`trades_per_year`):
+these describe individual trades (entry/exit, side, realized return) rather
+than how often the position flips. See also
+:meth:`~fynance.backtest.result.BacktestResult.trades` and
+:meth:`~fynance.backtest.result.BacktestResult.trade_summary`.
+
+.. autosummary::
+   :toctree: generated/
+
+   extract_trades
+   trade_summary
+
 Aggregated report
 =================
 

--- a/fynance/backtest/result.py
+++ b/fynance/backtest/result.py
@@ -54,6 +54,8 @@ class BacktestResult:
     to_numpy
     to_price_series
     summary
+    trades
+    trade_summary
 
     """
 
@@ -95,3 +97,36 @@ class BacktestResult:
             np.sum(trades_per_year(self.positions, period=period)))
 
         return out
+
+    def trades(self) -> NDArray:
+        """ Round-trip trades extracted from the strategy's own arrays.
+
+        Delegates to :func:`fynance.metrics.trades.extract_trades` on
+        :attr:`positions` and :attr:`returns`, taken exactly as stored (see
+        that function's docstring for the alignment convention this relies
+        on).
+
+        Returns
+        -------
+        numpy.ndarray
+            Structured array, one row per trade -- see
+            :func:`~fynance.metrics.trades.extract_trades`.
+        """
+        from fynance.metrics.trades import extract_trades
+
+        return extract_trades(self.positions, self.returns)
+
+    def trade_summary(self) -> dict[str, float]:
+        """ Summary statistics of the strategy's round-trip trades.
+
+        Delegates to :func:`fynance.metrics.trades.trade_summary` on
+        :meth:`trades`.
+
+        Returns
+        -------
+        dict of str to float
+            See :func:`~fynance.metrics.trades.trade_summary`.
+        """
+        from fynance.metrics.trades import trade_summary as _trade_summary
+
+        return _trade_summary(self.trades())

--- a/fynance/metrics/__init__.py
+++ b/fynance/metrics/__init__.py
@@ -24,6 +24,7 @@ from .returns import *
 from .returns import perf_strat, returns_strat  # noqa: F401
 from .risk import *
 from .summary import METRICS, summary  # noqa: F401
+from .trades import *
 from .trading import *
 
 # Aggregate __all__ via sys.modules (the star imports above rebind names that
@@ -33,18 +34,21 @@ from .trading import *
 # ``factor_rank_autocorr``), the trade-profile metrics (``sign_changes`` /
 # ``trades_per_year``), the benchmark-relative metrics (``beta``, ``alpha``,
 # ``tracking_error``, ``information_ratio``, ``capture_ratio``,
-# ``benchmark_summary``, ``roll_beta_benchmark``) and ``tail_dependence`` are
-# exported here but intentionally NOT added to the ``METRICS`` registry: that
-# registry maps a name to a callable taking a single equity/price curve (see
+# ``benchmark_summary``, ``roll_beta_benchmark``), ``tail_dependence`` and the
+# trade-level analytics (``extract_trades`` / ``trade_summary``) are exported
+# here but intentionally NOT added to the ``METRICS`` registry: that registry
+# maps a name to a callable taking a single equity/price curve (see
 # ``summary``), whereas the IC and factor helpers take an aligned
-# (pred, real) / (factor, fwd) pair, the trade-profile metrics take a position
-# series, the benchmark metrics take an aligned (strategy, benchmark) pair,
-# and ``tail_dependence`` takes a ``(T, N)`` returns panel, so none fit that
-# single-series contract. ``var``/``cvar``/``cdar`` (from ``risk``) do fit it
-# and are registered (see ``summary.METRICS``); their rolling variants
-# (``roll_var``/``roll_cvar``) are not, same as ``roll_sharpe``/``roll_calmar``.
+# (pred, real) / (factor, fwd) pair, the trade-profile / trade-level metrics
+# take a position (and, for the latter, a returns) series, the benchmark
+# metrics take an aligned (strategy, benchmark) pair, and ``tail_dependence``
+# takes a ``(T, N)`` returns panel, so none fit that single-series contract.
+# ``var``/``cvar``/``cdar`` (from ``risk``) do fit it and are registered (see
+# ``summary.METRICS``); their rolling variants (``roll_var``/``roll_cvar``)
+# are not, same as ``roll_sharpe``/``roll_calmar``.
 __all__ = []
-for _m in ("benchmark", "correlation", "returns", "ratios", "drawdown", "factor", "risk", "trading"):
+for _m in ("benchmark", "correlation", "returns", "ratios", "drawdown",
+           "factor", "risk", "trades", "trading"):
     __all__ += _sys.modules[f"{__name__}.{_m}"].__all__
 __all__ += ['perf_strat', 'returns_strat', 'METRICS', 'summary']
 

--- a/fynance/metrics/trades.py
+++ b/fynance/metrics/trades.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Trade-level analytics — round-trip extraction and summary statistics.
+
+Where :mod:`fynance.metrics.trading` describes *churn* (how often the position
+flips), this module describes individual **round-trip trades**: it segments a
+position series into maximal runs of constant nonzero sign and reports, per
+run, the entry/exit bars, side and compounded net return. :func:`trade_summary`
+then aggregates a set of such trades into the usual trading-desk statistics
+(win rate, profit factor, streaks, ...).
+
+"""
+
+from __future__ import annotations
+
+# Third-party packages
+import numpy as np
+from numba import njit
+from numpy.typing import NDArray
+
+__all__ = ['extract_trades', 'trade_summary']
+
+#: Structured dtype of the array returned by :func:`extract_trades`.
+TRADE_DTYPE = np.dtype([
+    ('asset', np.int16), ('t_in', np.int64), ('t_out', np.int64),
+    ('side', np.int8), ('ret', np.float64), ('bars', np.int64),
+])
+
+
+# --------------------------------------------------------------------------- #
+#   numba kernel                                                              #
+# --------------------------------------------------------------------------- #
+
+
+@njit(cache=True)
+def _extract_trades_kernel(positions, returns):
+    """ Scan one column and extract its maximal constant-sign runs.
+
+    A run breaks whenever ``sign(positions[t])`` changes -- including a
+    transition through/from ``0`` (flat) -- so a direct long -> short flip
+    with no flat bar in between yields two immediately adjacent trades (the
+    first's ``t_out`` is the bar right before the second's ``t_in``), rather
+    than being merged or skipped. ``NaN`` compares false to both ``> 0`` and
+    ``< 0``, so a ``NaN`` position is treated as flat (breaks any open run).
+    A run still open at the last bar is closed there and returned as-is
+    (see the ``extract_trades`` docstring).
+    """
+    T = positions.shape[0]
+    t_in_out = np.empty(T, dtype=np.int64)
+    t_out_out = np.empty(T, dtype=np.int64)
+    side_out = np.empty(T, dtype=np.int8)
+    ret_out = np.empty(T, dtype=np.float64)
+    bars_out = np.empty(T, dtype=np.int64)
+
+    n = 0
+    in_trade = False
+    cur_sign = np.int8(0)
+    cur_t_in = 0
+    compounded = 1.0
+
+    for t in range(T):
+        s = np.int8(0)
+        if positions[t] > 0:
+            s = np.int8(1)
+        elif positions[t] < 0:
+            s = np.int8(-1)
+
+        if in_trade and s == cur_sign:
+            compounded *= (1.0 + positions[t] * returns[t])
+        else:
+            if in_trade:
+                t_in_out[n] = cur_t_in
+                t_out_out[n] = t - 1
+                side_out[n] = cur_sign
+                ret_out[n] = compounded - 1.0
+                bars_out[n] = (t - 1) - cur_t_in + 1
+                n += 1
+                in_trade = False
+
+            if s != 0:
+                in_trade = True
+                cur_sign = s
+                cur_t_in = t
+                compounded = 1.0 + positions[t] * returns[t]
+
+    if in_trade:
+        t_in_out[n] = cur_t_in
+        t_out_out[n] = T - 1
+        side_out[n] = cur_sign
+        ret_out[n] = compounded - 1.0
+        bars_out[n] = (T - 1) - cur_t_in + 1
+        n += 1
+
+    return t_in_out[:n], t_out_out[:n], side_out[:n], ret_out[:n], bars_out[:n]
+
+
+# --------------------------------------------------------------------------- #
+#   public API                                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def extract_trades(positions: NDArray, returns: NDArray) -> NDArray:
+    r""" Extract round-trip trades from a position series.
+
+    A trade is a maximal run of bars over which ``sign(positions)`` is
+    constant and nonzero -- flat (``0``) bars are never part of a trade and
+    always close any open run. Its realized return is the compounded net
+    return of holding the (possibly sized, not just signed) position over the
+    run:
+
+    .. math::
+
+        ret = \prod_{t=t_{in}}^{t_{out}} \left(1 + positions_t \cdot
+              returns_t\right) - 1
+
+    ``positions`` and ``returns`` are assumed already aligned index-for-index
+    (``positions[t]`` earns ``returns[t]``) -- the convention
+    :class:`~fynance.backtest.result.BacktestResult` stores them in, so
+    ``extract_trades(result.positions, result.returns)`` and
+    :meth:`~fynance.backtest.result.BacktestResult.trades` agree exactly (see
+    that class for how the causal shift is folded into ``returns`` upstream,
+    in the engine).
+
+    Parameters
+    ----------
+    positions : np.ndarray[dtype, ndim=1 or 2]
+        Position / weight series, shape ``(T,)`` for a single asset or
+        ``(T, n_assets)`` for a book (column-wise, one independent scan per
+        column).
+    returns : np.ndarray[dtype, ndim=1 or 2]
+        Realized return series aligned with ``positions``. Either the same
+        shape as ``positions``, or, for a 2-D ``positions``, a 1-D array of
+        shape ``(T,)`` broadcast to every column (the
+        :class:`~fynance.backtest.result.BacktestResult` case: a single net
+        return path shared by every asset's own position run).
+
+    Returns
+    -------
+    np.ndarray[TRADE_DTYPE, ndim=1]
+        One row per trade, ordered by asset then by time within each asset,
+        with fields:
+
+        - ``asset`` (``int16``) -- column index (``0`` for a 1-D
+          ``positions``).
+        - ``t_in`` (``int64``) -- first bar of the run.
+        - ``t_out`` (``int64``) -- last bar of the run, inclusive. A run
+          still open at the last observation is included with its current
+          (unrealized) mark rather than dropped.
+        - ``side`` (``int8``) -- ``+1`` long, ``-1`` short.
+        - ``ret`` (``float64``) -- compounded net return over the run.
+        - ``bars`` (``int64``) -- ``t_out - t_in + 1``.
+
+    Raises
+    ------
+    ValueError
+        If ``positions`` or ``returns`` is not 1-D or 2-D, or their shapes
+        are incompatible (see above).
+
+    Examples
+    --------
+    A long run of two bars, a direct flip to a short run of two bars (no flat
+    gap -- two adjacent trades, not one), a flat bar, then an open long trade
+    at the end:
+
+    >>> import numpy as np
+    >>> positions = np.array([1.0, 1.0, -1.0, -1.0, 0.0, 1.0])
+    >>> returns = np.array([0.5, 0.5, 0.5, -0.5, 0.0, 0.25])
+    >>> trades = extract_trades(positions, returns)
+    >>> trades['t_in'], trades['t_out'], trades['side']
+    (array([0, 2, 5]), array([1, 3, 5]), array([ 1, -1,  1], dtype=int8))
+    >>> trades['ret']
+    array([ 1.25, -0.25,  0.25])
+    >>> trades['bars']
+    array([2, 2, 1])
+
+    A two-asset book: each column is scanned independently and tagged with
+    its own ``asset`` index:
+
+    >>> pos2 = np.array([[1.0, -1.0], [1.0, -1.0], [0.0, -1.0]])
+    >>> ret2 = np.array([[0.1, 0.1], [0.1, -0.1], [0.0, 0.2]])
+    >>> trades2 = extract_trades(pos2, ret2)
+    >>> trades2['asset']
+    array([0, 1], dtype=int16)
+    >>> trades2['t_in'], trades2['t_out']
+    (array([0, 0]), array([1, 2]))
+
+    See Also
+    --------
+    trade_summary
+    fynance.metrics.trading.sign_changes, fynance.metrics.trading.trades_per_year
+    fynance.backtest.result.BacktestResult.trades
+
+    """
+    pos = np.asarray(positions, dtype=np.float64)
+
+    if pos.ndim == 1:
+        pos2d = pos.reshape(-1, 1)
+    elif pos.ndim == 2:
+        pos2d = pos
+    else:
+
+        raise ValueError(f"positions must be 1-D or 2-D, got ndim={pos.ndim}")
+
+    T, N = pos2d.shape
+    ret = np.asarray(returns, dtype=np.float64)
+
+    if ret.ndim == 1:
+        if ret.shape[0] != T:
+
+            raise ValueError(
+                f"returns length {ret.shape[0]} != positions length {T}"
+            )
+        ret2d = np.broadcast_to(ret.reshape(-1, 1), (T, N))
+    elif ret.ndim == 2:
+        if ret.shape != pos2d.shape:
+
+            raise ValueError(
+                f"returns shape {ret.shape} != positions shape {pos2d.shape}"
+            )
+        ret2d = ret
+    else:
+
+        raise ValueError(f"returns must be 1-D or 2-D, got ndim={ret.ndim}")
+
+    chunks = []
+    for j in range(N):
+        t_in, t_out, side, r, bars = _extract_trades_kernel(
+            np.ascontiguousarray(pos2d[:, j]), np.ascontiguousarray(ret2d[:, j])
+        )
+        chunk = np.empty(t_in.shape[0], dtype=TRADE_DTYPE)
+        chunk['asset'] = 0 if pos.ndim == 1 else j
+        chunk['t_in'] = t_in
+        chunk['t_out'] = t_out
+        chunk['side'] = side
+        chunk['ret'] = r
+        chunk['bars'] = bars
+        chunks.append(chunk)
+
+    if chunks:
+
+        return np.concatenate(chunks)
+
+    return np.empty(0, dtype=TRADE_DTYPE)
+
+
+def _max_streak(mask: NDArray) -> int:
+    """ Longest run of consecutive ``True`` values in a 1-D boolean array. """
+    best = run = 0
+    for v in mask:
+        if v:
+            run += 1
+            best = max(best, run)
+        else:
+            run = 0
+
+    return best
+
+
+def trade_summary(trades: NDArray) -> dict[str, float]:
+    r""" Summary statistics of a set of round-trip trades.
+
+    Parameters
+    ----------
+    trades : np.ndarray[TRADE_DTYPE, ndim=1]
+        Output of :func:`extract_trades` (or any array sharing its dtype and
+        field semantics). ``max_win_streak`` / ``max_loss_streak`` are
+        computed over ``trades`` in the order given, so pass a single
+        asset's trades (already time-ordered) for a meaningful streak --
+        e.g. ``trades[trades['asset'] == k]``.
+
+    Returns
+    -------
+    dict of str to float
+        - ``n_trades`` -- number of trades.
+        - ``win_rate`` -- share of trades with ``ret > 0`` (of all trades,
+          not just wins + losses).
+        - ``profit_factor`` -- ``sum(wins) / abs(sum(losses))``; ``inf`` if
+          there are winning trades and no losing ones; ``NaN`` if there are
+          no trades or none with a nonzero return either way.
+        - ``avg_win``, ``avg_loss`` -- mean ``ret`` of winning / losing
+          trades (``avg_loss`` is negative); ``NaN`` if that side is empty.
+        - ``payoff_ratio`` -- ``avg_win / abs(avg_loss)``; ``NaN`` unless
+          both sides are non-empty.
+        - ``expectancy`` -- mean ``ret`` over *all* trades.
+        - ``max_win_streak``, ``max_loss_streak`` -- longest run of
+          consecutive winning / losing trades (a breakeven ``ret == 0``
+          trade breaks both streaks).
+        - ``mean_bars``, ``median_bars`` -- mean / median holding period.
+
+        ``trades`` empty: ``n_trades``, ``win_rate``, ``max_win_streak`` and
+        ``max_loss_streak`` are ``0.0``; every other field is ``NaN`` (there
+        is nothing to average).
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> positions = np.array([1.0, 1.0, -1.0, -1.0, 0.0, 1.0])
+    >>> returns = np.array([0.5, 0.5, 0.5, -0.5, 0.0, 0.25])
+    >>> trades = extract_trades(positions, returns)
+    >>> s = trade_summary(trades)
+    >>> s['n_trades'], s['win_rate']
+    (3.0, 0.6666666666666666)
+    >>> round(s['profit_factor'], 4)
+    6.0
+    >>> s['max_win_streak'], s['max_loss_streak']
+    (1.0, 1.0)
+
+    An empty set of trades reports zero counts and ``NaN`` averages:
+
+    >>> empty = extract_trades(np.zeros(4), np.zeros(4))
+    >>> trade_summary(empty)['n_trades'], trade_summary(empty)['profit_factor']
+    (0.0, nan)
+
+    See Also
+    --------
+    extract_trades
+
+    """
+    n = trades.shape[0]
+
+    if n == 0:
+
+        return {
+            'n_trades': 0.0,
+            'win_rate': 0.0,
+            'profit_factor': float('nan'),
+            'avg_win': float('nan'),
+            'avg_loss': float('nan'),
+            'payoff_ratio': float('nan'),
+            'expectancy': float('nan'),
+            'max_win_streak': 0.0,
+            'max_loss_streak': 0.0,
+            'mean_bars': float('nan'),
+            'median_bars': float('nan'),
+        }
+
+    ret = trades['ret'].astype(np.float64)
+    bars = trades['bars'].astype(np.float64)
+    win_mask = ret > 0.0
+    loss_mask = ret < 0.0
+    wins = ret[win_mask]
+    losses = ret[loss_mask]
+
+    sum_wins = float(wins.sum()) if wins.size else 0.0
+    sum_losses = float(losses.sum()) if losses.size else 0.0
+    abs_losses = abs(sum_losses)
+
+    if abs_losses > 0.0:
+        profit_factor = sum_wins / abs_losses
+    elif sum_wins > 0.0:
+        profit_factor = float('inf')
+    else:
+        profit_factor = float('nan')
+
+    avg_win = float(wins.mean()) if wins.size else float('nan')
+    avg_loss = float(losses.mean()) if losses.size else float('nan')
+    payoff_ratio = (
+        avg_win / abs(avg_loss) if wins.size and losses.size else float('nan')
+    )
+
+    return {
+        'n_trades': float(n),
+        'win_rate': float(win_mask.sum()) / n,
+        'profit_factor': profit_factor,
+        'avg_win': avg_win,
+        'avg_loss': avg_loss,
+        'payoff_ratio': payoff_ratio,
+        'expectancy': float(ret.mean()),
+        'max_win_streak': float(_max_streak(win_mask)),
+        'max_loss_streak': float(_max_streak(loss_mask)),
+        'mean_bars': float(bars.mean()),
+        'median_bars': float(np.median(bars)),
+    }
+
+
+if __name__ == '__main__':
+
+    import doctest
+
+    doctest.testmod()

--- a/fynance/tests/backtest/test_result.py
+++ b/fynance/tests/backtest/test_result.py
@@ -5,10 +5,12 @@
 
 # Third-party packages
 import numpy as np
+import pytest
 
 # Local packages
 from fynance.backtest import backtest
 from fynance.core import PriceSeries
+from fynance.metrics.trades import TRADE_DTYPE, extract_trades, trade_summary
 
 
 def test_summary_keys_and_finiteness():
@@ -43,3 +45,40 @@ def test_to_price_series():
 def test_max_drawdown_nonnegative():
     res = backtest(np.array([0.1, -0.5, 0.2]), np.ones(3), shift=False)
     assert res.summary()["max_drawdown"] >= 0.0
+
+
+def test_trades_matches_standalone_extract_trades():
+    rng = np.random.default_rng(7)
+    returns = rng.normal(0.0005, 0.01, 200)
+    positions = rng.choice([-1.0, 0.0, 1.0], size=200, p=[0.3, 0.2, 0.5])
+    res = backtest(returns, positions, shift=False)
+
+    out = res.trades()
+    ref = extract_trades(res.positions, res.returns)
+
+    assert out.dtype == TRADE_DTYPE
+    assert np.array_equal(out, ref)
+
+
+def test_trade_summary_matches_standalone_trade_summary():
+    rng = np.random.default_rng(11)
+    returns = rng.normal(0.0005, 0.01, 200)
+    positions = rng.choice([-1.0, 0.0, 1.0], size=200, p=[0.3, 0.2, 0.5])
+    res = backtest(returns, positions, shift=False)
+
+    out = res.trade_summary()
+    ref = trade_summary(res.trades())
+
+    assert out.keys() == ref.keys()
+    for key in out:
+        if np.isnan(ref[key]):
+            assert np.isnan(out[key])
+        else:
+            assert out[key] == pytest.approx(ref[key])
+
+
+def test_trades_empty_positions_edge():
+    res = backtest(np.zeros(10), np.zeros(10), shift=False)
+    out = res.trades()
+    assert out.shape[0] == 0
+    assert res.trade_summary()["n_trades"] == 0.0

--- a/fynance/tests/metrics/test_trades.py
+++ b/fynance/tests/metrics/test_trades.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for trade-level analytics (round-trip extraction, trade_summary). """
+
+# Third-party packages
+import numpy as np
+import pytest
+
+# Local packages
+from fynance.metrics.trades import TRADE_DTYPE, extract_trades, trade_summary
+
+# --------------------------------------------------------------------------- #
+#   extract_trades -- deterministic paths                                     #
+# --------------------------------------------------------------------------- #
+
+
+def test_extract_trades_flip_and_open_trade():
+    # Long run [0, 1], direct flip to short [2, 3] (no flat gap -- two
+    # adjacent trades), a flat bar, then an open long trade at the end.
+    positions = np.array([1.0, 1.0, -1.0, -1.0, 0.0, 1.0])
+    returns = np.array([0.5, 0.5, 0.5, -0.5, 0.0, 0.25])
+    out = extract_trades(positions, returns)
+
+    assert out.dtype == TRADE_DTYPE
+    assert out.shape[0] == 3
+
+    assert list(out['asset']) == [0, 0, 0]
+    assert list(out['t_in']) == [0, 2, 5]
+    assert list(out['t_out']) == [1, 3, 5]
+    assert list(out['side']) == [1, -1, 1]
+    assert list(out['bars']) == [2, 2, 1]
+    assert out['ret'][0] == pytest.approx(1.5 * 1.5 - 1.0)
+    assert out['ret'][1] == pytest.approx(0.5 * 1.5 - 1.0)
+    assert out['ret'][2] == pytest.approx(0.25)
+
+
+def test_extract_trades_flat_gap_is_not_a_trade():
+    positions = np.array([0.0, 0.0, 1.0, 0.0, 0.0])
+    returns = np.array([0.1, 0.1, 0.2, 0.1, 0.1])
+    out = extract_trades(positions, returns)
+    assert out.shape[0] == 1
+    assert out['t_in'][0] == 2
+    assert out['t_out'][0] == 2
+    assert out['bars'][0] == 1
+    assert out['ret'][0] == pytest.approx(0.2)
+
+
+def test_extract_trades_sized_position_is_one_trade():
+    # Constant sign but varying magnitude within the run stays one trade;
+    # ret compounds using the actual (sized) position at each bar.
+    positions = np.array([0.5, 1.0, 0.25])
+    returns = np.array([0.1, 0.1, 0.1])
+    out = extract_trades(positions, returns)
+    assert out.shape[0] == 1
+    assert out['t_in'][0] == 0
+    assert out['t_out'][0] == 2
+    expected = (1 + 0.5 * 0.1) * (1 + 1.0 * 0.1) * (1 + 0.25 * 0.1) - 1.0
+    assert out['ret'][0] == pytest.approx(expected)
+
+
+def test_extract_trades_all_zero_positions_yields_no_trades():
+    positions = np.zeros(10)
+    returns = np.zeros(10)
+    out = extract_trades(positions, returns)
+    assert out.shape[0] == 0
+    assert out.dtype == TRADE_DTYPE
+
+
+def test_extract_trades_2d_book_per_asset():
+    # asset 0: long [0,1], flat, long [3]. asset 1: short over the whole book.
+    positions = np.array([
+        [1.0, -1.0],
+        [1.0, -1.0],
+        [0.0, -1.0],
+        [1.0, -1.0],
+    ])
+    returns = np.array([
+        [0.1, 0.1],
+        [0.1, -0.1],
+        [0.0, 0.2],
+        [0.1, 0.1],
+    ])
+    out = extract_trades(positions, returns)
+    assert out.shape[0] == 3
+
+    asset0 = out[out['asset'] == 0]
+    asset1 = out[out['asset'] == 1]
+    assert list(asset0['t_in']) == [0, 3]
+    assert list(asset0['t_out']) == [1, 3]
+    assert asset1.shape[0] == 1
+    assert asset1['t_in'][0] == 0
+    assert asset1['t_out'][0] == 3
+    assert asset1['side'][0] == -1
+
+
+def test_extract_trades_returns_broadcast_1d_over_2d_positions():
+    # A single 1-D return path shared by every asset column (the
+    # BacktestResult convention).
+    positions = np.array([[1.0, -1.0], [1.0, -1.0]])
+    returns = np.array([0.1, 0.2])
+    out = extract_trades(positions, returns)
+    assert out.shape[0] == 2
+    asset0 = out[out['asset'] == 0]
+    asset1 = out[out['asset'] == 1]
+    assert asset0['ret'][0] == pytest.approx(1.1 * 1.2 - 1.0)
+    assert asset1['ret'][0] == pytest.approx(0.9 * 0.8 - 1.0)
+
+
+def test_extract_trades_invalid_shapes_raise():
+    with pytest.raises(ValueError):
+        extract_trades(np.zeros((2, 2, 2)), np.zeros((2, 2, 2)))
+    with pytest.raises(ValueError):
+        extract_trades(np.zeros(5), np.zeros(4))
+    with pytest.raises(ValueError):
+        extract_trades(np.zeros((4, 2)), np.zeros((4, 3)))
+
+
+# --------------------------------------------------------------------------- #
+#   extract_trades -- numba vs. slow-python parity                            #
+# --------------------------------------------------------------------------- #
+
+
+def _slow_extract_trades(positions, returns):
+    """ Pure-python reference (no numba), mirroring the kernel's own scan. """
+    pos = np.asarray(positions, dtype=np.float64)
+    ret = np.asarray(returns, dtype=np.float64)
+    if pos.ndim == 1:
+        pos = pos.reshape(-1, 1)
+    if ret.ndim == 1:
+        ret = np.broadcast_to(ret.reshape(-1, 1), pos.shape)
+
+    T, N = pos.shape
+    rows = []
+    for j in range(N):
+        in_trade = False
+        cur_sign = 0
+        cur_t_in = 0
+        compounded = 1.0
+        for t in range(T):
+            p = float(pos[t, j])
+            if p > 0:
+                s = 1
+            elif p < 0:
+                s = -1
+            else:
+                s = 0
+
+            if in_trade and s == cur_sign:
+                compounded *= (1.0 + p * float(ret[t, j]))
+            else:
+                if in_trade:
+                    rows.append(
+                        (j, cur_t_in, t - 1, cur_sign, compounded - 1.0,
+                         (t - 1) - cur_t_in + 1)
+                    )
+                    in_trade = False
+                if s != 0:
+                    in_trade = True
+                    cur_sign = s
+                    cur_t_in = t
+                    compounded = 1.0 + p * float(ret[t, j])
+        if in_trade:
+            rows.append(
+                (j, cur_t_in, T - 1, cur_sign, compounded - 1.0,
+                 (T - 1) - cur_t_in + 1)
+            )
+    return rows
+
+
+def test_extract_trades_numba_matches_slow_python_reference():
+    rng = np.random.default_rng(42)
+    T, N = 500, 3
+    # Ternary signal (long/flat/short) so runs, flips and flat gaps all occur.
+    positions = rng.choice([-1.0, 0.0, 1.0], size=(T, N), p=[0.3, 0.2, 0.5])
+    returns = rng.normal(0.0, 0.01, size=(T, N))
+
+    out = extract_trades(positions, returns)
+    ref = _slow_extract_trades(positions, returns)
+
+    assert out.shape[0] == len(ref)
+    for row, (asset, t_in, t_out, side, ret, bars) in zip(out, ref):
+        assert int(row['asset']) == asset
+        assert int(row['t_in']) == t_in
+        assert int(row['t_out']) == t_out
+        assert int(row['side']) == side
+        assert int(row['bars']) == bars
+        assert row['ret'] == ret
+
+
+# --------------------------------------------------------------------------- #
+#   trade_summary                                                             #
+# --------------------------------------------------------------------------- #
+
+
+def test_trade_summary_hand_values():
+    positions = np.array([1.0, 1.0, -1.0, -1.0, 0.0, 1.0])
+    returns = np.array([0.5, 0.5, 0.5, -0.5, 0.0, 0.25])
+    trades = extract_trades(positions, returns)
+    # rets: [1.25, -0.25, 0.25] -> 2 wins, 1 loss
+    s = trade_summary(trades)
+
+    assert s['n_trades'] == 3.0
+    assert s['win_rate'] == pytest.approx(2.0 / 3.0)
+    assert s['profit_factor'] == pytest.approx((1.25 + 0.25) / 0.25)
+    assert s['avg_win'] == pytest.approx((1.25 + 0.25) / 2.0)
+    assert s['avg_loss'] == pytest.approx(-0.25)
+    assert s['payoff_ratio'] == pytest.approx(s['avg_win'] / abs(s['avg_loss']))
+    assert s['expectancy'] == pytest.approx((1.25 - 0.25 + 0.25) / 3.0)
+    assert s['mean_bars'] == pytest.approx((2 + 2 + 1) / 3.0)
+    assert s['median_bars'] == pytest.approx(2.0)
+
+
+def test_trade_summary_streaks():
+    # ret sequence: win, win, loss, win, loss, loss, loss -> max_win=2, max_loss=3
+    trades = np.zeros(7, dtype=TRADE_DTYPE)
+    trades['ret'] = [0.1, 0.2, -0.1, 0.05, -0.2, -0.1, -0.3]
+    trades['bars'] = 1
+    s = trade_summary(trades)
+    assert s['max_win_streak'] == 2.0
+    assert s['max_loss_streak'] == 3.0
+
+
+def test_trade_summary_no_losses_is_inf_profit_factor():
+    trades = np.zeros(2, dtype=TRADE_DTYPE)
+    trades['ret'] = [0.1, 0.2]
+    trades['bars'] = 1
+    s = trade_summary(trades)
+    assert s['profit_factor'] == float('inf')
+    assert np.isnan(s['payoff_ratio'])  # no losses to compare against
+    assert np.isnan(s['avg_loss'])
+
+
+def test_trade_summary_empty_is_zeros_and_nan():
+    empty = np.empty(0, dtype=TRADE_DTYPE)
+    s = trade_summary(empty)
+
+    assert s['n_trades'] == 0.0
+    assert s['win_rate'] == 0.0
+    assert s['max_win_streak'] == 0.0
+    assert s['max_loss_streak'] == 0.0
+    for key in ('profit_factor', 'avg_win', 'avg_loss', 'payoff_ratio',
+                'expectancy', 'mean_bars', 'median_bars'):
+        assert np.isnan(s[key])


### PR DESCRIPTION
## Summary
- New `fynance.metrics.trades`: `extract_trades(positions, returns)` → structured array (asset, t_in, t_out, side, compounded ret, bars; Numba scan; long→short flips = two trades; open final trade marked); `trade_summary` (win rate, profit factor, avg win/loss, payoff, expectancy, streaks, holding stats).
- `BacktestResult.trades()` / `.trade_summary()` additive conveniences (documented alignment caveat vs the engine's internal shift).
- **Last leaf (04) of the `metrics-analytics` epic** — removes roadmap §6, updates status (epic PRs #253–#257).

## Verification (seeded SMA 10/50 crossover, T=2000)
48 trades, win rate 0.458, profit factor 0.796, mean holding 40.6 bars; n_trades == sign_changes on this path with the general identity documented (n_trades ≤ sign_changes + 1).

## Test plan
- [x] `pytest` — 1402 passed post-rebase (exact hand-built paths, flip/open-trade edges, Numba parity, BacktestResult integration)
- [x] `ruff` / `mypy` / interrogate / Sphinx -W
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)