### PR TITLE
feat: add holding costs and composite cost stacking (backtest.cost)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Holding costs & composite cost stacking.** `HoldingCost` (per-bar
+  borrow on short gross, financing on leverage above 1, cash-rate credit on
+  idle cash) and `CompositeCost` (sum of any cost models, merged
+  `components()` breakdown) in `fynance.backtest.cost`.
 - **Rebalancing policies & execution frictions.** New
   `fynance.portfolio.rebalance`: causal `(T, N)` book transforms —
   `rebalance_calendar` / `rebalance_band` (full or to-edge) /

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -72,7 +72,7 @@ Template:
 
 <!-- new entries below, newest first -->
 
-### 2026-07-06 — Backtest-realism epic (PRs #258, epic)  [accepted]
+### 2026-07-06 — Backtest-realism epic (PRs #258–#259, epic)  [accepted]
 
 - **Choice**: ship execution realism as composable, causal `(T, N)`
   transforms that sit between the allocator/signal and the vectorized

--- a/doc/source/backtest.rst
+++ b/doc/source/backtest.rst
@@ -14,5 +14,7 @@ Vectorized backtesting engine and result. Plotting/reporting lives in
    BacktestResult
    ProportionalCost
    MarketImpactCost
+   HoldingCost
+   CompositeCost
    set_text_stats
    BacktestNeuralNet

--- a/fynance/backtest/cost.py
+++ b/fynance/backtest/cost.py
@@ -3,23 +3,30 @@
 
 """ Transaction cost models for the vectorized backtest engine.
 
-Concretizes the :class:`~fynance.core.protocols.CostModel` seam. Two models
-ship: :class:`ProportionalCost` (linear, turnover-based) and
-:class:`MarketImpactCost` (adds a convex, super-linear market-impact term — the
-square-root impact law).
+Concretizes the :class:`~fynance.core.protocols.CostModel` seam. Four models
+ship: :class:`ProportionalCost` (linear, turnover-based), :class:`MarketImpactCost`
+(adds a convex, super-linear market-impact term — the square-root impact law),
+:class:`HoldingCost` (per-bar carry on the held book: borrow, financing and a
+cash credit) and :class:`CompositeCost` (stacks any number of the above, or
+any other :class:`~fynance.core.protocols.CostModel`-conforming model, into
+one).
 
 """
 
 from __future__ import annotations
+
+# Built-in packages
+from typing import Sequence
 
 # Third-party packages
 import numpy as np
 from numpy.typing import NDArray
 
 # Local packages
+from fynance.core.protocols import CostModel
 from fynance.portfolio.sizing import transaction_cost
 
-__all__ = ['ProportionalCost', 'MarketImpactCost']
+__all__ = ['ProportionalCost', 'MarketImpactCost', 'HoldingCost', 'CompositeCost']
 
 
 class ProportionalCost:
@@ -144,3 +151,179 @@ class MarketImpactCost:
             "transaction": self.fee * turnover,
             "market_impact": self.impact * turnover ** self.exponent,
         }
