### PR TITLE
feat: add vendor-agnostic intraday session utilities (data.sessions)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Intraday session utilities.** Vendor-agnostic `session_mask` /
+  `session_id` / `session_bounds` / `split_sessions` in
+  `fynance.data.sessions`: tag/slice intraday trading sessions on epoch-second
+  timestamp arrays with a fixed `utc_offset` (integer-arithmetic weekday math,
+  overnight sessions supported; DST explicitly out of scope, no pandas/pytz).
 - **Capacity analysis.** `capacity_curve` (net Sharpe / net annual return /
   total cost vs a sweep of AUM levels via a caller-supplied
   AUM→CostModel factory) and `breakeven_fee` (bisection for the fee at which

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -72,7 +72,7 @@ Template:
 
 <!-- new entries below, newest first -->
 
-### 2026-07-06 — Backtest-realism epic (PRs #258–#260, epic)  [accepted]
+### 2026-07-06 — Backtest-realism epic (PRs #258–#261, epic)  [accepted]
 
 - **Choice**: ship execution realism as composable, causal `(T, N)`
   transforms that sit between the allocator/signal and the vectorized

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -67,10 +67,13 @@ so an agent doesn't re-investigate settled ground or assume a known stub is a bu
   **attribution**, and a least-distance exposure-**constraints** overlay
   (`project_weights`).
 - **Backtest / Plot**: vectorized `backtest()` engine → `BacktestResult`, cost
-  models (`ProportionalCost` + **`MarketImpactCost`** — a convex, super-linear
-  market-impact term on top of the linear fee); reporting via `fynance.plot`
-  (`tearsheet`, composable figures, lazy matplotlib so `import fynance` stays
-  matplotlib-free).
+  models (`ProportionalCost` + **`MarketImpactCost`** + **`HoldingCost`** /
+  **`CompositeCost`** — borrow/financing/cash carry, composable stacking);
+  **rebalancing policies** (`portfolio.rebalance` — calendar/band/turnover-cap +
+  `discretize`/`delay`), **capacity analysis** (`capacity_curve`/`breakeven_fee`)
+  and **intraday session utilities** (`data.sessions`); reporting via
+  `fynance.plot` (`tearsheet`, composable figures, lazy matplotlib so
+  `import fynance` stays matplotlib-free).
 - **Research harness** (`fynance.research`, S1–S3 complete): `Experiment`
   (serializable spec + code + seed + metrics + curves), `run_experiment` (seeded,
   cost-aware, walk-forward; no-lookahead probe; records a **provenance** block —

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -46,15 +46,6 @@ Le harnais `fynance.research` est **livré** (S1–S3) : `Experiment`,
 - [ ] Explorateur **Streamlit** au-dessus du Ledger (parcourir / filtrer / comparer
   les runs persistés) — interactif, plus tardif.
 
-## 7. Backtest realism (épic `backtest-realism`)
-
-- [ ] Politiques de rebalancement + frictions : calendaire / no-trade band / budget
-  de turnover, `discretize()` (lots), `delay(steps)` — transforms composables.
-- [ ] Coûts de portage composables : borrow, financement, cash rate (stacking).
-- [ ] Analyse de capacité : Sharpe net vs AUM + breakeven cost rate (via
-  `MarketImpactCost`).
-- [ ] Utilitaires sessions & calendriers intraday.
-
 ## 8. GARCH family (épic `garch-family`)
 
 - [ ] Famille GARCH complète (L) : kernels GJR/EGARCH Numba, innovations Student-t,

--- a/doc/source/data.rst
+++ b/doc/source/data.rst
@@ -15,6 +15,10 @@ alignment/resampling, and no-lookahead temporal splits.
    ParquetSource
    align
    resample
+   session_mask
+   session_id
+   session_bounds
+   split_sessions
    train_test_split
    walk_forward
    combinatorial_purged_cv

--- a/fynance/data/__init__.py
+++ b/fynance/data/__init__.py
@@ -7,8 +7,10 @@
 
 The only I/O boundary of the library. File adapters turn local CSV/Parquet into
 :class:`~fynance.core.PriceSeries`; :func:`align`/:func:`resample` reconcile
-multiple series; :func:`train_test_split`/:func:`walk_forward`/
-:func:`combinatorial_purged_cv` build no-lookahead evaluation indices.
+multiple series; :func:`session_mask`/:func:`session_id`/:func:`session_bounds`/
+:func:`split_sessions` tag intraday trading sessions; :func:`train_test_split`/
+:func:`walk_forward`/:func:`combinatorial_purged_cv` build no-lookahead
+evaluation indices.
 
 """
 
@@ -17,6 +19,7 @@ from .align import align, resample
 from .base import BaseDataSource, get_source, load, register
 from .csv import CSVSource
 from .parquet import ParquetSource
+from .sessions import session_bounds, session_id, session_mask, split_sessions
 from .split import combinatorial_purged_cv, train_test_split, walk_forward
 
 __all__ = [
@@ -28,6 +31,10 @@ __all__ = [
     'ParquetSource',
     'align',
     'resample',
+    'session_mask',
+    'session_id',
+    'session_bounds',
+    'split_sessions',
     'train_test_split',
     'walk_forward',
     'combinatorial_purged_cv',

--- a/fynance/data/sessions.py
+++ b/fynance/data/sessions.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Vendor-agnostic intraday trading-session utilities.
+
+Deterministic, dependency-free tools to tag epoch-second timestamps with an
+exchange's regular trading hours: a boolean mask, a per-bar running session
+id, first/last-bar bounds per session, and a helper to split an array into
+one chunk per session.
+
+**Scope**: timestamps are plain ``int64``/``float64`` NumPy arrays holding
+epoch seconds (UTC) -- no ``pandas``, ``pytz`` or ``exchange_calendars``
+dependency. The exchange clock is modelled as a single fixed ``utc_offset``
+(hours). **Daylight-saving time is explicitly out of scope**: a fixed offset
+cannot represent an exchange that observes DST (its local open/close would
+drift by an hour twice a year). Users who need DST-correct sessions should
+bring ``exchange_calendars`` (or similar) themselves and pre-shift their
+timestamps, or call these functions twice with the two seasonal offsets. This
+module is the deterministic, zero-dependency tool for the common 80% case: a
+fixed-offset exchange (or an already DST-adjusted timestamp array).
+
+"""
+
+from __future__ import annotations
+
+# Built-in packages
+# Third-party packages
+import numpy as np
+from numpy.typing import NDArray
+
+__all__ = ['session_mask', 'session_id', 'session_bounds', 'split_sessions']
+
+_SECONDS_PER_DAY = 86400
+# 1970-01-01 (epoch day 0) is a Thursday; datetime.date.weekday() convention
+# (Monday=0 ... Sunday=6), so weekday = (epoch_day + 3) % 7.
+_EPOCH_DAY_0_WEEKDAY_OFFSET = 3
+_WEEKEND_CUTOFF = 5  # weekday >= 5 -> Saturday/Sunday
+
+
+def _parse_hhmm(value: str) -> int:
+    """ Parse an ``"HH:MM"`` string into seconds since local midnight.
+
+    Parameters
+    ----------
+    value : str
+        Time of day, e.g. ``"09:30"``.
+
+    Returns
+    -------
+    int
+        Seconds since local midnight, in ``[0, 86400)``.
+
+    Raises
+    ------
+    ValueError
+        If ``value`` is not a well-formed ``"HH:MM"`` string with
+        ``0 <= HH < 24`` and ``0 <= MM < 60``.
+
+    """
+    parts = value.split(":")
+
+    if len(parts) != 2:
+
+        raise ValueError(f"invalid HH:MM time string: {value!r}")
+
+    try:
+        hour, minute = int(parts[0]), int(parts[1])
+
+    except ValueError as exc:
+
+        raise ValueError(f"invalid HH:MM time string: {value!r}") from exc
+
+    if not (0 <= hour < 24 and 0 <= minute < 60):
+
+        raise ValueError(f"invalid HH:MM time string: {value!r}")
+
+    return hour * 3600 + minute * 60
+
+
+def _check_timestamps(ts: NDArray[np.int64] | NDArray[np.float64]) -> NDArray[np.float64]:
+    """ Validate ``ts`` and return it as a 1-D ``float64`` array.
+
+    Raises
+    ------
+    ValueError
+        If ``ts`` is not 1-D, or is not non-decreasing.
+
+    """
+    arr = np.asarray(ts)
+
+    if arr.ndim != 1:
+
+        raise ValueError(f"ts must be a 1-D array, got shape {arr.shape}")
+
+    if arr.size > 1 and np.any(np.diff(arr) < 0):
+
+        raise ValueError("ts must be non-decreasing")
+
+    return arr.astype(np.float64)
+
+
+def _session_components(
+    ts: NDArray[np.int64] | NDArray[np.float64],
+    open: str,
+    close: str,
+    utc_offset: float,
+    weekdays_only: bool,
+) -> tuple[NDArray[np.bool_], NDArray[np.int64]]:
+    """ Shared core: per-bar in-session flag and the session's opening day.
+
+    ``open_day`` is the local epoch-day number (``local_seconds // 86400``,
+    epoch day 0 = Thursday 1970-01-01) on which the bar's session OPENED --
+    for a regular (same-day) session this is just the bar's own calendar day,
+    but for an overnight session (``close < open``) the post-midnight half of
+    the session still carries the PREVIOUS day's ``open_day``. This lets
+    :func:`session_id` group an overnight session's bars under one id, and
+    lets ``weekdays_only`` decide inclusion from the day the session opened
+    rather than the calendar day a given bar happens to fall on.
+
+    """
+    arr = _check_timestamps(ts)
+    open_sod = _parse_hhmm(open)
+    close_sod = _parse_hhmm(close)
+
+    # Pure (float64, but integer-valued) arithmetic hot path: days = ts // 86400.
+    local = arr + utc_offset * 3600.0
+    days = np.floor(local / _SECONDS_PER_DAY).astype(np.int64)
+    seconds_of_day = local - days * float(_SECONDS_PER_DAY)
+
+    if open_sod < close_sod:
+        # Regular, same-day session: [open, close).
+        in_session = (seconds_of_day >= open_sod) & (seconds_of_day < close_sod)
+        open_day = days
+
+    else:
+        # Overnight session (close <= open, e.g. 18:00 -> 17:00): a bar either
+        # falls in the evening half [open, 24:00) of the day it opened, or in
+        # the morning half [00:00, close) that belongs to the PREVIOUS day's
+        # session. open_sod == close_sod is the degenerate 24h-session case
+        # (every bar matches one of the two halves).
+        evening = seconds_of_day >= open_sod
+        morning = seconds_of_day < close_sod
+        in_session = evening | morning
+        open_day = np.where(evening, days, days - 1)
+
+    if weekdays_only:
+        weekday = (open_day + _EPOCH_DAY_0_WEEKDAY_OFFSET) % 7
+        in_session = in_session & (weekday < _WEEKEND_CUTOFF)
+
+    return in_session, open_day
+
+
+def session_mask(
+    ts: NDArray[np.int64] | NDArray[np.float64],
+    open: str = "09:30",
+    close: str = "16:00",
+    utc_offset: float = 0.0,
+    weekdays_only: bool = True,
+) -> NDArray[np.bool_]:
+    """ Flag timestamps that fall inside a trading session.
+
+    Parameters
+    ----------
+    ts : ndarray of int64 or float64
+        Non-decreasing epoch-second (UTC) timestamps, shape ``(n,)``.
+    open, close : str, default "09:30", "16:00"
+        Local session open/close, ``"HH:MM"``. ``close < open`` (or
+        ``close == open``) models an overnight session, e.g. ``"18:00"`` ->
+        ``"17:00"``.
+    utc_offset : float, default 0.0
+        Fixed exchange-clock offset from UTC, in hours (e.g. ``-5.0`` for
+        NYSE standard time). A **single** fixed offset -- DST is out of
+        scope, see the module docstring.
+    weekdays_only : bool, default True
+        Exclude sessions that OPEN on a Saturday/Sunday (local calendar day
+        of the session's open, not of every individual bar -- see
+        :func:`session_id`).
+
+    Returns
+    -------
+    ndarray of bool
+        ``True`` where ``ts`` falls in ``[open, close)`` local time (and, if
+        ``weekdays_only``, the session opened on a weekday).
+
+    Raises
+    ------
+    ValueError
+        If ``open``/``close`` are not well-formed ``"HH:MM"`` strings, ``ts``
+        is not 1-D, or ``ts`` is not non-decreasing.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from fynance.data.sessions import session_mask
+    >>> ts = np.array([9 * 3600, 10 * 3600, 17 * 3600])  # 09:00, 10:00, 17:00 UTC
+    >>> session_mask(ts, open="09:30", close="16:00")
+    array([False,  True, False])
+
+    """
+    in_session, _ = _session_components(ts, open, close, utc_offset, weekdays_only)
+
+    return in_session
+
+
+def session_id(
+    ts: NDArray[np.int64] | NDArray[np.float64],
+    open: str = "09:30",
+    close: str = "16:00",
+    utc_offset: float = 0.0,
+    weekdays_only: bool = True,
+) -> NDArray[np.int64]:
+    """ Label each bar with a running trading-session id.
+
+    Bars outside a session get ``-1``. Bars inside a session get a
+    0-indexed, strictly increasing id shared by every bar of that session
+    (including across a data gap, e.g. a missing lunch bar): the id
+    increments whenever the session's opening day (see
+    :func:`_session_components`) changes from the previous in-session bar --
+    not merely when an array index transition occurs -- so it is robust to
+    ``ts`` that only contains in-session samples (no off-hours rows to mark
+    a boundary with ``False``).
+
+    Parameters
+    ----------
+    ts : ndarray of int64 or float64
+        Non-decreasing epoch-second (UTC) timestamps, shape ``(n,)``.
+    open, close, utc_offset, weekdays_only
+        See :func:`session_mask`.
+
+    Returns
+    -------
+    ndarray of int64
+        Shape ``(n,)``; ``-1`` outside sessions, else a 0-indexed running
+        session id.
+
+    Raises
+    ------
+    ValueError
+        Same as :func:`session_mask`.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from fynance.data.sessions import session_id
+    >>> ts = np.array([9 * 3600, 10 * 3600, 17 * 3600, 33 * 3600, 34 * 3600])
+    >>> session_id(ts, open="09:30", close="16:00")
+    array([-1,  0, -1, -1,  1])
+
+    """
+    in_session, open_day = _session_components(ts, open, close, utc_offset, weekdays_only)
+    ids = np.full(in_session.shape, -1, dtype=np.int64)
+
+    if not np.any(in_session):
+
+        return ids
+
+    session_days = open_day[in_session]
+    new_session = np.empty(session_days.shape, dtype=bool)
+    new_session[0] = True
+    new_session[1:] = session_days[1:] != session_days[:-1]
+    ids[in_session] = np.cumsum(new_session) - 1
+
+    return ids
+
+
+def session_bounds(
+    ts: NDArray[np.int64] | NDArray[np.float64],
+    open: str = "09:30",
+    close: str = "16:00",
+    utc_offset: float = 0.0,
+    weekdays_only: bool = True,
+) -> NDArray[np.int64]:
+    """ First/last bar index of each trading session.
+
+    Parameters
+    ----------
+    ts : ndarray of int64 or float64
+        Non-decreasing epoch-second (UTC) timestamps, shape ``(n,)``.
+    open, close, utc_offset, weekdays_only
+        See :func:`session_mask`.
+
+    Returns
+    -------
+    ndarray of int64
+        Shape ``(n_sessions, 2)``; row ``k`` is
+        ``(first_index, last_index)`` (both inclusive, into ``ts``) of
+        session ``k``. Empty (``shape (0, 2)``) if no bar falls in a
+        session.
+
+    Raises
+    ------
+    ValueError
+        Same as :func:`session_mask`.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from fynance.data.sessions import session_bounds
+    >>> ts = np.array([9 * 3600, 10 * 3600, 17 * 3600, 33 * 3600, 34 * 3600])
+    >>> session_bounds(ts, open="09:30", close="16:00")
+    array([[1, 1],
+           [4, 4]])
+
+    """
+    ids = session_id(ts, open=open, close=close, utc_offset=utc_offset, weekdays_only=weekdays_only)
+    in_session = ids >= 0
+
+    if not np.any(in_session):
+
+        return np.empty((0, 2), dtype=np.int64)
+
+    index = np.nonzero(in_session)[0]
+    valid_ids = ids[in_session]
+    n_sessions = int(valid_ids[-1]) + 1
+    boundaries = np.arange(n_sessions)
+    first = index[np.searchsorted(valid_ids, boundaries, side="left")]
+    last = index[np.searchsorted(valid_ids, boundaries, side="right") - 1]
+
+    return np.stack([first, last], axis=1)
+
+
+def split_sessions(
+    X: NDArray,
+    ts: NDArray[np.int64] | NDArray[np.float64],
+    open: str = "09:30",
+    close: str = "16:00",
+    utc_offset: float = 0.0,
+    weekdays_only: bool = True,
+) -> list[NDArray]:
+    """ Split ``X`` into one chunk per trading session.
+
+    Parameters
+    ----------
+    X : ndarray
+        Array aligned with ``ts`` along its first axis.
+    ts : ndarray of int64 or float64
+        Non-decreasing epoch-second (UTC) timestamps, shape ``(n,)``.
+    open, close, utc_offset, weekdays_only
+        See :func:`session_mask`.
+
+    Returns
+    -------
+    list of ndarray
+        One slice of ``X`` per session, in session order. Bars outside every
+        session (``session_id == -1``) are skipped, so concatenating the
+        result along axis 0 reproduces ``X[session_mask(ts, ...)]``.
+
+    Raises
+    ------
+    ValueError
+        Same as :func:`session_mask`.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from fynance.data.sessions import split_sessions
+    >>> ts = np.array([9 * 3600, 10 * 3600, 17 * 3600, 33 * 3600, 34 * 3600])
+    >>> X = np.arange(5)
+    >>> split_sessions(X, ts, open="09:30", close="16:00")
+    [array([1]), array([4])]
+
+    """
+    X = np.asarray(X)
+    ids = session_id(ts, open=open, close=close, utc_offset=utc_offset, weekdays_only=weekdays_only)
+    in_session = ids >= 0
+
+    if not np.any(in_session):
+
+        return []
+
+    index = np.nonzero(in_session)[0]
+    valid_ids = ids[in_session]
+    n_sessions = int(valid_ids[-1]) + 1
+    split_points = np.searchsorted(valid_ids, np.arange(1, n_sessions))
+    groups = np.split(index, split_points)
+
+    return [X[g] for g in groups]

--- a/fynance/tests/data/test_sessions.py
+++ b/fynance/tests/data/test_sessions.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Tests for vendor-agnostic intraday trading-session utilities. """
+
+# Built-in packages
+import datetime
+
+# Third-party packages
+import numpy as np
+import pytest
+
+# Local packages
+from fynance.data import session_bounds, session_id, session_mask, split_sessions
+
+UTC = datetime.timezone.utc
+
+
+def _utc(
+    year: int, month: int, day: int, hour: int = 0, minute: int = 0, second: int = 0,
+) -> float:
+    """ Build an epoch-second timestamp (UTC) from calendar fields. """
+    return datetime.datetime(year, month, day, hour, minute, second, tzinfo=UTC).timestamp()
+
+
+def test_regular_rth_day_390_one_minute_bars():
+    # Tuesday 2024-01-02, a full 24h grid of 1-min bars.
+    start = _utc(2024, 1, 2)
+    ts = np.array([start + i * 60 for i in range(24 * 60)])
+    mask = session_mask(ts, open="09:30", close="16:00", utc_offset=0.0)
+    assert mask.sum() == 390
+
+    in_session = np.nonzero(mask)[0]
+    first_dt = datetime.datetime(2024, 1, 2, tzinfo=UTC) + datetime.timedelta(minutes=int(in_session[0]))
+    last_dt = datetime.datetime(2024, 1, 2, tzinfo=UTC) + datetime.timedelta(minutes=int(in_session[-1]))
+    assert (first_dt.hour, first_dt.minute) == (9, 30)
+    assert (last_dt.hour, last_dt.minute) == (15, 59)
+
+
+def test_boundary_open_inclusive_close_exclusive():
+    open_ts = _utc(2024, 1, 2, 9, 30)
+    close_ts = _utc(2024, 1, 2, 16, 0)
+    ts = np.array([open_ts - 60, open_ts, close_ts - 60, close_ts])
+    mask = session_mask(ts, open="09:30", close="16:00")
+    assert list(mask) == [False, True, True, False]
+
+
+def test_weekend_excluded():
+    # 2024-01-06/07 are a Saturday/Sunday (2024-01-01 was a Monday).
+    saturday = _utc(2024, 1, 6, 10, 0)
+    sunday = _utc(2024, 1, 7, 10, 0)
+    ts = np.array([saturday, sunday])
+
+    mask = session_mask(ts, open="09:30", close="16:00", weekdays_only=True)
+    assert not mask.any()
+
+    mask_all_days = session_mask(ts, open="09:30", close="16:00", weekdays_only=False)
+    assert mask_all_days.all()
+
+
+def test_utc_offset_shift():
+    # 14:30 UTC == 09:30 local at utc_offset=-5 -> included (session open).
+    assert session_mask(
+        np.array([_utc(2024, 1, 2, 14, 30)]), open="09:30", close="16:00", utc_offset=-5.0,
+    )[0]
+    # 21:00 UTC == 16:00 local at utc_offset=-5 -> excluded (close is exclusive).
+    assert not session_mask(
+        np.array([_utc(2024, 1, 2, 21, 0)]), open="09:30", close="16:00", utc_offset=-5.0,
+    )[0]
+    # 13:00 UTC == 08:00 local at utc_offset=-5 -> excluded (before open).
+    assert not session_mask(
+        np.array([_utc(2024, 1, 2, 13, 0)]), open="09:30", close="16:00", utc_offset=-5.0,
+    )[0]
+
+
+def test_overnight_session_spans_midnight_single_id():
+    # Tuesday 18:00 -> Wednesday 17:00: 23h of 1-min bars, one session.
+    start = _utc(2024, 1, 2, 18, 0)
+    ts = np.array([start + i * 60 for i in range(1380)])
+
+    mask = session_mask(ts, open="18:00", close="17:00", weekdays_only=False)
+    assert mask.sum() == 1380
+    assert mask.all()
+
+    ids = session_id(ts, open="18:00", close="17:00", weekdays_only=False)
+    assert (ids == 0).all()
+    # explicitly check the id is unchanged straddling the midnight boundary
+    # (bar 359 == 23:59 Tue, bar 360 == 00:00 Wed).
+    assert ids[359] == ids[360] == 0
+
+
+def test_overnight_session_belongs_to_day_it_opens():
+    # Opens Friday 18:00 (weekday): stays included through the Saturday-dated
+    # post-midnight half -- the session belongs to the day it OPENED.
+    start_fri = _utc(2024, 1, 5, 18, 0)  # 2024-01-05 is a Friday
+    ts_fri = np.array([start_fri + i * 60 for i in range(1380)])
+    assert session_mask(ts_fri, open="18:00", close="17:00", weekdays_only=True).all()
+
+    # Opens Saturday 18:00 (weekend): excluded entirely, even though it bleeds
+    # into the Sunday-dated post-midnight half.
+    start_sat = _utc(2024, 1, 6, 18, 0)
+    ts_sat = np.array([start_sat + i * 60 for i in range(1380)])
+    assert not session_mask(ts_sat, open="18:00", close="17:00", weekdays_only=True).any()
+
+
+def test_session_id_negative_one_gaps_and_strict_increments():
+    day1 = datetime.datetime(2024, 1, 2, tzinfo=UTC)  # Tuesday
+    day2 = datetime.datetime(2024, 1, 3, tzinfo=UTC)  # Wednesday
+    ts = np.array([
+        (day1 + datetime.timedelta(hours=8)).timestamp(),   # before open
+        (day1 + datetime.timedelta(hours=10)).timestamp(),  # session 0
+        (day1 + datetime.timedelta(hours=12)).timestamp(),  # session 0
+        (day1 + datetime.timedelta(hours=20)).timestamp(),  # after close
+        (day2 + datetime.timedelta(hours=10)).timestamp(),  # session 1
+        (day2 + datetime.timedelta(hours=11)).timestamp(),  # session 1
+    ])
+    ids = session_id(ts, open="09:30", close="16:00")
+    assert list(ids) == [-1, 0, 0, -1, 1, 1]
+
+
+def test_split_sessions_concatenation_equals_masked_subset():
+    start = _utc(2024, 1, 2)
+    ts = np.array([start + i * 3600 for i in range(48)])  # 2 days, hourly
+    X = np.arange(48)
+
+    mask = session_mask(ts, open="09:30", close="16:00")
+    chunks = split_sessions(X, ts, open="09:30", close="16:00")
+
+    assert np.array_equal(np.concatenate(chunks), X[mask])
+    # skips -1 (out-of-session) rows: chunk count == number of sessions
+    assert len(chunks) == len(session_bounds(ts, open="09:30", close="16:00"))
+
+
+def test_session_bounds_correctness():
+    start = _utc(2024, 1, 2)
+    ts = np.array([start + i * 3600 for i in range(48)])  # 2 days, hourly
+
+    bounds = session_bounds(ts, open="09:30", close="16:00")
+    ids = session_id(ts, open="09:30", close="16:00")
+
+    assert bounds.shape == (2, 2)
+    for k, (first, last) in enumerate(bounds):
+        positions = np.nonzero(ids == k)[0]
+        assert first == positions[0]
+        assert last == positions[-1]
+
+
+def test_session_bounds_and_split_sessions_empty_when_no_session():
+    ts = np.array([_utc(2024, 1, 6, 10, 0)])  # Saturday only
+
+    bounds = session_bounds(ts, open="09:30", close="16:00")
+    assert bounds.shape == (0, 2)
+
+    chunks = split_sessions(np.zeros(1), ts, open="09:30", close="16:00")
+    assert chunks == []
+
+
+def test_invalid_hhmm_raises():
+    with pytest.raises(ValueError):
+        session_mask(np.array([0.0]), open="9:xx")
+    with pytest.raises(ValueError):
+        session_mask(np.array([0.0]), open="25:00")
+    with pytest.raises(ValueError):
+        session_mask(np.array([0.0]), close="12:60")
+    with pytest.raises(ValueError):
+        session_mask(np.array([0.0]), open="09:30:00")
+
+
+def test_non_decreasing_ts_raises():
+    ts = np.array([10.0, 5.0, 20.0])
+    with pytest.raises(ValueError, match="non-decreasing"):
+        session_mask(ts)
+
+
+def test_int64_and_float64_inputs_agree():
+    ts_int = np.array([9 * 3600 + 1800, 10 * 3600], dtype=np.int64)
+    ts_float = ts_int.astype(np.float64)
+    assert np.array_equal(session_mask(ts_int), session_mask(ts_float))
+
+
+def test_weekday_convention_golden_sweep_vs_datetime():
+    # Golden-test the (epoch_day + 3) % 7 weekday convention against Python's
+    # own datetime.weekday() over a ~750-day sweep, sampling local noon so
+    # every bar sits inside an (almost) full-day session.
+    n_days = 750
+    epoch_0 = datetime.date(1970, 1, 1)
+    ts = np.array([d * 86400 + 12 * 3600 for d in range(n_days)], dtype=np.int64)
+
+    mask = session_mask(ts, open="00:00", close="23:59", utc_offset=0.0, weekdays_only=True)
+
+    for d in range(n_days):
+        expected_weekday = (epoch_0 + datetime.timedelta(days=d)).weekday()
+        assert mask[d] == (expected_weekday < 5), f"day {d} mismatch"


### PR DESCRIPTION
## Summary
- New `fynance.data.sessions`: `session_mask`, `session_id`, `session_bounds`, `split_sessions` — tag and slice intraday trading sessions on epoch-second timestamp arrays with a fixed `utc_offset` (hours).
- Integer-arithmetic weekday math (no datetime in the hot path), overnight sessions supported (session belongs to the day it opens). DST explicitly out of scope; no pandas/pytz/exchange_calendars dependency.
- **Last leaf (04) of the `backtest-realism` epic** — removes roadmap §7, updates status (epic PRs #258–#261).

## Verification (1-min grid, two weeks)
10 sessions, 390 bars each for 09:30–16:00; overnight 18:00→17:00 gives 1380 bars/session with id stable across midnight; weekday arithmetic golden-tested vs datetime.weekday over a 2-year sweep.

## Test plan
- [x] `pytest` — 1486 passed post-rebase (boundary [open, close), weekends, utc_offset shift, overnight span, session_id gaps, split concatenation)
- [x] `ruff` / `mypy` / interrogate / Sphinx -W
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)