### PR TITLE
feat: add duck-typed pandas/polars seams (PriceSeries, OHLCV, BacktestResult)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **DataFrame seams.** Duck-typed `from_pandas` / `to_pandas` / `to_polars`
+  on `PriceSeries`, `OHLCV` and `BacktestResult` (`BacktestResult.to_pandas`)
+  — pandas/polars stay optional (lazy import, no module-level dependency;
+  `import fynance` remains pandas-free).
 - **Protocol conformance & causality checks.** New `fynance.core.checks`:
   `check_conforms(obj, protocol)` smoke-runs a protocol's methods on seeded
   synthetic data with actionable errors, and `assert_causal(func)` probes for

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -72,7 +72,7 @@ Template:
 
 <!-- new entries below, newest first -->
 
-### 2026-07-06 — DX one-offs epic (PRs #267, epic)  [accepted]
+### 2026-07-06 — DX one-offs epic (PRs #267–#268, epic)  [accepted]
 
 - **Choice**: two developer-experience bricks — `core.checks`
   (`check_conforms` + `assert_causal`, an executable lookahead probe) and

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -12,7 +12,9 @@ so an agent doesn't re-investigate settled ground or assume a known stub is a bu
 - **Core**: `PriceSeries` (thin numpy-backed value object — composition, not
   `ndarray` subclassing; price↔return identities, numpy/torch bridges, `.pipe`)
   and the pipeline protocols (`DataSource`/`FeatureTransform`/`SignalModel`/
-  `Allocator`/`CostModel`/`Metric`).
+  `Allocator`/`CostModel`/`Metric`); `core.checks` (`check_conforms` +
+  the `assert_causal` lookahead probe) and duck-typed `from_pandas`/
+  `to_pandas`/`to_polars` seams on `PriceSeries`/`OHLCV`/`BacktestResult`.
 - **Data**: `load()` dispatcher + CSV/Parquet adapters, causal `align`/`resample`,
   and no-lookahead `train_test_split`/`walk_forward` (embargo/purge).
 - **Features**: technical indicators (RSI/MACD/Bollinger/CCI/HMA/ROC/realized-vol/

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -45,10 +45,3 @@ Le harnais `fynance.research` est **livré** (S1–S3) : `Experiment`,
 
 - [ ] Explorateur **Streamlit** au-dessus du Ledger (parcourir / filtrer / comparer
   les runs persistés) — interactif, plus tardif.
-
-## 10. DX one-offs (épic `dx-oneoffs`)
-
-- [ ] `core/checks.py` : `check_conforms(obj, protocol)` + `assert_causal(func)` —
-  sonde de lookahead exécutable, dogfoodée dans les tests fynance.
-- [ ] Seams DataFrame duck-typées : `to_polars`/`from_pandas` sur `PriceSeries`/
-  `OHLCV`/`BacktestResult` (sans dépendance pandas/polars).

--- a/fynance/backtest/result.py
+++ b/fynance/backtest/result.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 # Built-in packages
 from dataclasses import dataclass
+from typing import Any
 
 # Third-party packages
 import numpy as np
@@ -53,6 +54,7 @@ class BacktestResult:
     -------
     to_numpy
     to_price_series
+    to_pandas
     summary
     trades
     trade_summary
@@ -75,6 +77,63 @@ class BacktestResult:
     def to_price_series(self) -> PriceSeries:
         """ Return the equity curve as a :class:`PriceSeries`. """
         return PriceSeries(self.equity, index=self.index, name="equity")
+
+    def to_pandas(self) -> Any:
+        """ Return this result as a :class:`pandas.DataFrame` (lazy import).
+
+        One row per time step. Always carries ``equity``, ``returns``,
+        ``gross_returns`` and ``costs``. :attr:`positions` becomes a single
+        ``positions`` column for a single-asset ``(T,)`` book, or
+        ``pos_0``..``pos_{N-1}`` columns for a multi-asset ``(T, N)`` book.
+        When present, :attr:`asset_gross_returns` similarly expands into
+        ``asset_gross_return_0``..``asset_gross_return_{N-1}`` columns, and
+        each :attr:`cost_components` entry becomes a ``cost_<name>`` column.
+        The DataFrame index is :attr:`index` when set, else pandas' default
+        ``RangeIndex``.
+
+        Raises
+        ------
+        ImportError
+            If pandas is not installed, with a clear, actionable message.
+
+        Examples
+        --------
+        >>> from fynance.backtest import backtest
+        >>> res = backtest(np.array([0.01, 0.02, -0.01]), np.ones(3))
+        >>> list(res.to_pandas().columns)
+        ['equity', 'returns', 'gross_returns', 'costs', 'positions']
+
+        """
+        try:
+            import pandas as pd
+
+        except ImportError as exc:
+
+            raise ImportError("install pandas to use to_pandas()") from exc
+
+        data: dict[str, NDArray] = {
+            "equity": self.equity,
+            "returns": self.returns,
+            "gross_returns": self.gross_returns,
+            "costs": self.costs,
+        }
+
+        if self.positions.ndim == 2:
+            for i in range(self.positions.shape[1]):
+                data[f"pos_{i}"] = self.positions[:, i]
+
+        else:
+            data["positions"] = self.positions
+
+        if self.asset_gross_returns is not None:
+            for i in range(self.asset_gross_returns.shape[1]):
+                data[f"asset_gross_return_{i}"] = self.asset_gross_returns[:, i]
+
+        if self.cost_components is not None:
+            for name, values in self.cost_components.items():
+                data[f"cost_{name}"] = values
+
+        return pd.DataFrame(data, index=self.index)
 
     def summary(self, period: int = 252) -> dict[str, float]:
         """ Standard performance summary.

--- a/fynance/core/ohlcv.py
+++ b/fynance/core/ohlcv.py
@@ -202,6 +202,80 @@ class OHLCV:
 
         return cls.from_dict(mapping)
 
+    @classmethod
+    def from_pandas(
+        cls,
+        df: Any,
+        columns: tuple[str, ...] = _FIELDS,
+    ) -> OHLCV:
+        """ Build from a pandas-like DataFrame (columns matched case-insensitively).
+
+        Unlike :meth:`from_polars` (which scans ``data.columns`` for the fixed
+        canonical names), ``columns`` here lets the caller declare the
+        DataFrame's actual column name for each OHLCV field, in
+        ``(open, high, low, close, volume)`` order; matching against
+        ``df.columns`` is case-insensitive on both sides.
+
+        Parameters
+        ----------
+        df : Any
+            Duck-typed DataFrame-like object: only ``df.columns`` (an
+            iterable of ``str``) and column access ``df[name]`` (exposing
+            ``.to_numpy()`` or ``.values``) are required -- no pandas import
+            happens in this method.
+        columns : tuple of str
+            The DataFrame's column name for each canonical field, in
+            ``(open, high, low, close, volume)`` order. Defaults to the
+            canonical names themselves. A shorter tuple leaves the trailing
+            fields unrequested (treated as absent, see below).
+
+        Returns
+        -------
+        OHLCV
+
+        Raises
+        ------
+        ValueError
+            If the column mapped to ``close`` -- the only field
+            :class:`OHLCV` requires -- cannot be found in ``df``. Every other
+            field follows :class:`OHLCV`'s own optionality (only ``close`` is
+            required at construction, see the class docstring): when its
+            column is absent, that field is simply omitted rather than
+            raising. This is why ``volume`` -- the field most often missing
+            from real OHLC feeds -- can be dropped from ``columns`` or absent
+            from ``df`` with no error; the same leniency applies to
+            ``open``/``high``/``low``.
+
+        Examples
+        --------
+        >>> import pandas as pd
+        >>> df = pd.DataFrame({"Close": [1., 2.], "High": [2., 3.]})
+        >>> OHLCV.from_pandas(df).columns
+        ('high', 'close')
+
+        """
+        available = {str(c).lower(): c for c in df.columns}
+        mapping: dict[str, Any] = {}
+
+        for field, col in zip(_FIELDS, columns):
+            key = str(col).lower()
+
+            if key not in available:
+
+                if field == 'close':
+
+                    raise ValueError(
+                        f"OHLCV.from_pandas: column {col!r} (field 'close') "
+                        f"not found; available columns: {list(df.columns)}"
+                    )
+
+                continue
+
+            raw = df[available[key]]
+            mapping[field] = raw.to_numpy() if hasattr(raw, "to_numpy") else raw.values
+
+        return cls.from_dict(mapping)
+
     # -- Field access -----------------------------------------------------
 
     def _get(self, field: str) -> NDArray[np.float64]:
@@ -266,6 +340,35 @@ class OHLCV:
             return np.empty((0, 0), dtype=np.float64)
 
         return np.column_stack([self._data[f] for f in self.columns])
+
+    def to_pandas(self) -> Any:
+        """ Return the present fields as a :class:`pandas.DataFrame` (lazy import).
+
+        Columns follow :attr:`columns` (canonical OHLCV order).
+
+        Raises
+        ------
+        ImportError
+            If pandas is not installed, with a clear, actionable message.
+
+        Examples
+        --------
+        >>> OHLCV(close=[1., 2.], high=[2., 3.]).to_pandas()
+           high  close
+        0   2.0    1.0
+        1   3.0    2.0
+
+        """
+        try:
+            import pandas as pd
+
+        except ImportError as exc:
+
+            raise ImportError("install pandas to use to_pandas()") from exc
+
+        return pd.DataFrame(
+            {f: self._data[f] for f in self.columns}, columns=list(self.columns)
+        )
 
     # -- Dunders ----------------------------------------------------------
 

--- a/fynance/core/price_series.py
+++ b/fynance/core/price_series.py
@@ -179,6 +179,93 @@ class PriceSeries:
             freq=freq,
         )
 
+    @classmethod
+    def from_pandas(cls, obj: Any, freq: str | None = None) -> PriceSeries:
+        """ Build a :class:`PriceSeries` from a duck-typed pandas-like object.
+
+        Accepts anything exposing ``.to_numpy()`` or ``.values`` -- a
+        :class:`pandas.Series`, a single-column :class:`pandas.DataFrame`, or
+        a minimal look-alike. No pandas import happens in this method: it is
+        pure duck typing, so any object satisfying the protocol works (this is
+        what lets the test suite exercise it with a pandas-free shim).
+
+        Parameters
+        ----------
+        obj : Any
+            Duck-typed pandas-like object (``Series`` or single-column
+            ``DataFrame``).
+        freq : str, optional
+            Frequency tag carried onto the series.
+
+        Returns
+        -------
+        PriceSeries
+
+        Raises
+        ------
+        TypeError
+            If ``obj`` exposes neither ``.to_numpy()`` nor ``.values``.
+        ValueError
+            If the extracted array is 2-D with more than one column (an
+            ambiguous, multi-column ``DataFrame``).
+
+        Notes
+        -----
+        Unlike :meth:`from_polars` (which drops the index -- polars frames
+        rarely carry a meaningful one), :class:`PriceSeries` is built here
+        with its ``index`` attribute populated from ``obj.index`` whenever
+        that attribute is present (e.g. a pandas ``Series``'s ``DatetimeIndex``),
+        converted through :func:`numpy.asarray`. It is only left at the
+        default ``0..n-1`` range when ``obj`` exposes no ``.index`` at all,
+        as with the minimal duck-typed shim used in the tests.
+
+        Examples
+        --------
+        >>> import pandas as pd
+        >>> s = pd.Series([100., 101., 99.], name="px")
+        >>> PriceSeries.from_pandas(s).values
+        array([100., 101.,  99.])
+
+        """
+        if hasattr(obj, "to_numpy"):
+            values = obj.to_numpy()
+
+        elif hasattr(obj, "values"):
+            values = obj.values
+
+        else:
+
+            raise TypeError(
+                "from_pandas() requires an object exposing .to_numpy() or "
+                f".values; got {type(obj)!r}"
+            )
+
+        values = np.asarray(values)
+
+        if values.ndim == 2:
+
+            if values.shape[1] != 1:
+
+                raise ValueError(
+                    "from_pandas() requires a Series or a single-column "
+                    f"DataFrame; got shape {values.shape}"
+                )
+
+            values = values[:, 0]
+
+        index = getattr(obj, "index", None)
+        if index is not None:
+            index = np.asarray(index)
+
+        name = getattr(obj, "name", None)
+        if name is None:
+            columns = getattr(obj, "columns", None)
+
+            if columns is not None and len(columns) == 1:
+                name = columns[0]
+
+        return cls(values, index=index, name=name, freq=freq)
+
     # -- Dunders ----------------------------------------------------------
 
     def __len__(self) -> int:
@@ -446,6 +533,58 @@ class PriceSeries:
 
         # Copy: the stored array is read-only, which torch warns about.
         return torch.as_tensor(self.values.copy(), dtype=dtype, device=device)
+
+    def to_pandas(self) -> Any:
+        """ Return this series as a :class:`pandas.Series` (lazy import).
+
+        Raises
+        ------
+        ImportError
+            If pandas is not installed, with a clear, actionable message.
+
+        Examples
+        --------
+        >>> PriceSeries([100., 101., 99.], name="px").to_pandas()
+        0    100.0
+        1    101.0
+        2     99.0
+        Name: px, dtype: float64
+
+        """
+        try:
+            import pandas as pd
+
+        except ImportError as exc:
+
+            raise ImportError("install pandas to use to_pandas()") from exc
+
+        return pd.Series(self.values, index=self.index, name=self.name)
+
+    def to_polars(self) -> Any:
+        """ Return this series as a :class:`polars.Series` (lazy import).
+
+        Raises
+        ------
+        ImportError
+            If polars is not installed, with a clear, actionable message.
+            (polars is a hard dependency of ``fynance``, so this branch is not
+            normally reachable in this package's own environment; it exists so
+            the method degrades gracefully wherever it is vendored or reused.)
+
+        Examples
+        --------
+        >>> PriceSeries([1., 2., 3.], name="px").to_polars().to_list()
+        [1.0, 2.0, 3.0]
+
+        """
+        try:
+            import polars as pl
+
+        except ImportError as exc:
+
+            raise ImportError("install polars to use to_polars()") from exc
+
+        return pl.Series(self.name, self.values)
 
     def pipe(
         self,

--- a/fynance/tests/backtest/test_result.py
+++ b/fynance/tests/backtest/test_result.py
@@ -82,3 +82,90 @@ def test_trades_empty_positions_edge():
     out = res.trades()
     assert out.shape[0] == 0
     assert res.trade_summary()["n_trades"] == 0.0
+
+
+# -- to_pandas ---------------------------------------------------------------
+
+def test_to_pandas_single_asset_columns_shape_dtypes():
+    pd = pytest.importorskip("pandas")
+    res = backtest(np.array([0.01, 0.02, -0.01]), np.ones(3), shift=False)
+    df = res.to_pandas()
+    assert isinstance(df, pd.DataFrame)
+    assert list(df.columns) == [
+        "equity", "returns", "gross_returns", "costs", "positions",
+    ]
+    assert df.shape == (3, 5)
+    for col in df.columns:
+        assert df[col].dtype == np.float64
+    assert np.array_equal(df["equity"].to_numpy(), res.equity)
+    assert np.array_equal(df["positions"].to_numpy(), res.positions)
+
+
+def test_to_pandas_uses_index_when_set():
+    pytest.importorskip("pandas")
+    res = backtest(np.array([0.01, 0.02, -0.01]), np.ones(3), shift=False)
+    res.index = np.array([10, 11, 12])
+    df = res.to_pandas()
+    assert np.array_equal(df.index.to_numpy(), [10, 11, 12])
+
+
+def test_to_pandas_multi_asset_positions_become_pos_columns():
+    pytest.importorskip("pandas")
+    rng = np.random.default_rng(3)
+    data = rng.normal(0.0, 0.01, (20, 3))
+    positions = rng.choice([-1.0, 0.0, 1.0], size=(20, 3))
+    res = backtest(data, positions, shift=True)
+    df = res.to_pandas()
+
+    assert "pos_0" in df.columns and "pos_1" in df.columns and "pos_2" in df.columns
+    assert "positions" not in df.columns
+    assert np.array_equal(df["pos_0"].to_numpy(), res.positions[:, 0])
+    assert np.array_equal(df["pos_1"].to_numpy(), res.positions[:, 1])
+    assert np.array_equal(df["pos_2"].to_numpy(), res.positions[:, 2])
+
+    # asset_gross_returns is populated for a multi-asset book
+    assert res.asset_gross_returns is not None
+    assert "asset_gross_return_0" in df.columns
+    assert np.array_equal(
+        df["asset_gross_return_0"].to_numpy(), res.asset_gross_returns[:, 0]
+    )
+
+
+def test_to_pandas_cost_components_become_cost_columns():
+    pytest.importorskip("pandas")
+
+    class _CostWithComponents:
+        def __call__(self, positions):
+            return np.abs(positions) * 0.01
+
+        def components(self, positions):
+            return {"transaction": np.abs(positions) * 0.01}
+
+    res = backtest(
+        np.array([0.01, 0.02, -0.01]), np.ones(3), cost=_CostWithComponents(),
+        shift=False,
+    )
+    df = res.to_pandas()
+    assert "cost_transaction" in df.columns
+    assert np.array_equal(
+        df["cost_transaction"].to_numpy(), res.cost_components["transaction"]
+    )
+
+
+def test_to_pandas_lazy_import_error_message(monkeypatch):
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _fake_import(name, *args, **kwargs):
+        if name == "pandas":
+
+            raise ImportError("No module named 'pandas'")
+
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_import)
+
+    res = backtest(np.array([0.01, 0.02, -0.01]), np.ones(3))
+    with pytest.raises(ImportError, match="install pandas to use to_pandas"):
+        res.to_pandas()

--- a/fynance/tests/core/test_ohlcv.py
+++ b/fynance/tests/core/test_ohlcv.py
@@ -119,3 +119,116 @@ def test_from_polars():
     bars = OHLCV.from_polars(df)
     assert bars.columns == ('high', 'close')
     assert np.array_equal(bars.high, [2.0, 3.0])
+
+
+# -- pandas seams -----------------------------------------------------------
+
+class _DuckFrame:
+    """ Minimal pandas-DataFrame look-alike; no pandas import anywhere. """
+
+    class _Col:
+        def __init__(self, values):
+            self._values = np.asarray(values, dtype=np.float64)
+
+        def to_numpy(self):
+            return self._values
+
+    def __init__(self, data):
+        self._data = {k: self._Col(v) for k, v in data.items()}
+        self.columns = list(data.keys())
+
+    def __getitem__(self, key):
+        return self._data[key]
+
+
+def test_from_pandas_duck_typed_shim_case_insensitive():
+    df = _DuckFrame({"Close": [1.0, 2.0], "High": [2.0, 3.0], "x": [9.0, 9.0]})
+    bars = OHLCV.from_pandas(df)
+    assert bars.columns == ('high', 'close')
+    assert np.array_equal(bars.high, [2.0, 3.0])
+    assert np.array_equal(bars.close, [1.0, 2.0])
+
+
+def test_from_pandas_missing_close_raises_naming_it():
+    df = _DuckFrame({"open": [1.0, 2.0], "high": [2.0, 3.0]})
+    with pytest.raises(ValueError, match="close"):
+        OHLCV.from_pandas(df)
+
+
+def test_from_pandas_missing_volume_is_optional():
+    # OHLCV itself treats volume as optional (see class docstring): from_pandas
+    # must not raise when the volume column is absent, even though `columns`
+    # defaults to naming it.
+    df = _DuckFrame({"open": [1.0], "high": [2.0], "low": [0.5], "close": [1.5]})
+    bars = OHLCV.from_pandas(df)
+    assert not bars.has('volume')
+    assert bars.columns == ('open', 'high', 'low', 'close')
+
+
+def test_from_pandas_missing_open_high_low_also_optional():
+    # Same leniency documented for volume applies to open/high/low: only
+    # `close` is hard-required, matching the class's own optionality.
+    df = _DuckFrame({"close": [1.0, 2.0, 3.0]})
+    bars = OHLCV.from_pandas(df)
+    assert bars.columns == ('close',)
+
+
+def test_from_pandas_custom_columns_mapping():
+    df = _DuckFrame({
+        "Open": [1.0], "High": [2.0], "Low": [0.5], "Close": [1.5], "Vol": [10.0],
+    })
+    bars = OHLCV.from_pandas(
+        df, columns=("Open", "High", "Low", "Close", "Vol")
+    )
+    assert bars.columns == ('open', 'high', 'low', 'close', 'volume')
+    assert np.array_equal(bars.volume, [10.0])
+
+
+def test_from_pandas_real_pandas_roundtrip():
+    pd = pytest.importorskip("pandas")
+    df = pd.DataFrame({
+        "open": [1.0, 2.0], "high": [2.0, 3.0], "low": [0.5, 1.5],
+        "close": [1.5, 2.5], "volume": [10.0, 20.0],
+    })
+    bars = OHLCV.from_pandas(df)
+    assert bars.columns == ('open', 'high', 'low', 'close', 'volume')
+    assert np.array_equal(bars.close, [1.5, 2.5])
+    assert np.array_equal(bars.volume, [10.0, 20.0])
+
+
+def test_to_pandas_columns_and_dtypes():
+    pd = pytest.importorskip("pandas")
+    bars = _synthetic(10)
+    df = bars.to_pandas()
+    assert isinstance(df, pd.DataFrame)
+    assert list(df.columns) == list(bars.columns)
+    assert df.shape == (10, 5)
+    for col in bars.columns:
+        assert df[col].dtype == np.float64
+        assert np.array_equal(df[col].to_numpy(), getattr(bars, col))
+
+
+def test_to_pandas_roundtrip_via_from_pandas():
+    pytest.importorskip("pandas")
+    bars = _synthetic(15)
+    df = bars.to_pandas()
+    rebuilt = OHLCV.from_pandas(df)
+    assert rebuilt == bars
+
+
+def test_to_pandas_lazy_import_error_message(monkeypatch):
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _fake_import(name, *args, **kwargs):
+        if name == "pandas":
+
+            raise ImportError("No module named 'pandas'")
+
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_import)
+
+    with pytest.raises(ImportError, match="install pandas to use to_pandas"):
+        OHLCV(close=[1.0, 2.0]).to_pandas()

--- a/fynance/tests/core/test_price_series.py
+++ b/fynance/tests/core/test_price_series.py
@@ -251,3 +251,145 @@ def test_from_polars_lone_string_column_raises_clean_error():
     ).with_columns(pl.col("date").str.to_date())
     with pytest.raises(ValueError, match="value_col is ambiguous"):
         PriceSeries.from_polars(df)
+
+
+# -- pandas/polars seams ---------------------------------------------------
+
+class _DuckSeries:
+    """ Minimal pandas-Series look-alike; no pandas import anywhere. """
+
+    def __init__(self, values, index=None, name=None):
+        self.values = np.asarray(values, dtype=np.float64)
+
+        if index is not None:
+            self.index = np.asarray(index)
+
+        self.name = name
+
+    def to_numpy(self):
+        return self.values
+
+
+def test_from_pandas_duck_typed_shim_values_attribute():
+    # A shim exposing only `.values` (no `.to_numpy()`, no pandas import).
+    class _ValuesOnly:
+        values = np.array([1.0, 2.0, 3.0])
+
+    ps = PriceSeries.from_pandas(_ValuesOnly())
+    assert np.array_equal(ps.values, [1.0, 2.0, 3.0])
+    # no .index on the shim -> default 0..n-1 range
+    assert np.array_equal(ps.index, np.arange(3))
+
+
+def test_from_pandas_duck_typed_shim_to_numpy_and_index_carried():
+    shim = _DuckSeries([10.0, 20.0, 30.0], index=[5, 6, 7], name="px")
+    ps = PriceSeries.from_pandas(shim)
+    assert np.array_equal(ps.values, [10.0, 20.0, 30.0])
+    assert np.array_equal(ps.index, [5, 6, 7])
+    assert ps.name == "px"
+
+
+def test_from_pandas_rejects_object_without_values_or_to_numpy():
+    with pytest.raises(TypeError, match="to_numpy"):
+        PriceSeries.from_pandas(object())
+
+
+def test_from_pandas_rejects_multi_column_frame():
+    class _MultiCol:
+        def to_numpy(self):
+            return np.zeros((4, 2))
+
+    with pytest.raises(ValueError, match="single-column"):
+        PriceSeries.from_pandas(_MultiCol())
+
+
+def test_from_pandas_real_pandas_series_roundtrip():
+    pd = pytest.importorskip("pandas")
+    s = pd.Series(
+        [100.0, 101.0, 99.5],
+        index=pd.RangeIndex(3),
+        name="px",
+    )
+    ps = PriceSeries.from_pandas(s)
+    assert np.array_equal(ps.values, s.to_numpy())
+    assert ps.name == "px"
+    assert np.array_equal(ps.index, s.index.to_numpy())
+
+
+def test_from_pandas_single_column_dataframe():
+    pd = pytest.importorskip("pandas")
+    df = pd.DataFrame({"px": [1.0, 2.0, 3.0]})
+    ps = PriceSeries.from_pandas(df)
+    assert np.array_equal(ps.values, [1.0, 2.0, 3.0])
+    assert ps.name == "px"
+
+
+def test_to_pandas_roundtrip_exact_values():
+    pd = pytest.importorskip("pandas")
+    ps = PriceSeries([100.0, 101.0, 99.5], index=[7, 8, 9], name="px")
+    s = ps.to_pandas()
+    assert isinstance(s, pd.Series)
+    assert np.array_equal(s.to_numpy(), ps.values)
+    assert np.array_equal(s.index.to_numpy(), ps.index)
+    assert s.name == "px"
+
+    back = PriceSeries.from_pandas(s)
+    assert np.array_equal(back.values, ps.values)
+    assert np.array_equal(back.index, ps.index)
+    assert back.name == ps.name
+
+
+def test_to_polars_roundtrip_exact_values():
+    pl = pytest.importorskip("polars")
+    ps = PriceSeries([1.0, 2.0, 3.0], name="px")
+    s = ps.to_polars()
+    assert isinstance(s, pl.Series)
+    assert np.array_equal(s.to_numpy(), ps.values)
+    assert s.name == "px"
+
+
+def test_to_pandas_lazy_import_error_message(monkeypatch):
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _fake_import(name, *args, **kwargs):
+        if name == "pandas":
+
+            raise ImportError("No module named 'pandas'")
+
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_import)
+
+    with pytest.raises(ImportError, match="install pandas to use to_pandas"):
+        PriceSeries([1.0, 2.0]).to_pandas()
+
+
+def test_to_polars_lazy_import_error_message(monkeypatch):
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _fake_import(name, *args, **kwargs):
+        if name == "polars":
+
+            raise ImportError("No module named 'polars'")
+
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_import)
+
+    with pytest.raises(ImportError, match="install polars to use to_polars"):
+        PriceSeries([1.0, 2.0]).to_polars()
+
+
+def test_import_fynance_stays_pandas_free():
+    # pandas is not a fynance dependency (all pandas seams lazy-import it
+    # inside their methods); importing the package must not pull it in.
+    import subprocess
+    import sys
+
+    code = "import fynance, sys; print('pandas' in sys.modules)"
+    out = subprocess.check_output([sys.executable, "-c", code], text=True)
+    assert out.strip() == "False"


### PR DESCRIPTION
## Summary
- `PriceSeries.from_pandas` / `.to_pandas` / `.to_polars`, `OHLCV.from_pandas(columns=)` (case-insensitive) / `.to_pandas`, `BacktestResult.to_pandas` (equity/positions/costs, per-asset columns).
- Duck-typed: `from_pandas` accepts any `.to_numpy()`/`.values` object; `to_*` lazy-import with a clear ImportError; **no pandas/polars import at module level** — `import fynance` stays pandas-free (subprocess-tested).
- **Last leaf (02) of the `dx-oneoffs` epic — closes the entire 2026-07 backlog** (roadmap §2–§10). Roadmap now holds only the optional Streamlit explorer.

## Verification
CSV → `load()` → PriceSeries → to_pandas → from_pandas round-trip bit-equal (values + index); OHLCV close-only frame → no volume, no error; backtest → to_pandas shape (30, 5) all float64; `'pandas' in sys.modules` after import fynance → False.

## Test plan
- [x] `pytest` — 1653 passed (round-trips, duck-typed shim, missing-column error, lazy-import error path, pandas-free import)
- [x] `ruff` / `mypy` / interrogate / Sphinx -W
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)