+
+
+class HoldingCost:
+    r""" Per-bar carry cost on the held book (not turnover).
+
+    Unlike :class:`ProportionalCost` and :class:`MarketImpactCost`, which
+    charge on *trades* (the change between consecutive weights),
+    :class:`HoldingCost` charges on the *held* weights at each bar: shorting,
+    leverage and idle cash all carry a cost — or, for idle cash, a credit —
+    for every bar the position is held, regardless of turnover. Three
+    additive terms, each de-annualized to a per-bar rate (``rate / period``):
+
+    - **borrow**: cost of the short gross exposure
+      :math:`\sum_i \max(-w_{t,i}, 0)`, at the annualized ``borrow`` rate.
+    - **financing**: cost of leverage in excess of fully invested (total
+      gross exposure above 1), :math:`\max\big(0, \sum_i |w_{t,i}| - 1\big)`,
+      at the annualized ``financing`` rate.
+    - **cash**: a *credit* (non-positive) on unused cash,
+      :math:`\max\big(0, 1 - \sum_i |w_{t,i}|\big)`, at the annualized
+      ``cash_rate``.
+
+    .. math::
+
+        c_t = \frac{borrow}{period} \sum_i \max(-w_{t,i}, 0)
+            + \frac{financing}{period}
+              \max\Big(0, \sum_i |w_{t,i}| - 1\Big)
+            - \frac{cash\_rate}{period}
+              \max\Big(0, 1 - \sum_i |w_{t,i}|\Big)
+
+    The total cost at each bar is the sum of the three terms; see
+    :meth:`components` for the per-term breakdown. Conforms to
+    :class:`~fynance.core.protocols.CostModel`.
+
+    Parameters
+    ----------
+    borrow : float
+        Annualized borrow rate charged on short gross exposure (e.g. ``0.02``
+        = 2%/yr). Default 0.0.
+    financing : float
+        Annualized financing rate charged on leverage above 1x (gross
+        exposure in excess of fully invested). Default 0.0.
+    cash_rate : float
+        Annualized rate credited on unused cash (idle capital not deployed
+        into any position). Default 0.0.
+    period : int
+        Number of bars per year used to de-annualize the rates (e.g. ``252``
+        for daily bars, ``12`` for monthly). Default 252.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> cost = HoldingCost(borrow=0.02, financing=0.01, cash_rate=0.005, period=250)
+    >>> w = np.array([[0.5, 0.0], [-0.5, 1.5], [0.0, 0.0]])
+    >>> cost(w)
+    array([-1.e-05,  8.e-05, -2.e-05])
+
+    """
+
+    def __init__(
+        self,
+        borrow: float = 0.0,
+        financing: float = 0.0,
+        cash_rate: float = 0.0,
+        period: int = 252,
+    ):
+        """ Store the annualized rates and the de-annualization period. """
+        self.borrow = borrow
+        self.financing = financing
+        self.cash_rate = cash_rate
+        self.period = period
+
+    def _exposures(self, weights: NDArray) -> tuple[NDArray, NDArray]:
+        """ Return per-bar (short gross, total gross) exposure. """
+        w = np.asarray(weights, dtype=np.float64)
+
+        if w.ndim == 1:
+
+            return np.maximum(-w, 0.0), np.abs(w)
+
+        return np.maximum(-w, 0.0).sum(axis=1), np.abs(w).sum(axis=1)
+
+    def __call__(self, weights: NDArray) -> NDArray[np.float64]:
+        """ Return the per-step (borrow + financing - cash credit) cost. """
+        comps = self.components(weights)
+
+        return comps["borrow"] + comps["financing"] + comps["cash"]
+
+    def components(self, weights: NDArray) -> dict[str, NDArray[np.float64]]:
+        """ Per-step cost split into its borrow/financing/cash terms.
+
+        Returns ``{"borrow", "financing", "cash"}``; the values sum to
+        :meth:`__call__`. ``cash`` entries are non-positive (a credit on idle
+        capital). The optional ``components`` convention lets the engine
+        carry a cost breakdown for the tearsheet's cumulative-fees panel.
+        """
+        short, gross = self._exposures(weights)
+
+        return {
+            "borrow": (self.borrow / self.period) * short,
+            "financing": (self.financing / self.period)
+            * np.maximum(0.0, gross - 1.0),
+            "cash": -(self.cash_rate / self.period)
+            * np.maximum(0.0, 1.0 - gross),
+        }
+
+
+class CompositeCost:
+    """ Stack several cost models into one.
+
+    Sums the per-step cost of every model in ``models`` (each of which must
+    conform to :class:`~fynance.core.protocols.CostModel`), so a single
+    :class:`CompositeCost` instance can be passed to
+    :func:`~fynance.backtest.engine.backtest` wherever one ``cost`` model is
+    expected. Conforms to :class:`~fynance.core.protocols.CostModel` itself.
+
+    Parameters
+    ----------
+    models : sequence of CostModel
+        The cost models to stack, in the order their components are merged
+        by :meth:`components`.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> cost = CompositeCost(
+    ...     [ProportionalCost(fee=0.001), HoldingCost(borrow=0.02, period=250)]
+    ... )
+    >>> w = np.array([[1.0, 0.0], [-0.5, 0.5], [-0.5, 0.5]])
+    >>> cost(w)
+    array([1.00e-03, 2.04e-03, 4.00e-05])
+
+    """
+
+    def __init__(self, models: Sequence[CostModel]):
+        """ Store the sequence of cost models to stack. """
+        self.models = list(models)
+
+    def __call__(self, weights: NDArray) -> NDArray[np.float64]:
+        """ Return the per-step cost summed over every stacked model. """
+        w = np.asarray(weights, dtype=np.float64)
+        n = w.shape[0]
+        total = np.zeros(n, dtype=np.float64)
+
+        for model in self.models:
+            total = total + np.asarray(model(weights), dtype=np.float64)
+
+        return total
+
+    def components(self, weights: NDArray) -> dict[str, NDArray[np.float64]]:
+        """ Merge the per-step components of every stacked model.
+
+        Each model contributes its own :meth:`components` breakdown (or, if a
+        model does not expose ``components``, its total under a key equal to
+        its class name). Component keys are merged in ``models`` order; when a
+        key already produced by an earlier model recurs, the *later*
+        occurrence is disambiguated by prefixing it with its owning class
+        name, e.g. ``"transaction"`` then ``"MarketImpactCost.transaction"``.
+        The merged values sum to :meth:`__call__`.
+        """
+        merged: dict[str, NDArray[np.float64]] = {}
+
+        for model in self.models:
+            cls_name = type(model).__name__
+            if hasattr(model, "components"):
+                comps = model.components(weights)
+
+            else:
+                comps = {cls_name: model(weights)}
+
+            for key, value in comps.items():
+                if key in merged:
+                    key = f"{cls_name}.{key}"
+
+                merged[key] = np.asarray(value, dtype=np.float64)
+
+        return merged

