### PR TITLE
chore: release v2.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+### Deprecated
+
+### Removed
+
+## [2.13.1] - 2026-07-06
+
+### Fixed
+
 - **Post-review corrections** (5 issues from the v2.13.0 adversarial review, all
   bounded to degenerate/rare inputs, each with a regression test):
   `combinatorial_purged_cv` now stacks the embargo *beyond* the post-test purge
@@ -26,10 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   same-class same-key collision by model index (no component silently
   overwritten, sum invariant preserved); `ConformalWrapper` rejects a
   non-positive `window` with a clear `ValueError` at construction.
-
-### Deprecated
-
-### Removed
 
 ## [2.13.0] - 2026-07-06
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fynance"
-version = "2.13.0"
+version = "2.13.1"
 description = "Pure-Python (Numba-accelerated) machine learning, econometrics and statistical tools for financial analysis and backtesting"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## [2.13.1] - 2026-07-06

### Fixed

- **Post-review corrections** (5 issues from the v2.13.0 adversarial review, all
  bounded to degenerate/rare inputs, each with a regression test):
  `combinatorial_purged_cv` now stacks the embargo *beyond* the post-test purge
  (`e+purge : e+purge+embargo`) instead of overlapping it, so no future-adjacent
  bar leaks back into train when both `purge>0` and `embargo>0`; `MDP` clamps
  `low_bound` to `1/N` like the sibling allocators (an infeasible box no longer
  silently yields weights summing to more than one); `book_vol_target` guards a
  book wipeout (one-bar book return <= -1) so leverage goes to zero with no NaN
  or `RuntimeWarning`; `CompositeCost.components` disambiguates a third
  same-class same-key collision by model index (no component silently
  overwritten, sum invariant preserved); `ConformalWrapper` rejects a
  non-positive `window` with a clear `ValueError` at construction.

## Test plan
- [x] Full suite green on develop (1659 tests) — this bundles PR #272 (the 5 post-review fixes, one regression test each)
- [ ] CI green on this PR
