### PR TITLE
docs: bring Sphinx API coverage + README/subpackage map up to date (2026-07 bricks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,49 +53,72 @@ is usable standalone; `fynance.strategy.Strategy` is an *optional* orchestrator.
 
 **Core** `fynance.core` — `PriceSeries` value object (thin, numpy-backed) and the
 pipeline protocols (`DataSource`, `FeatureTransform`, `SignalModel`, `Allocator`,
-`CostModel`, `Metric`).
+`CostModel`, `Metric`); executable conformance/causality checks (`check_conforms`,
+`assert_causal`) and duck-typed pandas/polars seams (`from_pandas`/`to_pandas`).
 
 **Data** `fynance.data` — file adapters (`load` for CSV/Parquet → `PriceSeries`),
-alignment/resampling, and no-lookahead temporal splits (`train_test_split`,
-`walk_forward`).
+alignment/resampling, no-lookahead temporal splits (`train_test_split`,
+`walk_forward`, combinatorial-purged `combinatorial_purged_cv`) and vendor-agnostic
+intraday session utilities (`session_mask`/`session_id`/`split_sessions`).
 
 **Features** `fynance.features` — technical indicators (Bollinger, RSI, MACD, ROC,
 realized volatility, rolling skew/kurtosis/autocorr, …), OHLCV indicators (ATR,
 ADX, Williams %R, OBV, VWAP), a causal GARCH(1,1) conditional-volatility feature,
-momentums (SMA, EMA, WMA) and adaptive windows, scaling (incl. rolling rank),
-statistics, feature engineering (multi-resolution, Granger causality) and
-market-regime detection.
+momentums (SMA, EMA, WMA) and adaptive windows, **NaN-aware cross-sectional
+operators** (`cs_rank`/`cs_zscore`/`cs_neutralize`, …), **pairwise rolling stats**
+(`roll_corr`/`roll_beta`, `cross_corr`), **fractional differentiation** (`fracdiff`),
+**AFML labeling** (`triple_barrier`, `meta_labels`, uniqueness weights), scaling
+(incl. rolling rank), statistics, feature engineering (multi-resolution, Granger
+causality) and market-regime detection.
 
 **Metrics** `fynance.metrics` — performance/evaluation metrics (Sharpe, Sortino,
-Calmar, drawdown, …) and a one-call `summary`.
+Calmar, drawdown, …) and a one-call `summary`; **tail risk** (VaR/CVaR/CDaR,
+tail dependence), **benchmark-relative** metrics (alpha, beta, tracking error,
+information ratio, capture), **factor evaluation** (quantile returns, rolling IC,
+IC decay), and turnover/exposure and per-trade analytics.
 
 **Signal** `fynance.signal` — prediction → position mappers (`sign`, `threshold`,
 `rank`, vol-targeting) and a model+mapper pipeline.
 
-**Portfolio** `fynance.portfolio` — allocation (ERC, HRP, IVP, MDP, MVP) and
-sizing (fractional Kelly, volatility targeting, transaction costs).
+**Portfolio** `fynance.portfolio` — allocation (ERC, HRP, IVP, MDP, MVP, plus
+risk-budgeting `RBP`) with an opt-in `cov=` seam over conditioned **covariance
+estimators** (Ledoit-Wolf, EWMA, factor, Marchenko-Pastur denoising); risk
+**attribution**, an exposure-**constraints** overlay (`project_weights`),
+**rebalancing policies** (calendar/band/turnover-cap, lot discretization) and
+sizing (fractional Kelly, single-series and book-level volatility targeting,
+transaction costs).
 
 **Backtest** `fynance.backtest` — vectorized engine (`backtest`: positions +
-returns/prices + cost → `BacktestResult`) and cost models (`ProportionalCost`
-and the non-linear `MarketImpactCost`).
+returns/prices + cost → `BacktestResult`), cost models (`ProportionalCost`, the
+non-linear `MarketImpactCost`, per-bar `HoldingCost` and `CompositeCost` stacking)
+and capacity analysis (`capacity_curve`, `breakeven_fee`).
 
-**Plot** `fynance.plot` — composable matplotlib figures and a one-call
-`tearsheet` report.
+**Plot** `fynance.plot` — composable matplotlib figures and one-call `tearsheet`
+and `factor_tearsheet` reports.
 
