### PR TITLE
feat: add capacity analysis (net Sharpe vs AUM, breakeven fee)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Capacity analysis.** `capacity_curve` (net Sharpe / net annual return /
+  total cost vs a sweep of AUM levels via a caller-supplied
+  AUM→CostModel factory) and `breakeven_fee` (bisection for the fee at which
+  net Sharpe hits zero) in `fynance.backtest.capacity`.
 - **Holding costs & composite cost stacking.** `HoldingCost` (per-bar
   borrow on short gross, financing on leverage above 1, cash-rate credit on
   idle cash) and `CompositeCost` (sum of any cost models, merged

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -72,7 +72,7 @@ Template:
 
 <!-- new entries below, newest first -->
 
-### 2026-07-06 — Backtest-realism epic (PRs #258–#259, epic)  [accepted]
+### 2026-07-06 — Backtest-realism epic (PRs #258–#260, epic)  [accepted]
 
 - **Choice**: ship execution realism as composable, causal `(T, N)`
   transforms that sit between the allocator/signal and the vectorized

--- a/doc/source/backtest.rst
+++ b/doc/source/backtest.rst
@@ -16,5 +16,7 @@ Vectorized backtesting engine and result. Plotting/reporting lives in
    MarketImpactCost
    HoldingCost
    CompositeCost
+   capacity_curve
+   breakeven_fee
    set_text_stats
    BacktestNeuralNet

--- a/fynance/backtest/__init__.py
+++ b/fynance/backtest/__init__.py
@@ -15,8 +15,9 @@ longer pulls matplotlib.
 
 """
 
-from . import backtest_neural_net, cost, engine, print_stats, result
+from . import backtest_neural_net, capacity, cost, engine, print_stats, result
 from .backtest_neural_net import *
+from .capacity import *
 from .cost import *
 from .engine import *
 from .print_stats import *
@@ -27,3 +28,4 @@ __all__ += cost.__all__
 __all__ += engine.__all__
 __all__ += result.__all__
 __all__ += backtest_neural_net.__all__
+__all__ += capacity.__all__

--- a/fynance/backtest/capacity.py
+++ b/fynance/backtest/capacity.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Capacity analysis: net Sharpe vs AUM, and the breakeven fee.
+
+Two questions a strategy owner asks before sizing up: how does performance
+degrade as more capital is deployed (:func:`capacity_curve`), and how large a
+proportional fee can the strategy absorb before it stops being worth trading
+(:func:`breakeven_fee`)? Both reuse :func:`~fynance.backtest.engine.backtest`
+unchanged — capacity is a sweep over cost models, not a new engine.
+
+"""
+
+from __future__ import annotations
+
+# Built-in packages
+from typing import Any, Callable
+
+# Third-party packages
+import numpy as np
+from numpy.typing import NDArray
+
+# Local packages
+from fynance.backtest.cost import ProportionalCost
+from fynance.backtest.engine import backtest
+
+__all__ = ['capacity_curve', 'breakeven_fee']
+
+#: Fee cap (proportional, per unit traded) above which :func:`breakeven_fee`
+#: gives up and reports the strategy has no breakeven fee below it.
+_FEE_CAP = 0.10
+
+
+def capacity_curve(
+    weights: Any,
+    X: Any,
+    aums: Any,
+    cost_factory: Callable[[float], Any],
+    period: int = 252,
+) -> dict[str, NDArray[np.float64]]:
+    """ Sweep net performance across a book of AUM levels.
+
+    Runs :func:`~fynance.backtest.engine.backtest` once per AUM level, each
+    time with the cost model ``cost_factory`` builds for that level. The
+    caller encodes how cost should scale with size (e.g. a market-impact
+    coefficient growing with the square root of AUM) inside ``cost_factory``;
+    this function only orchestrates the sweep and collects the results.
+
+    Parameters
+    ----------
+    weights : array-like
+        Position/weight book, shape ``(T,)`` for a single asset or
+        ``(T, N)`` for a multi-asset book.
+    X : array-like
+        Price levels aligned with ``weights`` (same shape); passed to
+        :func:`~fynance.backtest.engine.backtest` as ``returns_input=False``.
+    aums : array-like
+        1-D array of AUM levels to sweep, typically increasing.
+    cost_factory : callable
+        Maps an AUM level (float) to a cost model (e.g.
+        :class:`~fynance.backtest.cost.MarketImpactCost`) conforming to
+        :class:`~fynance.core.protocols.CostModel`.
+    period : int
+        Annualization factor forwarded to
+        :meth:`~fynance.backtest.result.BacktestResult.summary`.
+
+    Returns
+    -------
+    dict of str to numpy.ndarray
+        ``aum``, ``net_sharpe``, ``net_annual_return`` and ``total_cost``,
+        one entry per AUM level, aligned with ``aums``.
+
+    Raises
+    ------
+    ValueError
+        If ``aums`` is not 1-D, or ``weights`` and ``X`` do not share the
+        same shape.
+
+    Examples
+    --------
+    A single-asset strategy with a small planted edge (``0.06%`` of the
+    signal per bar) and turnover from a noisy signal, swept across AUM
+    levels with a square-root market-impact factory: net Sharpe degrades
+    monotonically as impact grows with size.
+
+    >>> import numpy as np
+    >>> from fynance.backtest.cost import MarketImpactCost
+    >>> rng = np.random.default_rng(0)
+    >>> steps = np.cumsum(rng.normal(0.0, 0.07, size=300))
+    >>> weights = np.clip(steps, -1.0, 1.0)
+    >>> noise = rng.normal(0.0, 0.01, size=300)
+    >>> returns = np.empty(300)
+    >>> returns[0] = noise[0]
+    >>> returns[1:] = 0.0006 * weights[:-1] + noise[1:]
+    >>> prices = 100.0 * np.cumprod(1.0 + returns)
+    >>> aums = np.array([1e5, 1e7, 1e9])
+    >>> cost_factory = lambda aum: MarketImpactCost(
+    ...     impact=0.0017 * np.sqrt(aum / 1e6), exponent=1.5
+    ... )
+    >>> out = capacity_curve(weights, prices, aums, cost_factory)
+    >>> sorted(out)
+    ['aum', 'net_annual_return', 'net_sharpe', 'total_cost']
+    >>> bool(np.all(np.diff(out['net_sharpe']) <= 1e-9))
+    True
+
+    """
+    w = np.asarray(weights, dtype=np.float64)
+    prices = np.asarray(X, dtype=np.float64)
+    aum_arr = np.asarray(aums, dtype=np.float64)
+
+    if aum_arr.ndim != 1:
+
+        raise ValueError(f"aums must be 1-D, got shape {aum_arr.shape}")
+
+    if w.shape != prices.shape:
+
+        raise ValueError(
+            f"weights shape {w.shape} != X shape {prices.shape}"
+        )
+
+    n = aum_arr.shape[0]
+    net_sharpe = np.empty(n, dtype=np.float64)
+    net_annual_return = np.empty(n, dtype=np.float64)
+    total_cost = np.empty(n, dtype=np.float64)
+
+    for i, aum in enumerate(aum_arr):
+        cost = cost_factory(float(aum))
+        res = backtest(prices, w, cost=cost, returns_input=False)
+        stats = res.summary(period=period)
+        net_sharpe[i] = stats["sharpe"]
+        net_annual_return[i] = stats["annual_return"]
+        total_cost[i] = stats["total_cost"]
+
+    return {
+        "aum": aum_arr,
+        "net_sharpe": net_sharpe,
+        "net_annual_return": net_annual_return,
+        "total_cost": total_cost,
+    }
+
+
+def breakeven_fee(
+    weights: Any,
+    X: Any,
+    period: int = 252,
+    tol: float = 1e-6,
+) -> float:
+    """ Proportional fee at which the net Sharpe ratio crosses zero.
+
+    Bisects on a :class:`~fynance.backtest.cost.ProportionalCost` fee: the
+    bracket's upper bound is doubled from a small seed until the net Sharpe
+    turns non-positive, capped at :data:`_FEE_CAP` (10% per trade traded).
+
+    Parameters
+    ----------
+    weights : array-like
+        Position/weight book, shape ``(T,)`` or ``(T, N)``.
+    X : array-like
+        Price levels aligned with ``weights``; passed to
+        :func:`~fynance.backtest.engine.backtest` as ``returns_input=False``.
+    period : int
+        Annualization factor for the Sharpe ratio.
+    tol : float
+        Bisection tolerance on the fee (absolute).
+
+    Returns
+    -------
+    float
+        The proportional fee at which the net Sharpe ratio is (approximately)
+        zero.
+
+    Raises
+    ------
+    ValueError
+        If the gross (fee=0) Sharpe ratio is already non-positive (message
+        ``'strategy unprofitable gross'``), or if the net Sharpe ratio is
+        still positive at the 10%-per-trade cap (message ``'no breakeven
+        below 10%'``).
+
+    Examples
+    --------
+    Same planted-edge, noisy-turnover strategy as in :func:`capacity_curve`:
+    a proportional fee somewhere below the 10%-per-trade cap wipes out the
+    net Sharpe ratio.
+
+    >>> import numpy as np
+    >>> rng = np.random.default_rng(0)
+    >>> steps = np.cumsum(rng.normal(0.0, 0.07, size=1000))
+    >>> weights = np.clip(steps, -1.0, 1.0)
+    >>> noise = rng.normal(0.0, 0.01, size=1000)
+    >>> returns = np.empty(1000)
+    >>> returns[0] = noise[0]
+    >>> returns[1:] = 0.0006 * weights[:-1] + noise[1:]
+    >>> prices = 100.0 * np.cumprod(1.0 + returns)
+    >>> fee = breakeven_fee(weights, prices)
+    >>> bool(0.0 < fee < 0.10)
+    True
+
+    """
+
+    def _sharpe(fee: float) -> float:
+        cost = ProportionalCost(fee=fee) if fee > 0.0 else None
+        res = backtest(X, weights, cost=cost, returns_input=False)
+
+        return float(res.summary(period=period)["sharpe"])
+
+    gross_sharpe = _sharpe(0.0)
+
+    if gross_sharpe <= 0.0:
+
+        raise ValueError("strategy unprofitable gross")
+
+    lo, hi = 0.0, 1e-4
+
+    while _sharpe(hi) > 0.0:
+
+        if hi >= _FEE_CAP:
+
+            raise ValueError("no breakeven below 10%")
+
+        hi = min(2.0 * hi, _FEE_CAP)
+
+    while hi - lo > tol:
+        mid = 0.5 * (lo + hi)
+
+        if _sharpe(mid) > 0.0:
+            lo = mid
+
+        else:
+            hi = mid
+
+    return 0.5 * (lo + hi)

--- a/fynance/tests/backtest/test_capacity.py
+++ b/fynance/tests/backtest/test_capacity.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for the capacity analysis (net Sharpe vs AUM, breakeven fee). """
+
+# Third-party packages
+import numpy as np
+import pytest
+
+# Local packages
+from fynance.backtest.capacity import breakeven_fee, capacity_curve
+from fynance.backtest.cost import MarketImpactCost, ProportionalCost
+from fynance.backtest.engine import backtest
+
+
+def _planted_strategy(seed: int = 0, T: int = 500):
+    """ Single-asset weights/prices with a real, causal, tradeable edge.
+
+    ``weights`` is a bounded noisy signal (turnover ~5% per bar from its
+    increments); ``returns`` bakes a small edge correlated with the *lagged*
+    weight (so ``backtest``'s own one-step shift realizes it), plus noise.
+    """
+    rng = np.random.default_rng(seed)
+    steps = np.cumsum(rng.normal(0.0, 0.07, size=T))
+    weights = np.clip(steps, -1.0, 1.0)
+    noise = rng.normal(0.0, 0.01, size=T)
+    returns = np.empty(T)
+    returns[0] = noise[0]
+    returns[1:] = 0.0006 * weights[:-1] + noise[1:]
+    prices = 100.0 * np.cumprod(1.0 + returns)
+
+    return weights, prices
+
+
+# -- capacity_curve ---------------------------------------------------------
+
+
+def test_zero_cost_factory_net_sharpe_equals_gross():
+    weights, prices = _planted_strategy(seed=1)
+    aums = np.array([1e5, 1e7, 1e9])
+    gross_sharpe = backtest(
+        prices, weights, returns_input=False
+    ).summary()["sharpe"]
+
+    def zero_cost_factory(aum):
+        return ProportionalCost(fee=0.0)
+
+    out = capacity_curve(weights, prices, aums, zero_cost_factory)
+
+    assert np.allclose(out["net_sharpe"], gross_sharpe)
+
+
+def test_convex_impact_net_sharpe_non_increasing_in_aum():
+    weights, prices = _planted_strategy(seed=7, T=2000)
+    aums = np.logspace(5, 9, 9)
+    def impact_factory(aum):
+        return MarketImpactCost(impact=0.0017 * np.sqrt(aum / 1e6), exponent=1.5)
+
+    out = capacity_curve(weights, prices, aums, impact_factory)
+
+    # non-increasing (allow tiny numeric slack)
+    assert np.all(np.diff(out["net_sharpe"]) <= 1e-9)
+    # cost itself must strictly grow with AUM (the driver of the decay)
+    assert np.all(np.diff(out["total_cost"]) > 0.0)
+
+
+def test_output_keys_and_lengths():
+    weights, prices = _planted_strategy(seed=2)
+    aums = np.array([1e6, 1e7, 1e8, 1e9])
+
+    def factory(aum):
+        return ProportionalCost(fee=1e-4)
+
+    out = capacity_curve(weights, prices, aums, factory)
+
+    assert set(out) == {"aum", "net_sharpe", "net_annual_return", "total_cost"}
+    for key in out:
+        assert out[key].shape == aums.shape
+
+
+def test_aums_not_1d_raises():
+    weights, prices = _planted_strategy(seed=3)
+    bad_aums = np.array([[1e5, 1e6]])
+
+    def factory(aum):
+        return ProportionalCost(fee=0.0)
+
+    with pytest.raises(ValueError):
+        capacity_curve(weights, prices, bad_aums, factory)
+
+
+def test_shape_mismatch_raises():
+    weights = np.ones(10)
+    prices = np.linspace(100.0, 110.0, 12)
+
+    def factory(aum):
+        return ProportionalCost(fee=0.0)
+
+    with pytest.raises(ValueError):
+        capacity_curve(weights, prices, np.array([1e6]), factory)
+
+
+# -- breakeven_fee ------------------------------------------------------
+
+
+def test_breakeven_fee_rerun_gives_near_zero_sharpe():
+    weights, prices = _planted_strategy(seed=4, T=1000)
+    fee = breakeven_fee(weights, prices)
+    res = backtest(
+        prices, weights, cost=ProportionalCost(fee=fee), returns_input=False
+    )
+    net_sharpe = res.summary()["sharpe"]
+    assert abs(net_sharpe) < 1e-2
+
+
+def test_breakeven_fee_unprofitable_gross_raises():
+    weights, prices = _planted_strategy(seed=5, T=1000)
+    # Trading against the planted edge is unprofitable gross by construction.
+    with pytest.raises(ValueError, match="unprofitable gross"):
+        breakeven_fee(-weights, prices)


### PR DESCRIPTION
## Summary
- `capacity_curve(weights, X, aums, cost_factory, period)`: runs `backtest()` once per AUM (cost_factory encodes how impact scales with AUM) → aligned net_sharpe / net_annual_return / total_cost arrays.
- `breakeven_fee(weights, X)`: bisection on a ProportionalCost fee for net Sharpe == 0 (ValueError if gross-unprofitable). Leaf 03/04 of the `backtest-realism` epic.

## Verification (planted-edge strategy, T=2000, impact ∝ √AUM, aums 1e5→1e9)
Net Sharpe monotonically 0.776 → −1.093, crossing zero between 1e8 and 3.16e8. breakeven_fee 59.7 bp.

## Test plan
- [x] `pytest` — 1468 passed post-rebase (flat curve at zero impact, monotone decay under convex impact, breakeven |sharpe|<1e-2, gross-unprofitable ValueError)
- [x] `ruff` / `mypy` / interrogate / Sphinx -W
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)