### PR TITLE
feat: add pinball loss and QuantileModel distributional head

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Distributional forecasting.** `PinballLoss` (multi-quantile) in
+  `fynance.models.loss` and `QuantileModel` (`SignalModel` with a
+  per-quantile head, non-crossing enforced at predict time,
+  `predict_quantiles`) in `fynance.models.quantile`.
 - **Cross-asset pretraining & persistence for `ObjectiveModel`.**
   `save`/`load`/`clone`, `finetune(freeze_trunk=)` (warm-start from current
   weights, optionally freezing the trunk) and `pretrain_pooled` (pool aligned

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -72,7 +72,7 @@ Template:
 
 <!-- new entries below, newest first -->
 
-### 2026-07-06 — ML bricks epic (PRs #263, epic)  [accepted]
+### 2026-07-06 — ML bricks epic (PRs #263–#264, epic)  [accepted]
 
 - **Choice**: four PyTorch bricks that all conform to `SignalModel` and stay
   inside `models/` — cross-asset pretraining/persistence on `ObjectiveModel`

--- a/doc/source/models.loss.rst
+++ b/doc/source/models.loss.rst
@@ -16,3 +16,4 @@ Differentiable financial loss functions for PyTorch training. They are drop-in P
    CalmarLoss
    OmegaLoss
    HybridLoss
+   PinballLoss

--- a/doc/source/models.neural_network.rst
+++ b/doc/source/models.neural_network.rst
@@ -55,6 +55,28 @@ round-trips to disk with
 :meth:`~fynance.models.objective.ObjectiveModel.save` /
 :meth:`~fynance.models.objective.ObjectiveModel.load`.
 
+.. rubric:: Distributional (quantile) regression
+
+:class:`~fynance.models.quantile.QuantileModel` trains a feed-forward trunk with
+one output per target quantile (default ``taus=(0.1, 0.5, 0.9)``) on
+:class:`~fynance.models.loss.PinballLoss`, giving a **distributional** forecast
+instead of a single point estimate. Unlike ``ObjectiveModel``, ``fit(X, y)`` reads
+``y`` as an ordinary supervised target (e.g. the next-bar return), not a returns
+series to combine with positions. It is a ``SignalModel``: ``predict(X)`` returns
+the median (or nearest-to-0.5 ``tau``) column, shape ``(T,)``; the full band is
+available through
+:meth:`~fynance.models.quantile.QuantileModel.predict_quantiles`, shape
+``(T, n_taus)``. Quantile columns are trained independently (no crossing penalty),
+so non-crossing is enforced **at predict time** by sorting along the quantile
+axis::
+
+    from fynance.models import QuantileModel
+
+    model = QuantileModel(taus=(0.1, 0.5, 0.9), layers=(16, 8), epochs=200, seed=0)
+    model.fit(X, y)
+    point = model.predict(X)              # (T,) median column
+    q10, q50, q90 = model.predict_quantiles(X).T
+
 .. rubric:: Regime-conditioned architecture
 
 :class:`~fynance.models.regime_model.RegimeMoE` conditions an objective-aligned
@@ -84,4 +106,5 @@ from a designated positive price/level column of ``X`` (``regime_col``). It reus
    mlp.MultiLayerPerceptron
    objective.ObjectiveModel
    objective.pretrain_pooled
+   quantile.QuantileModel
    regime_model.RegimeMoE

--- a/fynance/models/__init__.py
+++ b/fynance/models/__init__.py
@@ -52,12 +52,14 @@ from .loss import (
     DirectionalAccuracyLoss,
     HybridLoss,
     OmegaLoss,
+    PinballLoss,
     SharpeLoss,
     SortinoLoss,
 )
 from .lstm import LongShortTermMemory, LSTMCell
 from .mlp import MultiLayerPerceptron
 from .objective import ObjectiveModel, pretrain_pooled
+from .quantile import QuantileModel
 from .regime_model import RegimeMoE
 from .rnn import RecurrentNeuralNetwork
 from .rolling import CVResult, RollMultiLayerPerceptron, _RollingBasis
@@ -87,6 +89,8 @@ __all__ = [
     # objective-aligned training
     'ObjectiveModel',
     'pretrain_pooled',
+    # distributional (quantile) regression
+    'QuantileModel',
     # regime-conditioned architecture
     'RegimeMoE',
     # rnn / gru / lstm
@@ -113,6 +117,7 @@ __all__ = [
     'CalmarLoss',
     'HybridLoss',
     'OmegaLoss',
+    'PinballLoss',
     'SharpeLoss',
     'SortinoLoss',
     # tuning

--- a/fynance/models/loss/__init__.py
+++ b/fynance/models/loss/__init__.py
@@ -24,6 +24,9 @@ Main entry points
   ranking objective for a panel of assets.
 - :class:`HybridLoss` — convex combination of two losses with a fixed or
   learnable weight.
+- :class:`PinballLoss` — asymmetric quantile ("pinball") loss for
+  multi-quantile regression (see
+  :class:`~fynance.models.quantile.QuantileModel`).
 
 Notes
 -----
@@ -42,9 +45,10 @@ from .calmar import CalmarLoss
 from .directional import DirectionalAccuracyLoss
 from .hybrid import HybridLoss
 from .omega import OmegaLoss
+from .pinball import PinballLoss
 from .ranking import RankingLoss
 from .sharpe import SharpeLoss
 from .sortino import SortinoLoss
 
 __all__ = ['BaseLoss', 'CalmarLoss', 'DirectionalAccuracyLoss', 'HybridLoss',
-           'OmegaLoss', 'RankingLoss', 'SharpeLoss', 'SortinoLoss']
+           'OmegaLoss', 'PinballLoss', 'RankingLoss', 'SharpeLoss', 'SortinoLoss']

--- a/fynance/models/loss/pinball.py
+++ b/fynance/models/loss/pinball.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+""" Differentiable pinball (quantile) loss for PyTorch training loops. """
+
+from __future__ import annotations
+
+# Built-in packages
+from collections.abc import Sequence
+
+# Third-party packages
+import torch
+
+# Local packages
+from ._base import BaseLoss
+
+__all__ = ['PinballLoss']
+
+
+def _validate_taus(taus: float | Sequence[float]) -> tuple[float, ...]:
+    """ Validate ``taus`` and return them as a sorted tuple of floats in (0, 1).
+
+    Accepts a single float or any sequence of floats; a single float is
+    wrapped into a one-element tuple. The returned tuple is sorted
+    ascending so every caller (:class:`PinballLoss`,
+    :class:`~fynance.models.quantile.QuantileModel`) shares one canonical
+    column order for the quantile axis, regardless of the order ``taus``
+    was given in.
+    """
+    if isinstance(taus, (int, float)):
+        taus = (float(taus),)
+
+    values = tuple(float(t) for t in taus)
+
+    if not values:
+        raise ValueError("taus must be non-empty")
+
+    if any(not (0. < t < 1.) for t in values):
+        raise ValueError(f"each tau must be strictly in (0, 1), got {values}")
+
+    return tuple(sorted(values))
+
+
+class PinballLoss(BaseLoss):
+    r""" Pinball (quantile / check) loss for multi-quantile regression.
+
+    For a target quantile :math:`\tau \in (0, 1)` and error
+    :math:`e = y - \hat{y}_\tau`:
+
+    .. math::
+
+        \mathcal{L}_\tau(e) = \max(\tau e,\ (\tau - 1) e)
+
+    an asymmetric penalty: under-prediction (:math:`e > 0`) is penalized by
+    :math:`\tau` and over-prediction (:math:`e < 0`) by :math:`1 - \tau`. At
+    :math:`\tau = 0.5` it reduces to :math:`0.5 |e|`, i.e. half the mean
+    absolute error. Minimizing it over a batch drives ``pred`` toward the
+    :math:`\tau`-th conditional quantile of ``target``.
+
+    With several ``taus`` at once, ``pred`` carries one column per quantile
+    and the reported loss is the mean over quantiles *and* samples of the
+    per-quantile pinball loss — the standard way to train a single
+    multi-quantile head such as
+    :class:`~fynance.models.quantile.QuantileModel`.
+
+    Notes
+    -----
+    ``taus`` are sorted ascending internally (see :func:`_validate_taus`),
+    so ``pred``'s trailing axis is expected in that same ascending order.
+    This loss does **not** enforce non-crossing quantiles (``q10 <= q50 <=
+    q90``) — it is the plain per-column pinball loss; monotonicity is a
+    predict-time concern (see
+    :meth:`~fynance.models.quantile.QuantileModel.predict_quantiles`).
+
+    Parameters
+    ----------
+    taus : float or sequence of float, optional
+        Target quantile(s) in ``(0, 1)``. Default ``(0.1, 0.5, 0.9)``.
+    **kwargs
+        Forwarded to :class:`BaseLoss` (``rf``, ``period``, ``eps``) — not
+        used by this loss (it is not a ratio/annualized objective), kept
+        only for API consistency across :mod:`fynance.models.loss`.
+
+    Raises
+    ------
+    ValueError
+        If ``taus`` is empty or any value is not strictly in ``(0, 1)``.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from fynance.models.loss import PinballLoss
+    >>> target = torch.tensor([1.0, 2.0, 3.0])
+    >>> pred = torch.tensor([[1.0], [2.0], [3.0]])   # perfect single-tau fit
+    >>> PinballLoss(taus=0.5)(pred, target).item()
+    0.0
+    >>> pred_off = pred + 1.0
+    >>> loss = PinballLoss(taus=0.5)(pred_off, target)
+    >>> loss.item() == 0.5   # tau=0.5 -> half the (constant) absolute error
+    True
+
+    See Also
+    --------
+    fynance.models.quantile.QuantileModel
+
+    """
+
+    def __init__(
+        self,
+        taus: float | Sequence[float] = (0.1, 0.5, 0.9),
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.taus = _validate_taus(taus)
+
+    def forward(
+        self, pred: torch.Tensor, target: torch.Tensor,
+    ) -> torch.Tensor:
+        r""" Compute the mean pinball loss across quantiles and samples.
+
+        Parameters
+        ----------
+        pred : torch.Tensor
+            Predicted quantiles, shape ``(..., n_taus)``.
+        target : torch.Tensor
+            True values, shape ``(...,)`` — ``pred`` without its trailing
+            quantile axis — broadcast against every quantile column.
+
+        Returns
+        -------
+        torch.Tensor
+            Scalar loss: the mean over quantiles and samples of
+            :math:`\max(\tau e, (\tau - 1) e)`.
+
+        Raises
+        ------
+        TypeError
+            If ``pred`` or ``target`` is not a :class:`torch.Tensor`.
+        ValueError
+            If ``pred``'s trailing dimension does not equal the number of
+            ``taus``, or ``target``'s shape does not match ``pred``'s
+            shape without that trailing dimension.
+
+        """
+        self._check_tensor(pred)
+        self._check_tensor(target)
+        n_taus = len(self.taus)
+
+        if pred.shape[-1] != n_taus:
+            raise ValueError(
+                f"pred's trailing dimension ({pred.shape[-1]}) must equal "
+                f"the number of taus ({n_taus})"
+            )
+
+        if tuple(target.shape) != tuple(pred.shape[:-1]):
+            raise ValueError(
+                f"target shape {tuple(target.shape)} must equal pred's "
+                f"shape without the trailing quantile axis "
+                f"{tuple(pred.shape[:-1])}"
+            )
+
+        taus = torch.as_tensor(self.taus, dtype=pred.dtype, device=pred.device)
+        e = target.unsqueeze(-1) - pred
+
+        return torch.maximum(taus * e, (taus - 1.) * e).mean()

--- a/fynance/models/quantile.py
+++ b/fynance/models/quantile.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Multi-quantile regression head.
+
+:class:`QuantileModel` trains a feed-forward trunk with one output per
+target quantile on :class:`~fynance.models.loss.PinballLoss`, giving a
+**distributional** forecast instead of a single point estimate. It conforms
+to the ``SignalModel`` protocol (``fit``/``predict``): ``predict`` returns
+the median (or nearest-to-0.5) quantile column — the usual point-forecast
+contract — while :meth:`~QuantileModel.predict_quantiles` exposes the full
+quantile band.
+
+Non-crossing quantiles
+-----------------------
+A net trained independently per quantile column has no structural guarantee
+that ``q10 <= q50 <= q90`` at every row (:class:`~fynance.models.loss.PinballLoss`
+is the plain per-column pinball loss, with no crossing penalty). Instead,
+:class:`QuantileModel` enforces monotonicity **at predict time** by sorting
+the raw net output along the quantile axis. ``taus`` are kept sorted
+ascending internally (see
+:func:`~fynance.models.loss.pinball._validate_taus`), so after this sort
+column ``i`` still lines up with the ``i``-th requested quantile.
+
+"""
+
+# Built-in
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+# Third-party
+import numpy as np
+import torch
+from numpy.typing import NDArray
+
+# Local
+from fynance.models.loss.pinball import PinballLoss, _validate_taus
+
+__all__ = ['QuantileModel']
+
+
+def _quantile_trunk(
+    n_features: int,
+    n_taus: int,
+    layers: list[int],
+    activation: type[torch.nn.Module] | None,
+    activation_kwargs: dict[str, Any],
+    drop: float | None,
+    bias: bool,
+) -> torch.nn.Module:
+    r""" Feed-forward trunk: ``Linear -> [Dropout] -> [Activation]`` hidden
+    blocks with a **linear** (unbounded) ``n_taus``-wide output head.
+
+    Mirrors the architecture kwargs exposed by
+    :class:`~fynance.models.mlp.MultiLayerPerceptron` (``layers``,
+    ``activation``, ``drop``, ``bias``, ``activation_kwargs``), but — unlike
+    that class, whose ``forward`` applies the activation to *every* layer
+    including the output — leaves the output head linear, as
+    :func:`fynance.models.regime_model._mlp` and
+    :func:`fynance.models.objective._default_net` already do: a quantile
+    regression target is real-valued and unbounded, and an output-side
+    activation such as the default ``ReLU`` would clip it (verified to
+    collapse training to a constant-zero net on a symmetric-around-0
+    target).
+    """
+    mods: list[torch.nn.Module] = []
+    dim = n_features
+    for h in layers:
+        mods.append(torch.nn.Linear(dim, h, bias=bias))
+        if drop is not None:
+            mods.append(torch.nn.Dropout(p=drop))
+        if activation is not None:
+            mods.append(activation(**activation_kwargs))
+        dim = h
+    mods.append(torch.nn.Linear(dim, n_taus, bias=bias))  # linear output head
+
+    return torch.nn.Sequential(*mods)
+
+
+class QuantileModel:
+    r""" Multi-quantile regression ``SignalModel``.
+
+    Trains a feed-forward trunk with one output column per ``tau`` on
+    :class:`~fynance.models.loss.PinballLoss`. Unlike
+    :class:`~fynance.models.objective.ObjectiveModel` (trained on
+    ``positions * returns``), ``fit(X, y)`` reads ``y`` as an ordinary
+    supervised target (e.g. the next-bar return), not a returns series to be
+    combined with positions.
+
+    Parameters
+    ----------
+    taus : float or sequence of float, optional
+        Target quantile(s) in ``(0, 1)``. Default ``(0.1, 0.5, 0.9)``.
+    layers : list of int, optional
+        Hidden layer sizes of the trunk. Default ``[16, 8]`` (a small
+        nonlinear trunk — matching the ``ObjectiveModel`` / ``RegimeMoE``
+        convention of a usable-out-of-the-box default).
+    activation : type[torch.nn.Module] or None, optional
+        Activation class applied after each **hidden** layer (never after the
+        linear output head — see :func:`_quantile_trunk`). Default
+        :class:`torch.nn.ReLU`; pass ``None`` for a purely linear trunk.
+    drop : float, optional
+        Dropout probability after each hidden layer. Default ``None`` (no
+        dropout).
+    bias : bool, optional
+        Whether the trunk's linear layers use a bias term. Default True.
+    activation_kwargs : dict, optional
+        Extra keyword arguments for ``activation``. Default ``{}``.
+    lr : float, optional
+        Learning rate for the optimizer. Default ``1e-3``.
+    epochs : int, optional
+        Full-batch training steps. Default ``200``.
+    optimizer : type[torch.optim.Optimizer], optional
+        Optimizer class. Default :class:`torch.optim.Adam`.
+    seed : int, optional
+        Seed for reproducible net initialization. Default ``0``.
+
+    Attributes
+    ----------
+    net : torch.nn.Module or None
+        The trunk, built lazily on the first :meth:`fit` call (``None``
+        before that).
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> rng = np.random.default_rng(0)
+    >>> x = rng.uniform(-2, 2, size=300).astype(np.float32)
+    >>> sigma = 0.1 + 0.3 * np.abs(x)
+    >>> y = (x + sigma * rng.standard_normal(300)).astype(np.float32)
+    >>> X = x.reshape(-1, 1)
+    >>> model = QuantileModel(
+    ...     taus=(0.1, 0.5, 0.9), layers=[16, 8], epochs=200, lr=1e-2, seed=0,
+    ... ).fit(X, y)
+    >>> point = model.predict(X)
+    >>> point.shape
+    (300,)
+    >>> q = model.predict_quantiles(X)
+    >>> q.shape
+    (300, 3)
+    >>> bool(np.all(np.diff(q, axis=1) >= 0))   # non-crossing, enforced at predict time
+    True
+
+    See Also
+    --------
+    fynance.models.loss.PinballLoss,
+    fynance.models.objective.ObjectiveModel,
+    fynance.models.regime_model.RegimeMoE
+
+    """
+
+    def __init__(
+        self,
+        taus: float | Sequence[float] = (0.1, 0.5, 0.9),
+        layers: list[int] = [16, 8],
+        activation: type[torch.nn.Module] | None = torch.nn.ReLU,
+        drop: float | None = None,
+        bias: bool = True,
+        activation_kwargs: dict[str, Any] = {},
+        lr: float = 1e-3,
+        epochs: int = 200,
+        optimizer: type[torch.optim.Optimizer] = torch.optim.Adam,
+        seed: int = 0,
+    ):
+        self.taus = _validate_taus(taus)
+        self._median_idx = min(
+            range(len(self.taus)), key=lambda i: abs(self.taus[i] - 0.5)
+        )
+        self.layers = list(layers)
+        self.activation = activation
+        self.drop = drop
+        self.bias = bias
+        self.activation_kwargs = dict(activation_kwargs)
+        self.lr = lr
+        self.epochs = epochs
+        self.optimizer_cls = optimizer
+        self.seed = seed
+        self._loss = PinballLoss(taus=self.taus)
+        self.net: torch.nn.Module | None = None
+        self._optim: torch.optim.Optimizer | None = None
+
+    def fit(self, X: NDArray, y: NDArray) -> QuantileModel:
+        """ Train the trunk to minimize the multi-quantile pinball loss.
+
+        Parameters
+        ----------
+        X : array-like, shape (T, F)
+            Feature matrix.
+        y : array-like, shape (T,) (or any shape reshaping to it)
+            Supervised target aligned with ``X`` (e.g. the realized
+            next-bar return) — not a returns series to combine with
+            positions.
+
+        Returns
+        -------
+        QuantileModel
+            ``self``.
+
+        Raises
+        ------
+        ValueError
+            If ``X`` is not 2-D, or ``X`` and ``y`` have different lengths.
+
+        """
+        Xa = np.asarray(X, dtype=np.float32)
+        ya = np.asarray(y, dtype=np.float32).reshape(-1)
+
+        if Xa.ndim != 2:
+            raise ValueError(f"X must be 2-D (T, F), got shape {Xa.shape}")
+
+        if ya.shape[0] != Xa.shape[0]:
+            raise ValueError(
+                "X and y must have the same length, got "
+                f"{Xa.shape[0]} and {ya.shape[0]}"
+            )
+
+        # Seed before building the net for reproducible initialization.
+        torch.manual_seed(self.seed)
+        self.net = _quantile_trunk(
+            Xa.shape[1], len(self.taus), self.layers, self.activation,
+            self.activation_kwargs, self.drop, self.bias,
+        )
+        self._optim = self.optimizer_cls(
+            self.net.parameters(), lr=self.lr,  # type: ignore[call-arg]
+        )
+
+        Xt = torch.as_tensor(Xa)
+        yt = torch.as_tensor(ya)
+
+        self.net.train()
+        for _ in range(self.epochs):
+            self._optim.zero_grad()
+            pred = self.net(Xt)
+            loss = self._loss(pred, yt)
+            loss.backward()
+            self._optim.step()
+
+        return self
+
+    @torch.no_grad()
+    def predict_quantiles(self, X: NDArray) -> NDArray:
+        """ Return the full quantile band, shape ``(T, n_taus)``.
+
+        Columns follow ``self.taus`` (sorted ascending). Non-crossing is
+        enforced here (not during training) by sorting the raw, independently
+        trained columns along the quantile axis.
+
+        Parameters
+        ----------
+        X : array-like, shape (T, F)
+            Feature matrix.
+
+        Returns
+        -------
+        numpy.ndarray
+            Quantile predictions, shape ``(T, n_taus)``, non-decreasing
+            along axis 1.
+
+        Raises
+        ------
+        RuntimeError
+            If called before :meth:`fit`.
+
+        """
+        if self.net is None:
+            raise RuntimeError("QuantileModel must be fit before predict_quantiles")
+
+        Xt = torch.as_tensor(np.asarray(X, dtype=np.float32))
+        was_training = self.net.training
+        self.net.eval()
+        try:
+            raw = self.net(Xt)
+        finally:
+            self.net.train(was_training)
+        sorted_q, _ = torch.sort(raw, dim=-1)
+
+        return sorted_q.cpu().numpy()
+
+    def predict(self, X: NDArray) -> NDArray:
+        """ Point forecast: the tau=0.5 (or nearest) quantile column.
+
+        Parameters
+        ----------
+        X : array-like, shape (T, F)
+            Feature matrix.
+
+        Returns
+        -------
+        numpy.ndarray
+            Shape ``(T,)``, the median (or nearest-to-0.5 ``tau``) column of
+            :meth:`predict_quantiles`.
+
+        """
+        return self.predict_quantiles(X)[:, self._median_idx]

--- a/fynance/tests/models/test_loss.py
+++ b/fynance/tests/models/test_loss.py
@@ -15,6 +15,7 @@ from fynance.models.loss import (
     CalmarLoss,
     DirectionalAccuracyLoss,
     OmegaLoss,
+    PinballLoss,
     RankingLoss,
     SharpeLoss,
     SortinoLoss,
@@ -444,3 +445,77 @@ class TestRankingLoss:
     def test_non_tensor_raises(self):
         with pytest.raises(TypeError):
             RankingLoss()(np.zeros((T, 3)), np.zeros((T, 3)))
+
+
+# ---------------------------------------------------------------------------
+# Distributional loss: PinballLoss
+# ---------------------------------------------------------------------------
+
+class TestPinballLoss:
+    def test_median_tau_equals_half_mae(self):
+        # tau=0.5 -> loss is exactly 0.5 * MAE, for any pred/target.
+        target = torch.tensor([1.0, 2.0, 3.0, 10.0])
+        pred = torch.tensor([[2.0], [1.0], [5.0], [8.0]])
+        e = target - pred.squeeze(-1)
+        expected = 0.5 * e.abs().mean()
+        loss = PinballLoss(taus=0.5)(pred, target)
+        assert loss.shape == torch.Size([])
+        assert torch.isclose(loss, expected)
+
+    def test_asymmetric_known_value(self):
+        # tau=0.9: under-prediction (e>0) costs 0.9*e, over-prediction (e<0)
+        # costs 0.1*|e|. target=0, pred=[1, -1] -> e=[-1, 1] ->
+        # losses = [0.1*1, 0.9*1] = [0.1, 0.9] -> mean 0.5.
+        target = torch.tensor([0.0, 0.0])
+        pred = torch.tensor([[1.0], [-1.0]])
+        loss = PinballLoss(taus=0.9)(pred, target)
+        assert loss.item() == pytest.approx(0.5)
+
+    def test_multi_tau_matches_mean_of_single_tau_losses(self):
+        rng = np.random.default_rng(0)
+        target = torch.from_numpy(rng.standard_normal(20).astype(np.float32))
+        base_pred = torch.from_numpy(rng.standard_normal(20).astype(np.float32))
+        taus = (0.1, 0.5, 0.9)
+        pred = torch.stack([base_pred + 0.1 * i for i in range(3)], dim=-1)
+        multi = PinballLoss(taus=taus)(pred, target)
+        singles = torch.stack([
+            PinballLoss(taus=t)(pred[:, i:i + 1], target)
+            for i, t in enumerate(taus)
+        ])
+        assert torch.isclose(multi, singles.mean())
+
+    def test_taus_sorted_regardless_of_input_order(self):
+        assert PinballLoss(taus=(0.9, 0.1, 0.5)).taus == (0.1, 0.5, 0.9)
+
+    def test_single_float_tau_wrapped(self):
+        assert PinballLoss(taus=0.3).taus == (0.3,)
+
+    def test_invalid_tau_raises(self):
+        with pytest.raises(ValueError):
+            PinballLoss(taus=1.5)
+
+        with pytest.raises(ValueError):
+            PinballLoss(taus=())
+
+    def test_gradient_flow(self):
+        target = torch.from_numpy(RNG.standard_normal(T).astype(np.float32))
+        pred = torch.from_numpy(
+            RNG.standard_normal((T, 3)).astype(np.float32)
+        ).requires_grad_(True)
+        loss = PinballLoss(taus=(0.1, 0.5, 0.9))(pred, target)
+        loss.backward()
+        assert pred.grad is not None
+        assert torch.isfinite(pred.grad).all()
+        assert pred.grad.abs().sum() > 0
+
+    def test_non_tensor_raises(self):
+        with pytest.raises(TypeError):
+            PinballLoss()(np.zeros((T, 3)), np.zeros(T))
+
+    def test_wrong_trailing_dim_raises(self):
+        with pytest.raises(ValueError):
+            PinballLoss(taus=(0.1, 0.5, 0.9))(torch.randn(T, 2), torch.randn(T))
+
+    def test_target_shape_mismatch_raises(self):
+        with pytest.raises(ValueError):
+            PinballLoss(taus=0.5)(torch.randn(T, 1), torch.randn(T, 2))

--- a/fynance/tests/models/test_quantile.py
+++ b/fynance/tests/models/test_quantile.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+""" Distributional (quantile) regression: QuantileModel + PinballLoss. """
+
+# Third-party
+import numpy as np
+import pytest
+import torch
+
+# Local
+from fynance.core import SignalModel
+from fynance.models import QuantileModel
+from fynance.models.loss import PinballLoss
+
+
+def _heteroskedastic_data(n=3000, seed=0):
+    """ y = x + sigma(x) * noise: the spread of ``y`` grows with ``|x|``.
+
+    A single-feature regression where the conditional quantiles are known
+    analytically (``x + z_tau * sigma(x)`` for standard-normal noise), used
+    to check empirical coverage of the fitted quantile band.
+    """
+    rng = np.random.default_rng(seed)
+    x = rng.uniform(-3, 3, size=n).astype(np.float32)
+    sigma = (0.1 + 0.4 * np.abs(x)).astype(np.float32)
+    noise = rng.standard_normal(n).astype(np.float32)
+    y = (x + sigma * noise).astype(np.float32)
+
+    return x.reshape(-1, 1), y
+
+
+# Fit once per module: training is the expensive part, and every test below
+# only reads (never mutates) the fitted model's held-out predictions.
+_TAUS = (0.1, 0.5, 0.9)
+_X, _Y = _heteroskedastic_data()
+_N_TRAIN = 2400
+_X_TRAIN, _Y_TRAIN = _X[:_N_TRAIN], _Y[:_N_TRAIN]
+_X_TEST, _Y_TEST = _X[_N_TRAIN:], _Y[_N_TRAIN:]
+
+
+@pytest.fixture(scope="module")
+def fitted_model():
+    """ QuantileModel fit on the train slice only (no lookahead). """
+    return QuantileModel(
+        taus=_TAUS, layers=[16, 8], epochs=300, lr=1e-2, seed=0,
+    ).fit(_X_TRAIN, _Y_TRAIN)
+
+
+def test_conforms_to_signalmodel():
+    assert isinstance(QuantileModel(), SignalModel)
+
+
+def test_predict_before_fit_raises():
+    with pytest.raises(RuntimeError, match="fit"):
+        QuantileModel().predict(np.zeros((5, 1)))
+
+    with pytest.raises(RuntimeError, match="fit"):
+        QuantileModel().predict_quantiles(np.zeros((5, 1)))
+
+
+def test_fit_returns_self():
+    model = QuantileModel(epochs=2)
+    assert model.fit(_X_TRAIN[:50], _Y_TRAIN[:50]) is model
+
+
+def test_predict_quantiles_shape(fitted_model):
+    q = fitted_model.predict_quantiles(_X_TEST)
+    assert isinstance(q, np.ndarray)
+    assert q.shape == (_X_TEST.shape[0], len(_TAUS))
+
+
+def test_predict_shape_and_dtype(fitted_model):
+    point = fitted_model.predict(_X_TEST)
+    assert isinstance(point, np.ndarray)
+    assert point.shape == (_X_TEST.shape[0],)
+
+
+def test_predict_equals_median_column(fitted_model):
+    # taus=(0.1, 0.5, 0.9) -> tau=0.5 is exactly present at column index 1.
+    q = fitted_model.predict_quantiles(_X_TEST)
+    point = fitted_model.predict(_X_TEST)
+    assert np.array_equal(point, q[:, 1])
+
+
+def test_nearest_to_half_when_median_absent():
+    # taus without an exact 0.5: predict must pick the nearest column (0.4).
+    model = QuantileModel(
+        taus=(0.2, 0.4, 0.8), layers=[8], epochs=5, seed=0,
+    ).fit(_X_TRAIN[:200], _Y_TRAIN[:200])
+    q = model.predict_quantiles(_X_TEST[:20])
+    assert np.array_equal(model.predict(_X_TEST[:20]), q[:, 1])  # tau=0.4
+
+
+def test_quantiles_non_crossing_everywhere(fitted_model):
+    q = fitted_model.predict_quantiles(_X_TEST)
+    assert np.all(np.diff(q, axis=1) >= 0)
+
+
+def test_taus_sorted_regardless_of_input_order():
+    model = QuantileModel(taus=(0.9, 0.1, 0.5))
+    assert model.taus == (0.1, 0.5, 0.9)
+
+
+def test_held_out_coverage_in_expected_band(fitted_model):
+    # The nominal [q10, q90] band should cover ~80% of held-out points; allow
+    # a wide but meaningful tolerance around that for a small, quickly
+    # trained net on a noisy heteroskedastic target.
+    q = fitted_model.predict_quantiles(_X_TEST)
+    lo, hi = q[:, 0], q[:, 2]
+    coverage = np.mean((_Y_TEST >= lo) & (_Y_TEST <= hi))
+    assert 0.72 <= coverage <= 0.88
+
+
+def test_reproducible_with_seed():
+    a = QuantileModel(taus=_TAUS, layers=[8], epochs=20, seed=7).fit(
+        _X_TRAIN[:400], _Y_TRAIN[:400]).predict(_X_TEST[:50])
+    b = QuantileModel(taus=_TAUS, layers=[8], epochs=20, seed=7).fit(
+        _X_TRAIN[:400], _Y_TRAIN[:400]).predict(_X_TEST[:50])
+    assert np.allclose(a, b)
+
+
+def test_x_must_be_2d():
+    with pytest.raises(ValueError):
+        QuantileModel(epochs=2).fit(np.zeros(10), np.zeros(10))
+
+
+def test_length_mismatch_raises():
+    with pytest.raises(ValueError):
+        QuantileModel(epochs=2).fit(np.zeros((10, 1)), np.zeros(5))
+
+
+def test_accepts_float64_numpy():
+    # Plain float64 numpy (no .astype) must fit/predict without crashing.
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(80, 2))       # float64 by default
+    y = X.sum(axis=1)                  # float64
+    model = QuantileModel(layers=[8], epochs=5, seed=0).fit(X, y)
+    out = model.predict(X)
+    assert out.shape == (80,)
+
+
+class TestPinballLossOnQuantileModel:
+    def test_held_out_pinball_loss_is_finite(self, fitted_model):
+        q = fitted_model.predict_quantiles(_X_TEST)
+        loss = PinballLoss(taus=_TAUS)(
+            torch.as_tensor(q), torch.as_tensor(_Y_TEST),
+        )
+        assert torch.isfinite(loss)
+        assert loss.item() >= 0.0


### PR DESCRIPTION
## Summary
- `PinballLoss(taus)` in `fynance.models.loss` (quantile/pinball, mean over taus, sorted-tau canonical order).
- `QuantileModel` in `fynance.models.quantile`: `SignalModel` with a feed-forward trunk and one output per tau (default 0.1/0.5/0.9), trained on PinballLoss; `predict` returns the median column, `predict_quantiles` the full band, non-crossing enforced by sorting at predict time. Gaussian-NLL reuses `torch.nn.GaussianNLLLoss` directly (no house wrapper — documented).
- Leaf 02/04 of the `ml-bricks` epic.

## Verification (heteroskedastic synthetic y = x + σ(x)·noise, T=3000)
Held-out empirical coverage: tau=0.1→0.098, 0.5→0.525, 0.9→0.908; [q10,q90] band coverage 0.81 (in the target [0.72,0.88]); mean pinball loss 0.170; predict == median column, quantiles non-crossing.

## Test plan
- [x] `pytest` — 1563 passed post-rebase (pinball hand values, autograd, coverage band, non-crossing, SignalModel conformance)
- [x] `ruff` / `mypy` / interrogate / Sphinx -W
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)