-**Models** `fynance.models` — econometric models (MA, ARMA, ARMA-GARCH) and
-PyTorch nets (MLP, RNN, GRU, LSTM, MultiHeadAttention, TCN, Transformer), a
-direction+magnitude stacking ensemble, `RegimeMoE` (regime-conditioned
-mixture-of-experts), differentiable losses (Sharpe, Sortino, Calmar, Omega,
-directional, hybrid), and robust-training utilities.
+**Models** `fynance.models` — econometric models (MA, ARMA, ARMA-GARCH, plus
+GJR/EGARCH kernels) and PyTorch nets (MLP, RNN, GRU, LSTM, MultiHeadAttention,
+TCN, Transformer), a direction+magnitude stacking ensemble, `RegimeMoE`
+(regime-conditioned mixture-of-experts), objective-aligned training with
+cross-asset pretraining, distributional `QuantileModel`, uncertainty wrappers
+(`DeepEnsemble`, `MCDropout`), causal conformal intervals, purged walk-forward
+hyperparameter search, differentiable losses (Sharpe, Sortino, Calmar, Omega,
+directional, hybrid, pinball), and robust-training utilities.
+
+**Estimator** `fynance.estimator` — volatility-model MLE: `fit_volatility` fits
+GARCH / GJR-GARCH / EGARCH with Gaussian or Student-t innovations, returning a
+`VolatilityResult` (AIC/BIC, conditional vol, forecast, simulate).
 
 **Strategy** `fynance.strategy` — optional orchestrator composing the maillons
 end-to-end, with single-run and walk-forward evaluation.
 
 **Research** `fynance.research` — data-agnostic experiment harness: `Experiment`
 (serializable run record), `run_experiment` (seeded, cost-aware, walk-forward),
-`write_report` (portable markdown + tearsheet PNG + notebook) and synthetic data
-generators (`gbm`, `regime_switching`). Results are written only to a
-caller-provided `output_dir` — fynance never stores them itself.
+`write_report` (portable markdown + tearsheet PNG + notebook), synthetic data
+generators (`gbm`, `regime_switching`) and overfitting guards (permutation and
+block bootstrap, deflated Sharpe, PBO/CSCV, walk-forward MDA feature importance).
+Results are written only to a caller-provided `output_dir` — fynance never stores
+them itself.
 
 ## Quick start
 

--- a/doc/dev/04-subpackages.md
+++ b/doc/dev/04-subpackages.md
@@ -21,32 +21,52 @@ modernisation).
 ## Public API surface (what callers import)
 
 - **`core`** — `PriceSeries`; the protocols (`DataSource`/`FeatureTransform`/
-  `SignalModel`/`Allocator`/`CostModel`/`Metric`).
+  `SignalModel`/`Allocator`/`CostModel`/`Metric`); executable checks
+  (`check_conforms`/`assert_causal`) and duck-typed `from_pandas`/`to_pandas`/
+  `to_polars` seams.
 - **`data`** — `load()`, `CSVSource`/`ParquetSource`, `align`/`resample`,
-  `train_test_split`/`walk_forward`.
+  `train_test_split`/`walk_forward`/`combinatorial_purged_cv`, and intraday
+  session utilities (`session_mask`/`session_id`/`session_bounds`/
+  `split_sessions`).
 - **`features`** — momentums (EMA/SMA/WMA…), indicators (RSI/MACD/Bollinger/…),
-  `filters`, `scale`, `engineering`, `regime`, `money_management`. Numba `@njit`
-  kernels live in the `.py` modules (no `_cy` twins).
+  `filters`, `scale`, `engineering` (+ `fracdiff`), `regime`, `money_management`,
+  `horizon` (`horizon_returns`); **`cross_section`** (`cs_rank`/`cs_zscore`/
+  `cs_neutralize`…), pairwise **`roll_functions`** (`roll_cov`/`roll_corr`/
+  `roll_beta`/`cross_corr`), **`labels`** (`triple_barrier`/`meta_labels`/
+  uniqueness weights). Numba `@njit` kernels live in the `.py` modules (no `_cy`
+  twins).
 - **`metrics`** — `sharpe`, `sortino`, `calmar`, `diversified_ratio`,
   `annual_return`/`annual_volatility`, `drawdown`/`mdd`, `perf_*`, `roll_*`
-  variants, plus one-call `summary`.
+  variants, one-call `summary`; **`risk`** (VaR/CVaR/CDaR, `tail_dependence`),
+  **`benchmark`** (alpha/beta/TE/IR/capture), **`factor`** (quantile returns,
+  rolling IC, IC decay), turnover/exposure and **`trades`** analytics.
 - **`signal` / `portfolio`** — `sign`/`threshold`/`rank`/vol-target mappers +
   anti-churn `ema_smooth`/`deadband`/`min_hold` + `SignalPipeline`; allocation