--- a/fynance/tests/backtest/test_cost.py
+++ b/fynance/tests/backtest/test_cost.py
@@ -7,9 +7,13 @@
 import numpy as np
 import pytest
 
-from fynance.backtest.cost import MarketImpactCost, ProportionalCost
-
 # Local packages
+from fynance.backtest.cost import (
+    CompositeCost,
+    HoldingCost,
+    MarketImpactCost,
+    ProportionalCost,
+)
 from fynance.backtest.engine import backtest
 from fynance.core import CostModel
 from fynance.portfolio.sizing import transaction_cost
@@ -117,3 +121,131 @@ def test_impact_lowers_net_equity_in_backtest():
     # lower final equity.
     assert impacted.costs.sum() > base.costs.sum()
     assert impacted.equity[-1] < base.equity[-1]
+
+
+# -- HoldingCost ------------------------------------------------------------
+
+
+def test_holding_conforms_to_protocol():
+    assert isinstance(HoldingCost(), CostModel)
+
+
+def test_holding_long_only_unlevered_zero_borrow_financing_cash_credit():
+    # Gross exposure never exceeds 1 and weights are never negative: borrow
+    # and financing are zero on every bar, while idle cash earns a credit
+    # (a non-positive cost) proportional to the unused capital 1 - gross.
+    w = np.array([[0.5, 0.0], [0.3, 0.3], [0.0, 0.0]])
+    period = 250
+    cost = HoldingCost(borrow=0.02, financing=0.01, cash_rate=0.01, period=period)
+    gross = np.abs(w).sum(axis=1)
+    expected_cash = -(0.01 / period) * (1.0 - gross)
+    assert np.allclose(cost(w), expected_cash, rtol=1e-12)
+    comps = cost.components(w)
+    assert np.allclose(comps["borrow"], [0.0, 0.0, 0.0])
+    assert np.allclose(comps["financing"], [0.0, 0.0, 0.0])
+    assert np.all(comps["cash"] <= 0.0)
+
+
+def test_holding_short_book_charges_borrow_only():
+    # A fully (and constantly) short, unit-gross book isolates the borrow
+    # term: financing (gross never exceeds 1) and the cash credit (gross is
+    # never below 1) both stay at zero on every bar.
+    w = np.array([[-1.0], [-1.0], [-1.0]])
+    period = 250
+    cost = HoldingCost(borrow=0.02, financing=0.01, cash_rate=0.01, period=period)
+    expected = np.full(3, 0.02 / period)
+    assert np.allclose(cost(w), expected, rtol=1e-12)
+    comps = cost.components(w)
+    assert np.allclose(comps["borrow"], expected, rtol=1e-12)
+    assert np.allclose(comps["financing"], [0.0, 0.0, 0.0])
+    assert np.allclose(comps["cash"], [0.0, 0.0, 0.0])
+
+
+def test_holding_leverage_two_charges_financing_on_excess_only():
+    # A constant 2x-levered, long-only book isolates the financing term: it
+    # is charged on the gross exposure in excess of 1 (i.e. 1.0 here), while
+    # borrow (no shorts) and the cash credit (gross exceeds 1) are zero.
+    w = np.array([[2.0], [2.0], [2.0]])
+    period = 250
+    cost = HoldingCost(borrow=0.02, financing=0.01, cash_rate=0.01, period=period)
+    expected = np.full(3, 0.01 / period)
+    assert np.allclose(cost(w), expected, rtol=1e-12)
+    comps = cost.components(w)
+    assert np.allclose(comps["financing"], expected, rtol=1e-12)
+    assert np.allclose(comps["borrow"], [0.0, 0.0, 0.0])
+    assert np.allclose(comps["cash"], [0.0, 0.0, 0.0])
+
+
+def test_holding_zero_rates_zero_cost():
+    rng = np.random.default_rng(1)
+    w = rng.standard_normal((3, 4))
+    cost = HoldingCost(borrow=0.0, financing=0.0, cash_rate=0.0, period=252)
+    assert np.allclose(cost(w), [0.0, 0.0, 0.0])
+
+
+def test_holding_components_sum_to_total():
+    rng = np.random.default_rng(2)
+    w = rng.standard_normal((50, 3)) * 1.5   # mixed long/short/leveraged book
+    cost = HoldingCost(borrow=0.03, financing=0.015, cash_rate=0.01, period=252)
+    comps = cost.components(w)
+    assert set(comps) == {"borrow", "financing", "cash"}
+    total = comps["borrow"] + comps["financing"] + comps["cash"]
+    assert np.allclose(total, cost(w), rtol=1e-12)
+    assert np.all(comps["cash"] <= 0.0)
+
+
+# -- CompositeCost ------------------------------------------------------------
+
+
+def test_composite_conforms_to_protocol():
+    assert isinstance(CompositeCost([ProportionalCost()]), CostModel)
+
+
+def test_composite_equals_sum_of_parts_through_backtest():
+    rng = np.random.default_rng(3)
+    T, N = 1000, 5
+    returns = rng.standard_normal((T, N)) * 0.01
+    pos = rng.standard_normal((T, N))
+    pos = pos / np.abs(pos).sum(axis=1, keepdims=True) * 2.0   # gross ~= 2
+
+    prop = ProportionalCost(fee=0.001)
+    holding = HoldingCost(borrow=0.02, financing=0.01)
+
+    result_prop = backtest(returns, pos, cost=prop)
+    result_holding = backtest(returns, pos, cost=holding)
+    result_composite = backtest(returns, pos, cost=CompositeCost([prop, holding]))
+
+    manual_costs = result_prop.costs + result_holding.costs
+    assert np.allclose(result_composite.costs, manual_costs, rtol=1e-12)
+
+    manual_equity = np.cumprod(1.0 + result_composite.gross_returns - manual_costs)
+    assert np.allclose(result_composite.equity, manual_equity, rtol=1e-10)
+
+
+def test_composite_components_sum_to_total():
+    rng = np.random.default_rng(4)
+    w = rng.standard_normal((20, 3))
+    models = [ProportionalCost(fee=0.001), HoldingCost(borrow=0.02, financing=0.01)]
+    cost = CompositeCost(models)
+    comps = cost.components(w)
+    total = sum(comps.values())
+    assert np.allclose(total, cost(w), rtol=1e-12)
+
+
+def test_composite_components_prefix_duplicate_keys():
+    # Two ProportionalCost models both emit a "transaction" component: the
+    # later one is disambiguated by prefixing its class name.
+    w = np.array([[1.0, 0.0], [0.5, 0.5], [0.0, 1.0]])
+    cost = CompositeCost([ProportionalCost(fee=0.001), ProportionalCost(fee=0.002)])
+    comps = cost.components(w)
+    assert set(comps) == {"transaction", "ProportionalCost.transaction"}
+    assert np.allclose(comps["transaction"] + comps["ProportionalCost.transaction"], cost(w))
+
+
+def test_composite_components_merges_holding_terms():
+    w = np.array([[1.0, 0.0], [-0.5, 0.5], [2.0, 0.0]])
+    cost = CompositeCost(
+        [ProportionalCost(fee=0.001), HoldingCost(borrow=0.02, financing=0.01)]
+    )
+    comps = cost.components(w)
+    assert set(comps) == {"transaction", "borrow", "financing", "cash"}


### PR DESCRIPTION
## Summary
- `HoldingCost(borrow, financing, cash_rate, period)`: per-bar carry on the held book — borrow on short gross `Σmax(−w,0)`, financing on leverage `max(0, Σ|w|−1)`, minus a cash-rate credit on `max(0, 1−Σ|w|)`; `components()` → {borrow, financing, cash}.
- `CompositeCost(models)`: sums any CostModel-conforming parts, merges their `components()` (class-name-prefixed on key collisions).
- Both conform to the CostModel protocol as `backtest()` consumes it. Leaf 02/04 of the `backtest-realism` epic.

## Verification (long-short book, T=1000, N=5, gross ≈ 2)
Composite vs ProportionalCost-only: final equity 0.0637 vs 0.0719; component shares transaction 95.8% / borrow 2.8% / financing 1.4%; composite == manual sum of independent backtests (rtol 1e-12).

## Test plan
- [x] `pytest` — passed (per-term hand cases, composite==sum through backtest(), components sum-to-total, protocol conformance)
- [x] `ruff` / `mypy` / interrogate / Sphinx -W
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)