-  (`ERC`/`HRP`/`IVP`/`MDP`/`MVP`, `rolling_allocation()`) and sizing
-  (`kelly_fraction`/`vol_target`/`transaction_cost`).
-- **`models`** — econometric (`ARMA`/`GARCH` family via `get_parameters`) and
-  neural (`MultiLayerPerceptron`, `RollMultiLayerPerceptron`, RNN/`GRU`/`LSTM`,
-  attention, `TemporalConvNet`, `Transformer`), `StackingEnsemble`; custom losses
-  under `models/loss/` (Sharpe/Sortino/Calmar/Omega/directional/hybrid);
-  `ObjectiveModel` (objective-aligned training — net-of-cost, mini-batch) in
-  `models/objective.py`; training utils in `models/training.py`.
+  (`ERC`/`HRP`/`IVP`/`MDP`/`MVP`/**`RBP`**, `rolling_allocation()`, opt-in `cov=`
+  over **`covariance`** estimators), risk **`attribution`**, **`constraints`**
+  (`project_weights`), **`rebalance`** policies, and sizing
+  (`kelly_fraction`/`vol_target`/**`book_vol_target`**/`transaction_cost`).
+- **`models` / `estimator`** — econometric (`ARMA`/`GARCH` family via
+  `get_parameters`, + GJR/EGARCH kernels) and neural (`MultiLayerPerceptron`,
+  `RollMultiLayerPerceptron`, RNN/`GRU`/`LSTM`, attention, `TemporalConvNet`,
+  `Transformer`), `StackingEnsemble`; losses under `models/loss/`
+  (Sharpe/Sortino/Calmar/Omega/directional/hybrid/**pinball**); `ObjectiveModel`
+  (objective-aligned training — net-of-cost, mini-batch, + cross-asset
+  `pretrain_pooled`/save-load); **`QuantileModel`**, uncertainty wrappers
+  (**`DeepEnsemble`**/**`MCDropout`**), causal **`conformal`** intervals, purged
+  **`tuning`** (`walk_forward_search`); training utils in `models/training.py`;
+  **`estimator.fit_volatility`** (GARCH/GJR/EGARCH MLE → `VolatilityResult`).
 - **`backtest` / `plot` / `strategy`** — `backtest()` + `BacktestResult` +
-  `ProportionalCost`; `tearsheet`/`tearsheet_text`; `Strategy` +
-  `run_walk_forward`. (The legacy live-viz objects `PlotBackTest`/
+  cost models (`ProportionalCost`/`MarketImpactCost`/**`HoldingCost`**/
+  **`CompositeCost`**) + **capacity** (`capacity_curve`/`breakeven_fee`);
+  `tearsheet`/`tearsheet_text`/**`factor_tearsheet`**/**`plot_exposure`**;
+  `Strategy` + `run_walk_forward`. (The legacy live-viz objects `PlotBackTest`/
   `DynaPlotBackTest`/`display_perf` remain as lazy submodules, off the eager
   surface.)
 - **`research`** (namespaced as `fynance.research.*`, not flattened) — `Experiment`,
-  `run_experiment`, `write_report`, `gbm`/`regime_switching`. Driven by the
+  `run_experiment`, `write_report`, `gbm`/`regime_switching`, guards
+  (`permutation_test`/`deflated_sharpe_ratio`), **`bootstrap`** (block/stationary),
+  **`overfit`** (PBO/CSCV) and **`importance`** (walk-forward MDA). Driven by the
   user-level `/run-strategy` skill. Artifacts go only to a caller-provided
   `output_dir`.
 

--- a/doc/source/features.engineering.rst
+++ b/doc/source/features.engineering.rst
@@ -2,7 +2,7 @@
 Feature engineering
 *******************
 
-Feature-engineering and selection research tools: multi-resolution feature stacking (:func:`~fynance.features.engineering.multi_resolution`), regime-adaptive windows (:func:`~fynance.features.engineering.adaptive_roll` / :func:`~fynance.features.engineering.adaptive_volatility`), a Granger-causality test (:func:`~fynance.features.engineering.granger_causality`) and incremental moments (:func:`~fynance.features.engineering.IncrementalMoments`).
+Feature-engineering and selection research tools: multi-resolution feature stacking (:func:`~fynance.features.engineering.multi_resolution`), regime-adaptive windows (:func:`~fynance.features.engineering.adaptive_roll` / :func:`~fynance.features.engineering.adaptive_volatility`), fixed-width fractional differentiation (:func:`~fynance.features.engineering.fracdiff`), a Granger-causality test (:func:`~fynance.features.engineering.granger_causality`) and incremental moments (:func:`~fynance.features.engineering.IncrementalMoments`).
 
 .. currentmodule:: fynance.features.engineering
 
@@ -12,5 +12,6 @@ Feature-engineering and selection research tools: multi-resolution feature stack
    multi_resolution
    adaptive_roll
    adaptive_volatility
+   fracdiff
    granger_causality
    IncrementalMoments

--- a/doc/source/features.horizon.rst
+++ b/doc/source/features.horizon.rst
@@ -1,0 +1,12 @@
+****************
+Horizon returns
+****************
+
+Forward-return labels over a fixed horizon: :func:`~fynance.features.horizon.horizon_returns` builds the non-overlapping ``h``-bar forward return of a price/level series — the supervised target consumed by the factor-evaluation metrics (:mod:`fynance.metrics.factor`) and by objective-aligned training.
+
+.. currentmodule:: fynance.features.horizon
+
+.. autosummary::
+   :toctree: generated/
+
+   horizon_returns

--- a/doc/source/features.rst
+++ b/doc/source/features.rst
@@ -116,6 +116,7 @@ Common parameters across modules:
    features.cross_section
    features.engineering
    features.filters
+   features.horizon
    features.indicators
    features.labels
    features.ohlcv

--- a/doc/source/plot.rst
+++ b/doc/source/plot.rst
@@ -17,6 +17,9 @@ performance report. Each plot returns an ``Axes``/``Figure`` and never calls
    plot_drawdown
    plot_returns_hist
    plot_rolling_sharpe
+   plot_contribution
+   plot_turnover
+   plot_cost_decomposition
    plot_exposure
 
 Factor tear-sheet

--- a/doc/source/portfolio.sizing.rst
+++ b/doc/source/portfolio.sizing.rst
@@ -2,7 +2,7 @@
 Position sizing
 ***************
 
-Position sizing and transaction-cost primitives for realistic backtests: fractional Kelly (:func:`~fynance.portfolio.sizing.kelly_fraction`), volatility targeting (:func:`~fynance.portfolio.sizing.vol_target`) and turnover-based transaction costs (:func:`~fynance.portfolio.sizing.transaction_cost`).
+Position sizing and transaction-cost primitives for realistic backtests: fractional Kelly (:func:`~fynance.portfolio.sizing.kelly_fraction`), volatility targeting for a single series (:func:`~fynance.portfolio.sizing.vol_target`) or a whole ``(T, N)`` book (:func:`~fynance.portfolio.sizing.book_vol_target`) and turnover-based transaction costs (:func:`~fynance.portfolio.sizing.transaction_cost`).
 
 .. currentmodule:: fynance.portfolio.sizing
 
@@ -11,4 +11,5 @@ Position sizing and transaction-cost primitives for realistic backtests: fractio
 
    kelly_fraction
    vol_target
+   book_vol_target
    transaction_cost

--- a/fynance/models/uncertainty.py
+++ b/fynance/models/uncertainty.py
@@ -202,8 +202,6 @@ class MCDropout:
     Ghahramani, 2016, "Dropout as a Bayesian Approximation"). The spread across
     those passes — :meth:`predict_std` — is the epistemic-uncertainty proxy.
 
-    Technique
-    ---------
     A plain ``model.eval()`` freezes dropout too (no stochasticity left to
     sample from). :meth:`predict` / :meth:`predict_std` instead first put the
     *whole* model in eval mode (so batch-norm and similar layers behave as at


### PR DESCRIPTION
## What
Closes the documentation drift left after the 2026-07 backlog (PRs #235–#268) shipped ~30 new modules.

**Sphinx API coverage gaps fixed** (found by auditing each subpackage's `__all__` against `doc/source/*.rst`):
- `portfolio.sizing.rst` → `book_vol_target`
- `features.engineering.rst` → `fracdiff`
- new `features.horizon.rst` (+ toctree) → `horizon_returns` (had no page at all)
- `plot.rst` → `plot_contribution`, `plot_turnover`, `plot_cost_decomposition` (pre-existing gaps)

**README + `doc/dev/04-subpackages.md`** subpackage maps refreshed to mention the new bricks (covariance/attribution/constraints/rebalance, cross-section/pairwise-roll/fracdiff/labels, tail-risk/benchmark/factor/trade metrics, CPCV/sessions, tuning/quantile/uncertainty/conformal, GARCH driver, holding-cost/capacity, research guards) + the `estimator` subpackage.

**Docstring fix**: `MCDropout` used a non-standard `Technique` numpydoc section (emitted a UserWarning, and a naive rename would collide with its real `Notes`) — folded into the extended summary.

## Verification
`sphinx-build -W --keep-going` succeeds with **zero warnings** (the MCDropout numpydoc warning is gone); `ruff`/`pytest` on the touched module pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)