### PR TITLE
Release v2.13.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,9 +38,9 @@ todo/
 done/
 TODO.md
 
-# Developer docs: descriptive pack + roadmap are tracked (mirrors dccd);
-# only the plan trees and archived snapshots stay local
-doc/dev/plans/*/
+# Developer docs: descriptive pack, roadmap and plan trees are tracked
+# (mirrors dccd — the plan PR lands the tree before code so leaf branches
+# inherit it); only archived snapshots stay local
 doc/dev/_archive/
 
 # Local output of examples/research_workflow.py (results live in a downstream repo)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+### Deprecated
+
+### Removed
+
+## [2.13.1] - 2026-07-06
+
+### Fixed
+
 - **Post-review corrections** (5 issues from the v2.13.0 adversarial review, all
   bounded to degenerate/rare inputs, each with a regression test):
   `combinatorial_purged_cv` now stacks the embargo *beyond* the post-test purge
@@ -26,10 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   same-class same-key collision by model index (no component silently
   overwritten, sum invariant preserved); `ConformalWrapper` rejects a
   non-positive `window` with a clear `ValueError` at construction.
-
-### Deprecated
-
-### Removed
 
 ## [2.13.0] - 2026-07-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Post-review corrections** (5 issues from the v2.13.0 adversarial review, all
+  bounded to degenerate/rare inputs, each with a regression test):
+  `combinatorial_purged_cv` now stacks the embargo *beyond* the post-test purge
+  (`e+purge : e+purge+embargo`) instead of overlapping it, so no future-adjacent
+  bar leaks back into train when both `purge>0` and `embargo>0`; `MDP` clamps
+  `low_bound` to `1/N` like the sibling allocators (an infeasible box no longer
+  silently yields weights summing to more than one); `book_vol_target` guards a
+  book wipeout (one-bar book return <= -1) so leverage goes to zero with no NaN
+  or `RuntimeWarning`; `CompositeCost.components` disambiguates a third
+  same-class same-key collision by model index (no component silently
+  overwritten, sum invariant preserved); `ConformalWrapper` rejects a
+  non-positive `window` with a clear `ValueError` at construction.
+
 ### Deprecated
 
 ### Removed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Common conventions
 
+<!-- mirror of ~/.claude/CLAUDE.md — synced 2026-07-04 -->
+
 Shared across my repos, mirrored from `~/.claude/CLAUDE.md` (the single source of
 truth — if they ever disagree, the global file wins). Restated here so the repo
 stays self-contained:
@@ -21,8 +23,9 @@ stays self-contained:
   `Co-Authored-By` trailers** (personal repo).
 - **One PR = one concern**, small and disposable — a big plan ships as several small
   atomic PRs, never one catch-all branch.
-- **Model: `opus`, always** — interactive sessions and every spawned subagent; a plan
-  leaf's `complexity` is effort/ordering only and never downgrades the model.
+- **Model: the session model, always** — interactive sessions and every spawned
+  subagent inherit it (set in `~/.claude/settings.json`); a plan leaf's
+  `complexity` is effort/ordering only and never selects or downgrades the model.
 - **Before every commit** — `pytest` and `ruff check fynance/` must pass.
 
 ## Commands
@@ -61,7 +64,7 @@ sources of truth:
 | Doc | Holds | Updated by |
 |-----|-------|-----------|
 | `doc/dev/07-roadmap.md` | open work — single source *index* (**tracked**, mirrors dccd) | `/pick-task` reads · `/finish-task`, `/abandon-task` update |
-| `doc/dev/plans/<epic>/` | open work *detail* — durable plan trees (**local/gitignored**; the format `README.md` is tracked) | `/plan` writes · `/execute-leaf` reads · `/finish-task` archives |
+| `doc/dev/plans/<epic>/` | open work *detail* — durable plan trees (**tracked**, mirrors dccd; the plan PR lands them before code) | `/plan` writes · `/execute-leaf` reads · `/finish-task` archives |
 | `doc/dev/03-decisions.md` | the *why* — ADR journal (+ settled rationale) | `/finish-task` (accepted), `/abandon-task` (rejected/tombstone) |
 | `doc/dev/06-status.md` | where things stand | `/finish-task`, `/groom-docs` |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,9 +23,11 @@ stays self-contained:
   `Co-Authored-By` trailers** (personal repo).
 - **One PR = one concern**, small and disposable — a big plan ships as several small
   atomic PRs, never one catch-all branch.
-- **Model: the session model, always** — interactive sessions and every spawned
-  subagent inherit it (set in `~/.claude/settings.json`); a plan leaf's
-  `complexity` is effort/ordering only and never selects or downgrades the model.
+- **Model: session model for judgement, tiered execution** — sessions,
+  orchestration and the judgement skills run on the session model (set in
+  `~/.claude/settings.json`); plan-leaf execution runs at the tier derived from
+  the leaf's `complexity` (`low→haiku / medium→sonnet / high→session model`),
+  escalating one tier on failed tests/verification.
 - **Before every commit** — `pytest` and `ruff check fynance/` must pass.
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -53,49 +53,72 @@ is usable standalone; `fynance.strategy.Strategy` is an *optional* orchestrator.
 
 **Core** `fynance.core` — `PriceSeries` value object (thin, numpy-backed) and the
 pipeline protocols (`DataSource`, `FeatureTransform`, `SignalModel`, `Allocator`,
-`CostModel`, `Metric`).
+`CostModel`, `Metric`); executable conformance/causality checks (`check_conforms`,
+`assert_causal`) and duck-typed pandas/polars seams (`from_pandas`/`to_pandas`).
 
 **Data** `fynance.data` — file adapters (`load` for CSV/Parquet → `PriceSeries`),
-alignment/resampling, and no-lookahead temporal splits (`train_test_split`,
-`walk_forward`).
+alignment/resampling, no-lookahead temporal splits (`train_test_split`,
+`walk_forward`, combinatorial-purged `combinatorial_purged_cv`) and vendor-agnostic
+intraday session utilities (`session_mask`/`session_id`/`split_sessions`).
 
 **Features** `fynance.features` — technical indicators (Bollinger, RSI, MACD, ROC,
 realized volatility, rolling skew/kurtosis/autocorr, …), OHLCV indicators (ATR,
 ADX, Williams %R, OBV, VWAP), a causal GARCH(1,1) conditional-volatility feature,
-momentums (SMA, EMA, WMA) and adaptive windows, scaling (incl. rolling rank),
-statistics, feature engineering (multi-resolution, Granger causality) and
-market-regime detection.
+momentums (SMA, EMA, WMA) and adaptive windows, **NaN-aware cross-sectional
+operators** (`cs_rank`/`cs_zscore`/`cs_neutralize`, …), **pairwise rolling stats**
+(`roll_corr`/`roll_beta`, `cross_corr`), **fractional differentiation** (`fracdiff`),
+**AFML labeling** (`triple_barrier`, `meta_labels`, uniqueness weights), scaling
+(incl. rolling rank), statistics, feature engineering (multi-resolution, Granger
+causality) and market-regime detection.
 
 **Metrics** `fynance.metrics` — performance/evaluation metrics (Sharpe, Sortino,
-Calmar, drawdown, …) and a one-call `summary`.
+Calmar, drawdown, …) and a one-call `summary`; **tail risk** (VaR/CVaR/CDaR,
+tail dependence), **benchmark-relative** metrics (alpha, beta, tracking error,
+information ratio, capture), **factor evaluation** (quantile returns, rolling IC,
+IC decay), and turnover/exposure and per-trade analytics.
 
 **Signal** `fynance.signal` — prediction → position mappers (`sign`, `threshold`,
 `rank`, vol-targeting) and a model+mapper pipeline.
 
-**Portfolio** `fynance.portfolio` — allocation (ERC, HRP, IVP, MDP, MVP) and
-sizing (fractional Kelly, volatility targeting, transaction costs).
+**Portfolio** `fynance.portfolio` — allocation (ERC, HRP, IVP, MDP, MVP, plus
+risk-budgeting `RBP`) with an opt-in `cov=` seam over conditioned **covariance
+estimators** (Ledoit-Wolf, EWMA, factor, Marchenko-Pastur denoising); risk
+**attribution**, an exposure-**constraints** overlay (`project_weights`),
+**rebalancing policies** (calendar/band/turnover-cap, lot discretization) and
+sizing (fractional Kelly, single-series and book-level volatility targeting,
+transaction costs).
 
 **Backtest** `fynance.backtest` — vectorized engine (`backtest`: positions +
-returns/prices + cost → `BacktestResult`) and cost models (`ProportionalCost`
-and the non-linear `MarketImpactCost`).
+returns/prices + cost → `BacktestResult`), cost models (`ProportionalCost`, the
+non-linear `MarketImpactCost`, per-bar `HoldingCost` and `CompositeCost` stacking)
+and capacity analysis (`capacity_curve`, `breakeven_fee`).
 
-**Plot** `fynance.plot` — composable matplotlib figures and a one-call
-`tearsheet` report.
+**Plot** `fynance.plot` — composable matplotlib figures and one-call `tearsheet`
+and `factor_tearsheet` reports.
 
-**Models** `fynance.models` — econometric models (MA, ARMA, ARMA-GARCH) and
-PyTorch nets (MLP, RNN, GRU, LSTM, MultiHeadAttention, TCN, Transformer), a
-direction+magnitude stacking ensemble, `RegimeMoE` (regime-conditioned
-mixture-of-experts), differentiable losses (Sharpe, Sortino, Calmar, Omega,
-directional, hybrid), and robust-training utilities.
+**Models** `fynance.models` — econometric models (MA, ARMA, ARMA-GARCH, plus
+GJR/EGARCH kernels) and PyTorch nets (MLP, RNN, GRU, LSTM, MultiHeadAttention,
+TCN, Transformer), a direction+magnitude stacking ensemble, `RegimeMoE`
+(regime-conditioned mixture-of-experts), objective-aligned training with
+cross-asset pretraining, distributional `QuantileModel`, uncertainty wrappers
+(`DeepEnsemble`, `MCDropout`), causal conformal intervals, purged walk-forward
+hyperparameter search, differentiable losses (Sharpe, Sortino, Calmar, Omega,
+directional, hybrid, pinball), and robust-training utilities.
+
+**Estimator** `fynance.estimator` — volatility-model MLE: `fit_volatility` fits
+GARCH / GJR-GARCH / EGARCH with Gaussian or Student-t innovations, returning a
+`VolatilityResult` (AIC/BIC, conditional vol, forecast, simulate).
 
 **Strategy** `fynance.strategy` — optional orchestrator composing the maillons
 end-to-end, with single-run and walk-forward evaluation.
 
 **Research** `fynance.research` — data-agnostic experiment harness: `Experiment`
 (serializable run record), `run_experiment` (seeded, cost-aware, walk-forward),
-`write_report` (portable markdown + tearsheet PNG + notebook) and synthetic data
-generators (`gbm`, `regime_switching`). Results are written only to a
-caller-provided `output_dir` — fynance never stores them itself.
+`write_report` (portable markdown + tearsheet PNG + notebook), synthetic data
+generators (`gbm`, `regime_switching`) and overfitting guards (permutation and
+block bootstrap, deflated Sharpe, PBO/CSCV, walk-forward MDA feature importance).
+Results are written only to a caller-provided `output_dir` — fynance never stores
+them itself.
 
 ## Quick start
 

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -72,6 +72,26 @@ Template:
 
 <!-- new entries below, newest first -->
 
+### 2026-07-06 — Post-release adversarial review + corrections (PR #272)  [accepted]
+
+- **Choice**: after shipping the 2026-07 backlog (PRs #235-#268, released as
+  v2.13.0), ran a 9-subsystem adversarial code review (opus reviewers + a
+  refute-biased verifier per finding). Fixed the 5 confirmed findings in one
+  batch with a regression test each: CPCV embargo now stacks beyond the purge
+  (de Prado semantics); MDP clamps `low_bound` to `1/N` (allocation-API
+  consistency); `book_vol_target` gets the book-wipeout guard its sibling
+  `rebalance._drift_step` already had; `CompositeCost.components` disambiguates
+  a third same-class same-key collision by index; `ConformalWrapper` validates
+  `window > 0`.
+- **Why**: all five are the "green suite isn't enough" class the CI gates
+  cannot catch (silently-wrong numbers / a causality leak on degenerate or
+  rare inputs). None was critical/high and 4 of 9 subsystems came back clean,
+  but the CPCV embargo gap is a real train/test leak worth fixing before the
+  splitter is used in anger.
+- **Rejected alternatives**: leaving them as documented sharp edges (a
+  causality leak in a CV splitter is not an acceptable sharp edge); five
+  separate PRs (they are one coherent, low-risk correction pass).
+
 ### 2026-07-06 — DX one-offs epic (PRs #267–#268, epic)  [accepted]
 
 - **Choice**: two developer-experience bricks — `core.checks`

--- a/doc/dev/04-subpackages.md
+++ b/doc/dev/04-subpackages.md
@@ -21,32 +21,52 @@ modernisation).
 ## Public API surface (what callers import)
 
 - **`core`** — `PriceSeries`; the protocols (`DataSource`/`FeatureTransform`/
-  `SignalModel`/`Allocator`/`CostModel`/`Metric`).
+  `SignalModel`/`Allocator`/`CostModel`/`Metric`); executable checks
+  (`check_conforms`/`assert_causal`) and duck-typed `from_pandas`/`to_pandas`/
+  `to_polars` seams.
 - **`data`** — `load()`, `CSVSource`/`ParquetSource`, `align`/`resample`,
-  `train_test_split`/`walk_forward`.
+  `train_test_split`/`walk_forward`/`combinatorial_purged_cv`, and intraday
+  session utilities (`session_mask`/`session_id`/`session_bounds`/
+  `split_sessions`).
 - **`features`** — momentums (EMA/SMA/WMA…), indicators (RSI/MACD/Bollinger/…),
-  `filters`, `scale`, `engineering`, `regime`, `money_management`. Numba `@njit`
-  kernels live in the `.py` modules (no `_cy` twins).
+  `filters`, `scale`, `engineering` (+ `fracdiff`), `regime`, `money_management`,
+  `horizon` (`horizon_returns`); **`cross_section`** (`cs_rank`/`cs_zscore`/
+  `cs_neutralize`…), pairwise **`roll_functions`** (`roll_cov`/`roll_corr`/
+  `roll_beta`/`cross_corr`), **`labels`** (`triple_barrier`/`meta_labels`/
+  uniqueness weights). Numba `@njit` kernels live in the `.py` modules (no `_cy`
+  twins).
 - **`metrics`** — `sharpe`, `sortino`, `calmar`, `diversified_ratio`,
   `annual_return`/`annual_volatility`, `drawdown`/`mdd`, `perf_*`, `roll_*`
-  variants, plus one-call `summary`.
+  variants, one-call `summary`; **`risk`** (VaR/CVaR/CDaR, `tail_dependence`),
+  **`benchmark`** (alpha/beta/TE/IR/capture), **`factor`** (quantile returns,
+  rolling IC, IC decay), turnover/exposure and **`trades`** analytics.
 - **`signal` / `portfolio`** — `sign`/`threshold`/`rank`/vol-target mappers +
   anti-churn `ema_smooth`/`deadband`/`min_hold` + `SignalPipeline`; allocation
-  (`ERC`/`HRP`/`IVP`/`MDP`/`MVP`, `rolling_allocation()`) and sizing
-  (`kelly_fraction`/`vol_target`/`transaction_cost`).
-- **`models`** — econometric (`ARMA`/`GARCH` family via `get_parameters`) and
-  neural (`MultiLayerPerceptron`, `RollMultiLayerPerceptron`, RNN/`GRU`/`LSTM`,
-  attention, `TemporalConvNet`, `Transformer`), `StackingEnsemble`; custom losses
-  under `models/loss/` (Sharpe/Sortino/Calmar/Omega/directional/hybrid);
-  `ObjectiveModel` (objective-aligned training — net-of-cost, mini-batch) in
-  `models/objective.py`; training utils in `models/training.py`.
+  (`ERC`/`HRP`/`IVP`/`MDP`/`MVP`/**`RBP`**, `rolling_allocation()`, opt-in `cov=`
+  over **`covariance`** estimators), risk **`attribution`**, **`constraints`**
+  (`project_weights`), **`rebalance`** policies, and sizing
+  (`kelly_fraction`/`vol_target`/**`book_vol_target`**/`transaction_cost`).
+- **`models` / `estimator`** — econometric (`ARMA`/`GARCH` family via
+  `get_parameters`, + GJR/EGARCH kernels) and neural (`MultiLayerPerceptron`,
+  `RollMultiLayerPerceptron`, RNN/`GRU`/`LSTM`, attention, `TemporalConvNet`,
+  `Transformer`), `StackingEnsemble`; losses under `models/loss/`
+  (Sharpe/Sortino/Calmar/Omega/directional/hybrid/**pinball**); `ObjectiveModel`
+  (objective-aligned training — net-of-cost, mini-batch, + cross-asset
+  `pretrain_pooled`/save-load); **`QuantileModel`**, uncertainty wrappers
+  (**`DeepEnsemble`**/**`MCDropout`**), causal **`conformal`** intervals, purged
+  **`tuning`** (`walk_forward_search`); training utils in `models/training.py`;
+  **`estimator.fit_volatility`** (GARCH/GJR/EGARCH MLE → `VolatilityResult`).
 - **`backtest` / `plot` / `strategy`** — `backtest()` + `BacktestResult` +
-  `ProportionalCost`; `tearsheet`/`tearsheet_text`; `Strategy` +
-  `run_walk_forward`. (The legacy live-viz objects `PlotBackTest`/
+  cost models (`ProportionalCost`/`MarketImpactCost`/**`HoldingCost`**/
+  **`CompositeCost`**) + **capacity** (`capacity_curve`/`breakeven_fee`);
+  `tearsheet`/`tearsheet_text`/**`factor_tearsheet`**/**`plot_exposure`**;
+  `Strategy` + `run_walk_forward`. (The legacy live-viz objects `PlotBackTest`/
   `DynaPlotBackTest`/`display_perf` remain as lazy submodules, off the eager
   surface.)
 - **`research`** (namespaced as `fynance.research.*`, not flattened) — `Experiment`,
-  `run_experiment`, `write_report`, `gbm`/`regime_switching`. Driven by the
+  `run_experiment`, `write_report`, `gbm`/`regime_switching`, guards
+  (`permutation_test`/`deflated_sharpe_ratio`), **`bootstrap`** (block/stationary),
+  **`overfit`** (PBO/CSCV) and **`importance`** (walk-forward MDA). Driven by the
   user-level `/run-strategy` skill. Artifacts go only to a caller-provided
   `output_dir`.
 

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -53,14 +53,27 @@ cross-section sur un univers ETF, données via dccd) est **bloquée** par deux
 hypothèses crypto câblées dans le harnais. Code de librairie data-agnostique —
 c'est bien ici que ça vit, la campagne elle-même reste dans le repo privé.
 
-- [ ] **Calendrier de sessions.** Le walk-forward et les features supposent une
-  grille continue 24/7 ; les marchés actions ont des sessions, jours fériés,
-  demi-séances, timezones — et le gap overnight n'est pas un rendement intraday
-  comme un autre. Il faut un calendrier de marché injectable (sessions valides,
-  agrégation intra-session, coupure train/test sur frontières de séance) sans
-  régresser le chemin crypto 24/7 par défaut.
-- [ ] **Modèle de coûts actions.** Remplacer (par configuration, pas par fork) le
-  couple taker-fee + funding-perp par : commission par ordre, **coût d'emprunt du
-  short** (borrow, variable — l'équivalent économique du funding mais asymétrique)
-  et intérêt de marge sur le levier. Sans ça, aucun backtest actions n'est honnête
-  — même exigence que le 0.26 %/side côté crypto.
+> **MàJ 2026-07-06 (v2.13.0) — primitives livrées, reste le câblage.** L'épic
+> `backtest-realism` a livré les briques data-agnostiques de ces deux items ;
+> ce qui reste est leur intégration dans le chemin walk-forward.
+
+- [ ] **Calendrier de sessions.** _Primitives livrées_ : `fynance.data.sessions`
+  (`session_mask`/`session_id`/`session_bounds`/`split_sessions`) tague et
+  découpe les sessions sur des timestamps epoch. _Reste_ : les câbler dans
+  `walk_forward` (coupure train/test sur frontières de séance), l'agrégation
+  intra-session, et traiter le **gap overnight** comme un rendement à part (pas
+  un pas intraday) — sans régresser le chemin crypto 24/7 par défaut. NB : DST
+  est hors scope de `data.sessions` (offset fixe) — à trancher ici.
+- [ ] **Modèle de coûts actions.** _Primitives livrées_ : `HoldingCost`
+  (commission implicite via `ProportionalCost`, **borrow** du short, financement
+  du levier, crédit de cash) + `CompositeCost` pour empiler. _Reste_ : le
+  brancher par **configuration** (pas par fork) sur le chemin de recherche
+  actions, en remplacement du couple taker-fee + funding-perp crypto.
+- [ ] **Coût du turnover implicite d'un book qui drift.** Remonté par les agents
+  pendant l'épic `backtest-realism` : le coût turnover du moteur `backtest()`
+  **sous-compte** le trading réel d'un book dont les poids dérivent avec les
+  rendements entre deux rebalancements — il mesure `Σ|E_t − E_{t-1}|` (equity)
+  au lieu du trade effectif `Σ|w_t − drift(w_{t-1}, r_t)|`. Les briques
+  `portfolio.rebalance` produisent déjà le book effectif correct ; il reste à
+  faire refléter ce coût dans les KPIs du moteur (petit chantier moteur isolé,
+  API `backtest()` stable à préserver).

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -45,3 +45,22 @@ Le harnais `fynance.research` est **livré** (S1–S3) : `Experiment`,
 
 - [ ] Explorateur **Streamlit** au-dessus du Ledger (parcourir / filtrer / comparer
   les runs persistés) — interactif, plus tardif.
+
+## 3. Multi-actifs non-crypto — calendrier & coûts (prérequis d'honnêteté)
+
+Déposé 2026-07-04 par fynance-research : sa prochaine campagne (book trend /
+cross-section sur un univers ETF, données via dccd) est **bloquée** par deux
+hypothèses crypto câblées dans le harnais. Code de librairie data-agnostique —
+c'est bien ici que ça vit, la campagne elle-même reste dans le repo privé.
+
+- [ ] **Calendrier de sessions.** Le walk-forward et les features supposent une
+  grille continue 24/7 ; les marchés actions ont des sessions, jours fériés,
+  demi-séances, timezones — et le gap overnight n'est pas un rendement intraday
+  comme un autre. Il faut un calendrier de marché injectable (sessions valides,
+  agrégation intra-session, coupure train/test sur frontières de séance) sans
+  régresser le chemin crypto 24/7 par défaut.
+- [ ] **Modèle de coûts actions.** Remplacer (par configuration, pas par fork) le
+  couple taker-fee + funding-perp par : commission par ordre, **coût d'emprunt du
+  short** (borrow, variable — l'équivalent économique du funding mais asymétrique)
+  et intérêt de marge sur le levier. Sans ça, aucun backtest actions n'est honnête
+  — même exigence que le 0.26 %/side côté crypto.

--- a/doc/dev/plans/v2-refactor/00-plan.md
+++ b/doc/dev/plans/v2-refactor/00-plan.md
@@ -1,0 +1,99 @@
+---
+plan: v2-refactor
+kind: global
+status: planning
+roadmap: "fynance 2.0 — full refactor into a layered ML/DL backtesting tool (data→features→signal→portfolio→backtest→metrics)"
+release_on_done: true
+---
+
+# fynance 2.0 — global plan
+
+A clean, breaking **2.0** that turns the current *toolbox* into a *complete tool*
+for backtesting ML/DL trading strategies — from data ingestion to performance
+reporting, through signal prediction and portfolio construction — **while staying
+modular** (composable units, never a forced pipeline).
+
+## Vision
+
+```
+data → features → signal (ML/DL prediction → position) → portfolio (alloc + sizing)
+     → backtest (vectorized) → metrics / reporting
+```
+
+Each maillon is an independent, reusable unit with a clear contract. An optional
+`Strategy` orchestrator composes them; it is never mandatory.
+
+## Architecture decisions (settled in brainstorm)
+
+1. **Layered + Protocols, ports&adapters only at I/O.** Not full hexagonal. The
+   domain is maths on arrays; we use `typing.Protocol` seams for internal
+   composition (`FeatureTransform`, `SignalModel`, `Allocator`, `CostModel`,
+   `Metric`) and ports&adapters **only** where the outside world is touched
+   (`DataSource` now; `Broker`/execution later).
+2. **numpy is the lingua franca** at every seam. **pytorch is confined to
+   `models/`** (entered at `set_data`, exited at `predict` → numpy); used only
+   where autodiff (differentiable Sharpe/Sortino/… losses) or GPU pays.
+   **numba `@njit`** for hot CPU loops (estimator, rolling).
+3. **Composition over a god-object.** `PriceSeries` is a *thin* numpy-backed
+   value object (compose, **never subclass** `np.ndarray`): a handful of core
+   price↔return conversions + `.pipe()` delegating to free functions. The rich
+   transforms stay free functions in `features/`.
+4. **No backward-compat.** Drop legacy shims, drop Cython (→ numba), drop the
+   `*_cy` duality. This is a 2.0; breaking is expected.
+5. **UI last, optional.** A thin Streamlit playground (`fynance[ui]`, `apps/`)
+   built on a clean `tearsheet()` API — not a bespoke IDE. The notebook is the
+   reference workflow.
+
+## Target layout
+
+```
+fynance/
+  core/       PriceSeries value object · Protocols · numpy/torch bridges
+  data/       DataSource port · CSV/Parquet adapters · align/resample · temporal splits
+  features/   transforms + indicators (perf-metrics removed)
+  metrics/    performance metrics (moved out of features)
+  models/     pytorch models · numba estimator (ex-Cython)
+  signal/     prediction → position mappers
+  portfolio/  allocation + sizing (ex-algorithms)
+  backtest/   vectorized engine: positions + prices + costs → BacktestResult
+  plot/       reporting · tearsheet()
+  strategy/   optional orchestrator composing the protocols
+apps/         streamlit playground (optional extra)
+```
+
+## Epics & dependency order
+
+| Epic | Scope | Depends on |
+|------|-------|-----------|
+| **E1 core** | `PriceSeries`, Protocols, array bridges | — (foundation) |
+| **E2 data** | DataSource port, CSV/Parquet adapters, align, splits | E1 |
+| **E3 features+metrics** | regroup features, extract perf-metrics → `metrics/` | E1 |
+| **E4 backtest** | CostModel + vectorized engine → `BacktestResult` | E1 |
+| **E5 reporting** | `metrics/` consolidation, `plot/`, `tearsheet()` | E3, E4 |
+| **E6 signal+portfolio** | `signal/` mappers, `portfolio/` (ex-algorithms) | E1 |
+| **E7 models+numba** | estimator → numba, drop Cython, SignalModel conformance | E1 |
+| **E8 strategy** | optional orchestrator + walk-forward run | E2,E3,E4,E6,E7 |
+| **E9 ui** | Streamlit playground (optional) | E5, E8 |
+| **E10 docs** | Sphinx restructure, example notebook, README/migration | all |
+
+Critical path: **E1 → (E2 ∥ E3 ∥ E6 ∥ E7) → E4 → E5 → E8 → (E9 ∥ E10)**.
+
+## Execution protocol
+
+- Each leaf ships as **one small disposable PR** into `develop` (CLAUDE.md: one
+  PR = one concern). Order respects `deps:`.
+- Every leaf must keep the 4 CI gates green (tests 3.10–3.13, ruff+interrogate,
+  Sphinx `-W`, mypy) and respect **no-lookahead** (property tests).
+- Because 2.0 breaks the public API, land the breaking moves early and update
+  docs per-epic; the final `metrics`/layout doc overhaul is E10.
+- Release the whole tree as **v2.0.0** once E1–E8 are in (E9/E10 may trail into
+  2.0.x / 2.1).
+
+## Open decision points (flagged in leaves)
+
+- **D1** `features/*_cy` (momentums/metrics Cython): migrate to numba in 2.0, or
+  keep frozen? Leaning migrate (consistency, no compile step). → E7.
+- **D2** `PriceSeries` vs a multi-column `Panel` for OHLCV: ship `PriceSeries`
+  (mono) first; `Panel` deferred (enables ATR/ADX/OBV/VWAP later). → E1/E2.
+- **D3** Backtest costs: proportional only in 2.0; non-linear slippage deferred.
+- **D4** `Strategy` API style: fluent builder vs declarative config. → E8 leaf 01.

--- a/doc/dev/plans/v2-refactor/E1-core/00-plan.md
+++ b/doc/dev/plans/v2-refactor/E1-core/00-plan.md
@@ -1,0 +1,29 @@
+---
+plan: v2-refactor/E1-core
+kind: global
+status: done
+roadmap: "E1 core — PriceSeries value object, Protocol seams, numpy/torch bridges"
+release_on_done: false
+---
+
+# E1 — core: the spine
+
+Foundation for everything. Introduces `fynance/core/` with the central value
+object (`PriceSeries`), the `typing.Protocol` seams the whole library composes
+through, and the numpy/torch bridges.
+
+**Design invariants (apply to every leaf):**
+- numpy-backed, immutable-ish value object; **compose, never subclass `ndarray`**.
+- pytorch never stored — only produced on demand via `.to_torch()`.
+- Thin object: ~5 core methods + `.pipe`; richness lives in free functions.
+
+## Leaves
+
+| # | Leaf | Complexity | Deps |
+|---|------|-----------|------|
+| 01 | `PriceSeries` container (values+index+meta) | medium | — |
+| 02 | finance core methods (returns/prices/pnl) | medium | 01 |
+| 03 | array bridges + `.pipe()` accessor | low | 01 |
+| 04 | Protocol seams module | medium | — |
+
+Order: 01 → {02, 03}; 04 independent (can run first/parallel).

--- a/doc/dev/plans/v2-refactor/E1-core/01-priceseries.md
+++ b/doc/dev/plans/v2-refactor/E1-core/01-priceseries.md
@@ -1,0 +1,40 @@
+---
+plan: v2-refactor/E1-core
+kind: leaf
+status: done
+complexity: medium
+deps: []
+parallel: false
+---
+
+# E1.01 — `PriceSeries` value object
+
+Create `fynance/core/price_series.py` defining `PriceSeries`: a **thin, numpy-backed**
+container holding a 1-D financial series with its temporal index and metadata.
+
+## Design
+- Fields: `values: np.ndarray` (1-D, float64 default), `index: np.ndarray`
+  (datetime64 or int positions), `name: str | None`, `freq: str | None`.
+- **Composition, not subclassing.** Internally store a contiguous numpy array.
+- Construction: `PriceSeries(values, index=None, name=None, freq=None)`; if
+  `index` is None, default to a 0..n-1 RangeIndex (int64). Validate lengths match.
+- Immutable feel: store a copy / set `values.flags.writeable = False`; mutating
+  ops return a **new** `PriceSeries`.
+- Dunders: `__len__`, `__getitem__` (int → scalar; slice → new `PriceSeries`
+  carrying the sliced index), `__repr__` (head/tail + dtype + freq), `__eq__`
+  by value+index, `__array__` (so `np.asarray(ps)` works → numpy interop).
+- Constructors: `from_numpy`, `from_polars` (a `pl.Series`/`pl.DataFrame` column,
+  picking up a datetime index column if present).
+
+## Files
+- new `fynance/core/price_series.py`
+- `fynance/core/__init__.py` — export `PriceSeries`
+- new `fynance/tests/core/test_price_series.py`
+
+## Test
+- round-trip `from_numpy`/`np.asarray` identity; slicing keeps index aligned;
+  immutability (writeable False; ops return new); `from_polars` picks datetime
+  index; `__len__`/`__getitem__`/`__repr__` doctests.
+
+## Done when
+- `PriceSeries` importable from `fynance.core`; tests + doctests green; mypy clean.

--- a/doc/dev/plans/v2-refactor/E1-core/02-finance-methods.md
+++ b/doc/dev/plans/v2-refactor/E1-core/02-finance-methods.md
@@ -1,0 +1,36 @@
+---
+plan: v2-refactor/E1-core
+kind: leaf
+status: done
+complexity: medium
+deps: [1]
+parallel: false
+---
+
+# E1.02 — finance core methods on `PriceSeries`
+
+Add the **few fundamental** price↔return identities as methods. Everything else
+stays a free function reachable via `.pipe` (E1.03). Resist scope creep here.
+
+## Methods (numpy under the hood, return `PriceSeries` unless noted)
+- `to_returns(kind="pct" | "log" | "raw")` — pct: `p_t/p_{t-1}-1`; log:
+  `ln(p_t/p_{t-1})`; raw: `p_t-p_{t-1}`. First element NaN or dropped (param
+  `dropna=True`). **Causal**: no future leak.
+- `to_prices(base=1.0, kind="pct"|"log")` — inverse: cumulate returns → price path.
+- `cumulative()` — `(1+r).cumprod()` style equity from a return series.
+- `pnl(positions)` — element-wise `position_{t-1} * return_t` (positions **shifted**
+  one step → strictly causal); returns a `PriceSeries` of strategy returns.
+- `drop_na()` / `fillna(method)` minimal helpers.
+
+## Files
+- extend `fynance/core/price_series.py`
+- extend `fynance/tests/core/test_price_series.py`
+
+## Test
+- `to_returns(log)` then `to_prices(log)` round-trips to original (atol 1e-12);
+  pct/log/raw numerically correct on a tiny hand series; `pnl` uses shifted
+  positions (assert no-lookahead: a position known only at t cannot affect r_t);
+  doctests on each method.
+
+## Done when
+- methods green incl. round-trip + causality assertions; mypy clean.

--- a/doc/dev/plans/v2-refactor/E1-core/03-bridges-pipe.md
+++ b/doc/dev/plans/v2-refactor/E1-core/03-bridges-pipe.md
@@ -1,0 +1,32 @@
+---
+plan: v2-refactor/E1-core
+kind: leaf
+status: done
+complexity: low
+deps: [1]
+parallel: true
+---
+
+# E1.03 — array bridges + `.pipe()` accessor
+
+Make `PriceSeries` interoperate cleanly and reach the free-function toolbox
+without becoming a god-object.
+
+## API
+- `.to_numpy(copy=True) -> np.ndarray`
+- `.to_torch(dtype=torch.float32, device=None) -> torch.Tensor` (lazy torch import)
+- `.pipe(fn, *args, **kwargs)` — calls `fn(self.values, *args, **kwargs)`; if the
+  result is array-like of same length, wrap back into a `PriceSeries` (same index),
+  else return raw. This is the delegation pattern: `ps.pipe(rsi, window=14)`.
+- optional `.apply(fn)` element-wise convenience.
+
+## Files
+- extend `fynance/core/price_series.py`
+- extend `fynance/tests/core/test_price_series.py`
+
+## Test
+- `to_torch` dtype/shape; torch import is lazy (no hard import at module load);
+  `.pipe` wraps length-preserving results, passes through scalars; index carried.
+
+## Done when
+- bridges + pipe green; importing `fynance.core` does not import torch eagerly.

--- a/doc/dev/plans/v2-refactor/E1-core/04-protocols.md
+++ b/doc/dev/plans/v2-refactor/E1-core/04-protocols.md
@@ -1,0 +1,35 @@
+---
+plan: v2-refactor/E1-core
+kind: leaf
+status: done
+complexity: medium
+deps: []
+parallel: true
+---
+
+# E1.04 — Protocol seams
+
+Define the composition contracts in `fynance/core/protocols.py` using
+`typing.Protocol` (+ `@runtime_checkable`). These are **structural** — no forced
+inheritance; existing/new objects conform by shape.
+
+## Protocols (signatures, all numpy-typed)
+- `DataSource` — `load(...) -> PriceSeries` (the only **port**; adapters in E2).
+- `FeatureTransform` — `fit(X) -> Self`, `transform(X) -> NDArray`; causal.
+- `SignalModel` — `fit(X, y) -> Self`, `predict(X) -> NDArray`.
+- `Allocator` — `__call__(returns_or_cov) -> NDArray` (weights).
+- `CostModel` — `__call__(weights) -> NDArray` (per-step cost); impl in E4.
+- `Metric` — `__call__(returns) -> float`.
+
+## Files
+- new `fynance/core/protocols.py`
+- export from `fynance/core/__init__.py`
+- new `fynance/tests/core/test_protocols.py`
+
+## Test
+- `runtime_checkable` isinstance smoke tests with tiny conforming/​non-conforming
+  dummies; mypy treats a conforming object as the Protocol (a typing assertion).
+
+## Done when
+- protocols importable; runtime_checkable smoke tests green; documented in
+  docstrings (each protocol states shapes + causality contract).

--- a/doc/dev/plans/v2-refactor/E10-docs/00-plan.md
+++ b/doc/dev/plans/v2-refactor/E10-docs/00-plan.md
@@ -1,0 +1,23 @@
+---
+plan: v2-refactor/E10-docs
+kind: global
+status: done
+roadmap: "E10 docs — Sphinx restructure, end-to-end notebook, README 2.0 + migration guide"
+release_on_done: true
+---
+
+# E10 — docs, examples, migration (closes 2.0)
+
+Bring all documentation in line with the new layout and tell users how to move
+from 1.x. Cross-cutting; lands near the end. Last leaf removes the v2-refactor
+roadmap line and triggers `/release` → v2.0.0.
+
+## Leaves
+
+| # | Leaf | Complexity | Deps |
+|---|------|-----------|------|
+| 01 | Sphinx restructure for new layout | medium | — |
+| 02 | end-to-end example notebook | low | — |
+| 03 | README 2.0 + migration guide + CHANGELOG | medium | 01,02 |
+
+Depends on all feature epics being in.

--- a/doc/dev/plans/v2-refactor/E10-docs/01-sphinx-restructure.md
+++ b/doc/dev/plans/v2-refactor/E10-docs/01-sphinx-restructure.md
@@ -1,0 +1,26 @@
+---
+plan: v2-refactor/E10-docs
+kind: leaf
+status: done
+complexity: medium
+deps: []
+parallel: false
+---
+
+# E10.01 — Sphinx restructure for the new layout
+
+Rebuild `doc/source/` to mirror the 2.0 package tree: `core`, `data`, `features`,
+`metrics`, `models`, `signal`, `portfolio`, `backtest`, `plot`, `strategy`.
+
+## Scope
+- new subpackage `.rst` (card grid + hidden toctree) + module `.rst`
+  (`currentmodule` + `autosummary :toctree: generated/`) for every new package.
+- drop pages for removed modules (algorithms, backtest plotting, `*_cy`).
+- regenerate committed autosummary stubs; keep `sphinx-build -W` clean.
+
+## Files
+- `doc/source/*.rst`, `doc/source/generated/*`.
+
+## Test / Done when
+- `cd doc && make html` (and `-W`) clean; every public symbol documented; CI docs
+  gate green.

--- a/doc/dev/plans/v2-refactor/E10-docs/02-example-notebook.md
+++ b/doc/dev/plans/v2-refactor/E10-docs/02-example-notebook.md
@@ -1,0 +1,21 @@
+---
+plan: v2-refactor/E10-docs
+kind: leaf
+status: done
+complexity: low
+deps: []
+parallel: true
+---
+
+# E10.02 — end-to-end example notebook
+
+`Notebooks/quickstart_v2.ipynb` — the reference workflow: load CSV → build features
+→ train a model (or write a signal fn) → backtest → `tearsheet`. Doubles as the
+"notebook does the job" answer and the template the Streamlit app seeds.
+
+## Files
+- new `Notebooks/quickstart_v2.ipynb`; remove stale 1.x notebooks.
+
+## Test / Done when
+- every cell runs top-to-bottom (verify by executing the concatenated cell code);
+  produces a tearsheet figure; uses only public 2.0 API.

--- a/doc/dev/plans/v2-refactor/E10-docs/03-readme-migration.md
+++ b/doc/dev/plans/v2-refactor/E10-docs/03-readme-migration.md
@@ -1,0 +1,28 @@
+---
+plan: v2-refactor/E10-docs
+kind: leaf
+status: done
+complexity: medium
+deps: [1, 2]
+parallel: false
+---
+
+# E10.03 — README 2.0 + migration guide + CHANGELOG
+
+Finalize user-facing docs for the breaking release.
+
+## Scope
+- rewrite `README.md` around the new pipeline + quickstart snippet (load → signal →
+  backtest → tearsheet); update the subpackage table to the 2.0 layout.
+- new `doc/MIGRATION-2.0.md`: import-path map (`algorithms`→`portfolio`,
+  features-metrics→`metrics`, removed `*_cy`, dropped Cython build), behavioural
+  breaks, the "no compat shims" note.
+- `CHANGELOG.md`: a `### Breaking Changes` section enumerating the moves; this
+  drives the **major** bump in `/release`.
+
+## Files
+- `README.md`, `doc/MIGRATION-2.0.md`, `CHANGELOG.md`.
+
+## Test / Done when
+- README snippet runs; migration map complete; CHANGELOG breaking section ready;
+  this leaf removes the v2-refactor roadmap line → `/release` cuts **v2.0.0**.

--- a/doc/dev/plans/v2-refactor/E2-data/00-plan.md
+++ b/doc/dev/plans/v2-refactor/E2-data/00-plan.md
@@ -1,0 +1,25 @@
+---
+plan: v2-refactor/E2-data
+kind: global
+status: done
+roadmap: "E2 data — DataSource port, CSV/Parquet adapters, alignment, temporal splits"
+release_on_done: false
+---
+
+# E2 — data: the missing ingestion maillon
+
+The biggest gap vs the vision. A ports&adapters layer that turns local files into
+`PriceSeries`, aligns/resamples them, and produces **no-lookahead** temporal
+splits for ML evaluation. Polars is the read engine; numpy/`PriceSeries` the output.
+
+## Leaves
+
+| # | Leaf | Complexity | Deps |
+|---|------|-----------|------|
+| 01 | DataSource base + registry | low | — |
+| 02 | CSV adapter | medium | 01 |
+| 03 | Parquet adapter | low | 01,02 |
+| 04 | align / resample | medium | 02 |
+| 05 | temporal splits (train/test + walk-forward) | medium | 02 |
+
+Order: 01 → 02 → {03, 04, 05}. Depends on E1 (PriceSeries).

--- a/doc/dev/plans/v2-refactor/E2-data/01-datasource-base.md
+++ b/doc/dev/plans/v2-refactor/E2-data/01-datasource-base.md
@@ -1,0 +1,28 @@
+---
+plan: v2-refactor/E2-data
+kind: leaf
+status: done
+complexity: low
+deps: []
+parallel: false
+---
+
+# E2.01 — DataSource base + registry
+
+Concretize the `DataSource` port (E1.04) with a small base + a name→adapter
+registry so callers do `load("data.csv")` without importing adapters directly.
+
+## API
+- `BaseDataSource` (ABC implementing the `DataSource` Protocol) with `load(...)`.
+- `register(name)` decorator + `get_source(name)` / `load(path, source="auto", **kw)`
+  dispatcher that auto-selects by file extension (`.csv`→csv, `.parquet`→parquet).
+
+## Files
+- new `fynance/data/__init__.py`, `fynance/data/base.py`
+- new `fynance/tests/data/test_registry.py`
+
+## Test
+- registry dispatch by extension; unknown extension → clear `ValueError`.
+
+## Done when
+- `from fynance.data import load` works; registry tests green.

--- a/doc/dev/plans/v2-refactor/E2-data/02-csv-adapter.md
+++ b/doc/dev/plans/v2-refactor/E2-data/02-csv-adapter.md
@@ -1,0 +1,31 @@
+---
+plan: v2-refactor/E2-data
+kind: leaf
+status: done
+complexity: medium
+deps: [1]
+parallel: false
+---
+
+# E2.02 — CSV adapter
+
+`fynance/data/csv.py` — read a CSV via polars into `PriceSeries` (mono-column) or
+a dict/Panel-lite of `PriceSeries` (multi-column).
+
+## API
+- `CSVSource.load(path, *, value_col=None, index_col=None, freq=None) -> PriceSeries`
+  — picks the value column (single non-index numeric col if `value_col` None),
+  parses `index_col` as datetime (or infers a datetime col), passes `freq`.
+- Multi-column: `value_col=None` + several numerics → return `dict[str, PriceSeries]`.
+- Robust to: missing header, separator inference (polars), tz-naive datetimes.
+
+## Files
+- new `fynance/data/csv.py`; register as `"csv"`
+- new fixtures in `fynance/tests/data/` (tiny csv) + `test_csv.py`
+
+## Test
+- load a 5-row csv → correct values, datetime index, name; multi-col → dict;
+  numeric dtype is float64; round-trip values match the raw file.
+
+## Done when
+- `load("x.csv")` returns a `PriceSeries`; tests + doctest green.

--- a/doc/dev/plans/v2-refactor/E2-data/03-parquet-adapter.md
+++ b/doc/dev/plans/v2-refactor/E2-data/03-parquet-adapter.md
@@ -1,0 +1,25 @@
+---
+plan: v2-refactor/E2-data
+kind: leaf
+status: done
+complexity: low
+deps: [1, 2]
+parallel: true
+---
+
+# E2.03 — Parquet adapter
+
+`fynance/data/parquet.py` — same contract as CSV via `pl.read_parquet`. Share the
+column-selection / datetime-index logic with the CSV adapter (extract a helper in
+`data/base.py` if it isn't already).
+
+## Files
+- new `fynance/data/parquet.py`; register `"parquet"`
+- `fynance/tests/data/test_parquet.py` (+ tiny parquet fixture written in-test)
+
+## Test
+- write a small DataFrame to parquet in a tmp_path, load it back → matches the
+  CSV adapter's behaviour on the same data.
+
+## Done when
+- `load("x.parquet")` returns a `PriceSeries`; tests green.

--- a/doc/dev/plans/v2-refactor/E2-data/04-align-resample.md
+++ b/doc/dev/plans/v2-refactor/E2-data/04-align-resample.md
@@ -1,0 +1,30 @@
+---
+plan: v2-refactor/E2-data
+kind: leaf
+status: done
+complexity: medium
+deps: [2]
+parallel: true
+---
+
+# E2.04 — alignment & resampling
+
+`fynance/data/align.py` — multi-asset alignment and frequency resampling, all
+**causal** (no forward leakage on downsample; explicit fill policy).
+
+## API
+- `align(series: dict[str, PriceSeries], *, how="outer"|"inner", fill="ffill"|None)`
+  → aligned `dict` (common index) — ffill only uses past values.
+- `resample(ps: PriceSeries, freq, agg="last"|"mean"|"ohlc")` — downsample via
+  polars group_by_dynamic; last/mean for a value series.
+
+## Files
+- new `fynance/data/align.py`
+- new `fynance/tests/data/test_align.py`
+
+## Test
+- outer align fills gaps with past-only ffill (assert no future value used);
+  inner align intersects indices; resample last == period-end value.
+
+## Done when
+- align/resample green incl. a no-lookahead assertion on ffill.

--- a/doc/dev/plans/v2-refactor/E2-data/05-temporal-splits.md
+++ b/doc/dev/plans/v2-refactor/E2-data/05-temporal-splits.md
@@ -1,0 +1,33 @@
+---
+plan: v2-refactor/E2-data
+kind: leaf
+status: done
+complexity: medium
+deps: [2]
+parallel: true
+---
+
+# E2.05 — temporal splits (train/test + walk-forward)
+
+`fynance/data/split.py` — strictly time-ordered splits for ML evaluation. No
+shuffling, ever. Reuses the walk-forward semantics of `_RollingBasis` but as a
+pure, data-side index generator (decoupled from any model).
+
+## API
+- `train_test_split(n, *, test_size, gap=0)` → `(train_idx, test_idx)` arrays,
+  with an optional embargo `gap` between train end and test start.
+- `walk_forward(n, *, train, test, step, purge=0)` → generator of
+  `(train_idx, test_idx)` windows: train `[t-train:t]`, test `[t:t+test]`,
+  optional `purge` removed at the boundary. Mirrors `cross_validate(..., purge=)`.
+
+## Files
+- new `fynance/data/split.py`
+- new `fynance/tests/data/test_split.py`
+
+## Test
+- every test index strictly > its train indices (no leakage); gap/purge create
+  the expected embargo; window count == expected for given n/train/test/step;
+  property test: no index appears in both train and test of the same fold.
+
+## Done when
+- splits green; no-lookahead property holds across all generated folds.

--- a/doc/dev/plans/v2-refactor/E3-features-metrics/00-plan.md
+++ b/doc/dev/plans/v2-refactor/E3-features-metrics/00-plan.md
@@ -1,0 +1,24 @@
+---
+plan: v2-refactor/E3-features-metrics
+kind: global
+status: done
+roadmap: "E3 features+metrics — regroup features, extract performance metrics into a metrics/ package"
+release_on_done: false
+---
+
+# E3 — features reorg + metrics extraction
+
+Fix the brouillage conceptuel: **performance metrics leave `features/`** for a new
+top-level `metrics/` package (evaluation ≠ feature). Features are regrouped into
+clear modules and adopt the `FeatureTransform` protocol (fit/transform wrappers
+over the existing free functions — functions stay composable).
+
+## Leaves
+
+| # | Leaf | Complexity | Deps |
+|---|------|-----------|------|
+| 01 | extract perf-metrics → `fynance/metrics/` | medium | — |
+| 02 | regroup features + `FeatureTransform` adoption | medium | 01 |
+| 03 | causality / parity test sweep | low | 02 |
+
+Order: 01 → 02 → 03. Depends on E1 (PriceSeries optional input).

--- a/doc/dev/plans/v2-refactor/E3-features-metrics/01-extract-metrics.md
+++ b/doc/dev/plans/v2-refactor/E3-features-metrics/01-extract-metrics.md
@@ -1,0 +1,44 @@
+---
+plan: v2-refactor/E3-features-metrics
+kind: leaf
+status: done
+complexity: medium
+deps: []
+parallel: false
+---
+
+# E3.01 — extract performance metrics into `fynance/metrics/`
+
+Move evaluation metrics out of `features/` into a dedicated `fynance/metrics/`.
+This is a **breaking move** (2.0): no re-export shim in `features`.
+
+## What moves
+From `features/{ratios,drawdown,returns,stats,metrics}.py` →
+`metrics/`: `sharpe`, `sortino`, `calmar`, `roll_sharpe`, `mdd`/`drawdown`,
+`annual_return`, `annual_volatility`, `perf_strat`, `returns_strat`,
+`percent_positive`, `tail_ratio`, etc. (full list = current `features.metrics.__all__`).
+
+What **stays** in features: indicators, momentums, scale/normalization,
+engineering, regime, filters, roll_functions, raw `returns`/`prices` transforms
+used as *features* (keep a thin `features.returns` for the transform sense if
+needed, distinct from the perf metric).
+
+## Layout
+- `fynance/metrics/__init__.py` (+ submodules `ratios.py`, `drawdown.py`,
+  `summary.py`); each function conforms to the `Metric` protocol where it takes a
+  return series → float.
+- delete the moved code from `features/`; update `features/__init__.py` `__all__`.
+- update all internal imports (backtest, models, tests).
+
+## Files
+- new `fynance/metrics/*`; edited `fynance/features/*`; moved tests →
+  `fynance/tests/metrics/`.
+
+## Test
+- numeric parity with pre-move values on a fixed series (golden values);
+  `from fynance.metrics import sharpe, mdd, ...` works; `features` no longer
+  exposes them (assert ImportError/AttributeError).
+
+## Done when
+- metrics live in `fynance/metrics`; full suite green; doc autosummary updated
+  (deferred detail to E10 but keep `-W` Sphinx green now).

--- a/doc/dev/plans/v2-refactor/E3-features-metrics/02-feature-transform.md
+++ b/doc/dev/plans/v2-refactor/E3-features-metrics/02-feature-transform.md
@@ -1,0 +1,38 @@
+---
+plan: v2-refactor/E3-features-metrics
+kind: leaf
+status: done
+complexity: medium
+deps: [1]
+parallel: false
+---
+
+# E3.02 — regroup features + `FeatureTransform` adoption
+
+Reorganize `features/` into coherent groups and offer a thin class layer
+conforming to `FeatureTransform` (E1.04) **wrapping** the existing free functions
+— functions remain the primary, composable API.
+
+## Grouping (rename/merge, no behaviour change)
+- `transforms.py` — returns/prices/diff/scale/roll z-score (the transform sense).
+- `indicators.py` — EMA/MACD/RSI/Bollinger/CCI/HMA/roc/realized_vol/skew/kurt/autocorr.
+- `stats.py` — descriptive stats helpers (non-perf).
+- `engineering.py`, `regime.py`, `filters.py` — keep.
+
+## FeatureTransform layer
+- a small `make_transform(fn, **fixed)` factory + a few first-class classes
+  (`ZScore`, `RSI`, …) exposing `fit(X)->self`, `transform(X)->ndarray`, all
+  **stateless or fit-on-train-only** (causal). `fit` records only past-derivable
+  params (e.g. mean/std on the train slice) — never peeks at transform input future.
+
+## Files
+- reorganized `fynance/features/*`; new `features/_transform_base.py`
+- updated tests under `fynance/tests/features/`
+
+## Test
+- each `FeatureTransform.transform` == its free-function counterpart (parity);
+  `isinstance(t, FeatureTransform)` (runtime_checkable); fit-on-train then
+  transform-on-test uses **no** test-set statistics (no-lookahead assertion).
+
+## Done when
+- regrouped imports stable; transform classes parity-green; mypy clean.

--- a/doc/dev/plans/v2-refactor/E3-features-metrics/03-causality-sweep.md
+++ b/doc/dev/plans/v2-refactor/E3-features-metrics/03-causality-sweep.md
@@ -1,0 +1,27 @@
+---
+plan: v2-refactor/E3-features-metrics
+kind: leaf
+status: done
+complexity: low
+deps: [2]
+parallel: false
+---
+
+# E3.03 — causality / parity test sweep
+
+Carry over and extend the property-test battery so the reorg preserves the two
+invariants: **free-fn ↔ transform-class parity** and **no-lookahead** across all
+features/metrics.
+
+## Coverage
+- property test (hypothesis or fixed grids): for every rolling feature, value at
+  index t depends only on X[:t+1]; perturbing X[t+1:] leaves output[:t+1] unchanged.
+- parity: every `FeatureTransform` == free function; every relocated metric ==
+  golden pre-move value.
+
+## Files
+- `fynance/tests/features/test_property.py` (extend), `tests/metrics/test_*`.
+
+## Test / Done when
+- the sweep is green and explicitly covers each public feature + metric;
+  CI 4 gates green; this leaf removes the E3 roadmap line.

--- a/doc/dev/plans/v2-refactor/E4-backtest/00-plan.md
+++ b/doc/dev/plans/v2-refactor/E4-backtest/00-plan.md
@@ -1,0 +1,23 @@
+---
+plan: v2-refactor/E4-backtest
+kind: global
+status: done
+roadmap: "E4 backtest — vectorized engine: positions + prices + costs → BacktestResult"
+release_on_done: false
+---
+
+# E4 — backtest: the missing engine
+
+Build the real artery: a **vectorized** engine that turns positions/signal +
+prices + a cost model into a `BacktestResult` (equity, returns, turnover,
+exposure). Strictly causal (positions shifted). Plotting is **out** (E5).
+
+## Leaves
+
+| # | Leaf | Complexity | Deps |
+|---|------|-----------|------|
+| 01 | CostModel + proportional cost | low | — |
+| 02 | vectorized engine | high | 01 |
+| 03 | `BacktestResult` object | medium | 02 |
+
+Order: 01 → 02 → 03. Depends on E1; consumes E3 metrics in 03.

--- a/doc/dev/plans/v2-refactor/E4-backtest/01-cost-model.md
+++ b/doc/dev/plans/v2-refactor/E4-backtest/01-cost-model.md
@@ -1,0 +1,28 @@
+---
+plan: v2-refactor/E4-backtest
+kind: leaf
+status: done
+complexity: low
+deps: []
+parallel: false
+---
+
+# E4.01 — CostModel + proportional cost
+
+`fynance/backtest/cost.py` — concretize the `CostModel` protocol (E1.04).
+
+## API
+- `ProportionalCost(fee=0.0, slippage=0.0)`; `__call__(weights) -> NDArray` returns
+  per-step cost = `(fee+slippage) * turnover`, turnover = `|w_t - w_{t-1}|` summed
+  over assets (reuse the turnover logic from `algorithms/sizing.transaction_cost`).
+- D3: non-linear slippage deferred — leave a documented extension point.
+
+## Files
+- new `fynance/backtest/cost.py`; new `fynance/tests/backtest/test_cost.py`
+
+## Test
+- zero fee → zero cost; constant weights → zero turnover cost; known turnover →
+  known cost; parity with the existing `transaction_cost`.
+
+## Done when
+- `ProportionalCost` conforms to `CostModel`; tests green.

--- a/doc/dev/plans/v2-refactor/E4-backtest/02-engine.md
+++ b/doc/dev/plans/v2-refactor/E4-backtest/02-engine.md
@@ -1,0 +1,38 @@
+---
+plan: v2-refactor/E4-backtest
+kind: leaf
+status: done
+complexity: high
+deps: [1]
+parallel: false
+---
+
+# E4.02 — vectorized backtest engine
+
+`fynance/backtest/engine.py` — the core function. Pure numpy, vectorized.
+
+## API
+- `backtest(prices_or_returns, positions, *, cost=None, rebalance="step",
+  capital=1.0, returns_input=False) -> BacktestResult`
+  - infer returns from prices (pct) unless `returns_input`.
+  - **causal**: position at t applies to return at t+1 (shift positions by 1);
+    assert positions cannot use future returns.
+  - gross strat returns = `pos_shifted * asset_returns` (sum over assets if 2-D).
+  - net returns = gross − `cost(weights)` per step.
+  - equity = `capital * cumprod(1 + net)`.
+- single-asset (1-D) and multi-asset (2-D, weights) both supported.
+
+## Files
+- new `fynance/backtest/engine.py`
+- new `fynance/tests/backtest/test_engine.py`
+
+## Test
+- buy-and-hold (pos=1) equity == price path normalized (atol 1e-12);
+- zero position → flat equity == capital;
+- **no-lookahead**: shuffling returns *after* the last position date doesn't change
+  equity up to that date; a position known at t cannot capture r_t;
+- costs reduce net returns by exactly the turnover cost;
+- 2-D weights case matches manual computation on a tiny example.
+
+## Done when
+- engine green incl. causality + cost assertions; numpy-only; mypy clean.

--- a/doc/dev/plans/v2-refactor/E4-backtest/03-backtest-result.md
+++ b/doc/dev/plans/v2-refactor/E4-backtest/03-backtest-result.md
@@ -1,0 +1,33 @@
+---
+plan: v2-refactor/E4-backtest
+kind: leaf
+status: done
+complexity: medium
+deps: [2]
+parallel: false
+---
+
+# E4.03 — `BacktestResult` object
+
+`fynance/backtest/result.py` — the engine's output value object, the hand-off to
+metrics & reporting.
+
+## Design
+- dataclass: `equity`, `returns` (net), `gross_returns`, `positions`, `costs`,
+  `index` (carried from input `PriceSeries` if given).
+- methods: `.to_numpy()`, `.to_price_series()` (equity as `PriceSeries`),
+  `.summary()` → dict of metrics computed via `fynance.metrics` (sharpe, sortino,
+  calmar, mdd, annual_return/vol, turnover, hit-rate). No plotting here (E5).
+
+## Files
+- new `fynance/backtest/result.py`; update `backtest/__init__.py` (drop the old
+  plot-centric `__all__`; plotting moves to `plot/` in E5).
+- new `fynance/tests/backtest/test_result.py`
+
+## Test
+- `.summary()` keys present + numerically match direct `fynance.metrics` calls;
+  `.to_price_series()` equity round-trips; dataclass equality.
+
+## Done when
+- `BacktestResult` green; `backtest` package exports engine + result + cost;
+  legacy plot modules slated for E5 move (leave a note, don't break Sphinx).

--- a/doc/dev/plans/v2-refactor/E5-reporting/00-plan.md
+++ b/doc/dev/plans/v2-refactor/E5-reporting/00-plan.md
@@ -1,0 +1,23 @@
+---
+plan: v2-refactor/E5-reporting
+kind: global
+status: done
+roadmap: "E5 reporting — metrics consolidation, plot/ package, one-call tearsheet()"
+release_on_done: false
+---
+
+# E5 — reporting: metrics + plot + tearsheet
+
+The maillon that makes both the notebook workflow and the future UI trivial. A
+clean `tearsheet(result)` is the real product value; the Streamlit UI (E9) is a
+thin shell over it.
+
+## Leaves
+
+| # | Leaf | Complexity | Deps |
+|---|------|-----------|------|
+| 01 | metrics consolidation + `Metric` protocol | medium | — |
+| 02 | `plot/` package (figures) | medium | 01 |
+| 03 | `tearsheet()` one-call report | medium | 01,02 |
+
+Depends on E3 (metrics moved) and E4 (`BacktestResult`).

--- a/doc/dev/plans/v2-refactor/E5-reporting/01-metrics-consolidate.md
+++ b/doc/dev/plans/v2-refactor/E5-reporting/01-metrics-consolidate.md
@@ -1,0 +1,31 @@
+---
+plan: v2-refactor/E5-reporting
+kind: leaf
+status: done
+complexity: medium
+deps: []
+parallel: false
+---
+
+# E5.01 — metrics consolidation + `Metric` protocol
+
+Finish the `fynance/metrics/` package started in E3: ensure a complete, coherent,
+numpy-only metric set, all conforming to the `Metric` protocol, with a registry.
+
+## Scope
+- complete set: sharpe, sortino, calmar, omega, mdd, max_drawdown_duration,
+  annual_return, annual_volatility, downside_vol, var/cvar, hit_rate,
+  percent_positive, tail_ratio, turnover, rolling variants (`roll_sharpe`).
+- a `METRICS` registry + `summary(returns) -> dict` computing the standard panel.
+- consistent signature `metric(returns, *, period=252, **kw) -> float`.
+
+## Files
+- `fynance/metrics/*` (extend), `fynance/metrics/registry.py`
+- `fynance/tests/metrics/test_summary.py`
+
+## Test
+- golden values on a fixed return series; registry round-trip; `summary` keys
+  stable; each metric isinstance `Metric` (runtime_checkable).
+
+## Done when
+- metrics package complete + green; mypy clean.

--- a/doc/dev/plans/v2-refactor/E5-reporting/02-plot-package.md
+++ b/doc/dev/plans/v2-refactor/E5-reporting/02-plot-package.md
@@ -1,0 +1,32 @@
+---
+plan: v2-refactor/E5-reporting
+kind: leaf
+status: done
+complexity: medium
+deps: [1]
+parallel: false
+---
+
+# E5.02 — `plot/` package
+
+Move plotting out of `backtest/` into `fynance/plot/`; modernize into small,
+composable figure functions (matplotlib; return `Figure`/`Axes`, never `plt.show`).
+
+## Scope
+- migrate/rewrite the useful bits of the old `backtest/plot*.py` →
+  `plot/equity.py` (equity + drawdown), `plot/returns.py` (hist/QQ/rolling),
+  `plot/metrics.py` (rolling sharpe/vol). Drop dead `_basis_plot`/dynamic plot
+  unless trivially salvageable.
+- each fn: `fn(result_or_series, *, ax=None) -> Axes`.
+
+## Files
+- new `fynance/plot/*`; delete migrated `backtest/plot*`, `print_stats` (→ metrics
+  `summary` already covers stats text).
+- `fynance/tests/plot/test_smoke.py` (Agg backend, no display).
+
+## Test
+- smoke: each fn returns a matplotlib `Axes`/`Figure` on a tiny `BacktestResult`
+  under the Agg backend; no `plt.show`.
+
+## Done when
+- `plot/` green headless; `backtest/` no longer owns plotting; Sphinx `-W` green.

--- a/doc/dev/plans/v2-refactor/E5-reporting/03-tearsheet.md
+++ b/doc/dev/plans/v2-refactor/E5-reporting/03-tearsheet.md
@@ -1,0 +1,31 @@
+---
+plan: v2-refactor/E5-reporting
+kind: leaf
+status: done
+complexity: medium
+deps: [1, 2]
+parallel: false
+---
+
+# E5.03 — `tearsheet()` one-call report
+
+`fynance/plot/tearsheet.py` — the single entry point that turns a `BacktestResult`
+(or equity `PriceSeries`) into a full report: grid of figures + a metrics table.
+This is the API the notebook and the Streamlit UI both call.
+
+## API
+- `tearsheet(result, *, metrics="standard", figsize=...) -> Figure` — composes
+  equity+drawdown, rolling sharpe, returns dist, and renders `summary()` as a
+  table subplot. Pure matplotlib (works headless, embeds in Streamlit).
+- optional `tearsheet_text(result) -> str` for notebook/CLI quick print.
+
+## Files
+- new `fynance/plot/tearsheet.py`; export from `fynance/plot/__init__.py`
+- `fynance/tests/plot/test_tearsheet.py`
+
+## Test
+- returns a `Figure` with the expected number of axes on a tiny result; the
+  embedded table values equal `metrics.summary(result.returns)`.
+
+## Done when
+- `from fynance.plot import tearsheet` green headless; example used in E10 notebook.

--- a/doc/dev/plans/v2-refactor/E6-signal-portfolio/00-plan.md
+++ b/doc/dev/plans/v2-refactor/E6-signal-portfolio/00-plan.md
@@ -1,0 +1,22 @@
+---
+plan: v2-refactor/E6-signal-portfolio
+kind: global
+status: planning
+roadmap: "E6 signal+portfolio — signal/ mappers and portfolio/ (ex-algorithms) under protocols"
+release_on_done: false
+---
+
+# E6 — signal + portfolio
+
+Two reorgs that complete the maillons between model and backtest. `signal/`
+turns a model prediction into a position; `portfolio/` (renamed from
+`algorithms/`) holds allocation + sizing under the `Allocator` protocol.
+
+## Leaves
+
+| # | Leaf | Complexity | Deps |
+|---|------|-----------|------|
+| 01 | `signal/` mappers | medium | — |
+| 02 | `portfolio/` (rename algorithms) + Allocator | medium | — |
+
+Both depend on E1. Parallel-able.

--- a/doc/dev/plans/v2-refactor/E6-signal-portfolio/01-signal.md
+++ b/doc/dev/plans/v2-refactor/E6-signal-portfolio/01-signal.md
@@ -1,0 +1,31 @@
+---
+plan: v2-refactor/E6-signal-portfolio
+kind: leaf
+status: done
+complexity: medium
+deps: []
+parallel: true
+---
+
+# E6.01 — `signal/` package
+
+New `fynance/signal/` — the bridge prediction → position. Pure numpy, causal.
+
+## API (mappers: prediction array → position array in [-1,1] or weights)
+- `sign(pred)` — long/short by sign.
+- `threshold(pred, *, long=0.0, short=0.0)` — flat band.
+- `rank(pred, *, top, bottom)` — cross-sectional long/short by rank.
+- `vol_target_position(pred, returns, target_vol, ...)` — reuse
+  `portfolio.sizing.vol_target` to scale a directional signal (causal).
+- optional `SignalPipeline` composing a `SignalModel` (E1.04) + a mapper, exposing
+  `predict_position(X)`.
+
+## Files
+- new `fynance/signal/*`; new `fynance/tests/signal/test_signal.py`
+
+## Test
+- sign/threshold/rank correct on tiny arrays; vol-target scaling is causal
+  (no future returns); positions bounded as documented.
+
+## Done when
+- `signal/` green; composes with a dummy `SignalModel`; mypy clean.

--- a/doc/dev/plans/v2-refactor/E6-signal-portfolio/02-portfolio.md
+++ b/doc/dev/plans/v2-refactor/E6-signal-portfolio/02-portfolio.md
@@ -1,0 +1,33 @@
+---
+plan: v2-refactor/E6-signal-portfolio
+kind: leaf
+status: done
+complexity: medium
+deps: []
+parallel: true
+---
+
+# E6.02 — `portfolio/` package (rename `algorithms/`) + Allocator
+
+Rename `fynance/algorithms/` → `fynance/portfolio/` (2.0 breaking) and express
+allocators under the `Allocator` protocol; keep sizing.
+
+## Scope
+- `git mv` allocation.py, sizing.py → `portfolio/`; update package `__init__`,
+  `__all__`, all imports, tests.
+- `Allocator` conformance: `ERC`, `HRP`, `IVP`, `MDP`, `rolling_allocation` expose
+  `__call__(cov_or_returns) -> weights`. Keep numpy-only (already pandas-free).
+- sizing (`kelly_fraction`, `vol_target`, `transaction_cost`) stays; the cost one
+  is also reused by `backtest.cost` (single source — import, don't duplicate).
+
+## Files
+- `fynance/portfolio/*` (moved), updated imports across repo + tests under
+  `fynance/tests/portfolio/`.
+
+## Test
+- allocators isinstance `Allocator`; numeric parity with pre-rename golden values;
+  `from fynance.portfolio import ERC, HRP, kelly_fraction` works; old
+  `fynance.algorithms` import path is gone (assert ImportError).
+
+## Done when
+- portfolio package green; allocation public-API parity (values) preserved.

--- a/doc/dev/plans/v2-refactor/E7-models-numba/00-plan.md
+++ b/doc/dev/plans/v2-refactor/E7-models-numba/00-plan.md
@@ -1,0 +1,24 @@
+---
+plan: v2-refactor/E7-models-numba
+kind: global
+status: planning
+roadmap: "E7 models+numba — estimator Cython→numba, drop Cython build, SignalModel conformance"
+release_on_done: false
+---
+
+# E7 — models + numba migration
+
+Modernize the numerical backend per the 2.0 decision (drop Cython → numba) and
+make the model layer conform to the `SignalModel` protocol. pytorch stays the ML
+backend, confined to this maillon.
+
+## Leaves
+
+| # | Leaf | Complexity | Deps |
+|---|------|-----------|------|
+| 01 | estimator ARMA/GARCH → numba | high | — |
+| 02 | features `*_cy` → numba (D1) | high | 01 |
+| 03 | drop Cython from build | medium | 01,02 |
+| 04 | SignalModel conformance for models | low | — |
+
+Depends on E1. 02 is gated on decision **D1** (confirm migrate vs freeze).

--- a/doc/dev/plans/v2-refactor/E7-models-numba/01-estimator-numba.md
+++ b/doc/dev/plans/v2-refactor/E7-models-numba/01-estimator-numba.md
@@ -1,0 +1,32 @@
+---
+plan: v2-refactor/E7-models-numba
+kind: leaf
+status: done
+complexity: high
+deps: []
+parallel: false
+---
+
+# E7.01 — estimator ARMA/GARCH → numba
+
+Reimplement `fynance/estimator/estimator_cy.pyx` (ARMA/GARCH parameter estimation)
+as pure-python + numba `@njit` in `fynance/estimator/estimator.py`. Authoritative
+logic stays in one place (CLAUDE.md invariant), now numba not Cython.
+
+## Approach
+- port the recursion/likelihood loops to `@njit` functions; keep `get_parameters`
+  public API and the `econometric_models.get_parameters()` wrapper signature.
+- delete `estimator_cy.pyx` / `.c`; remove from setup.py ext list (full removal in 03).
+
+## Files
+- `fynance/estimator/estimator.py` (rewrite), delete `estimator_cy.*`,
+  `models/econometric_models_cy.*` (the wrapper) — update `models/__init__`.
+- `fynance/tests/estimator/test_estimator.py` (extend with golden params).
+
+## Test
+- estimated params match the Cython output on a fixed seeded series within tight
+  atol (golden values captured before deletion); ARMA/GARCH/ARMA_GARCH/ARMAX_GARCH
+  all covered; first-call JIT warm-up acceptable.
+
+## Done when
+- estimator numba-backed, parity-green; no estimator Cython remains.

--- a/doc/dev/plans/v2-refactor/E7-models-numba/02-features-cy-numba.md
+++ b/doc/dev/plans/v2-refactor/E7-models-numba/02-features-cy-numba.md
@@ -1,0 +1,31 @@
+---
+plan: v2-refactor/E7-models-numba
+kind: leaf
+status: done
+complexity: high
+deps: [1]
+parallel: false
+---
+
+# E7.02 — features `*_cy` → numba  (decision D1)
+
+**Gate: confirm D1** (2.0 drops the Cython/Python duality in `features/`). If
+confirmed, migrate the hot loops of `momentums_cy`/`metrics_cy` etc. to numba and
+delete the `.pyx`/`.c` + the dual import in `features/__init__.py`.
+
+## Approach
+- for each `*_cy` function, ensure the pure-python `.py` twin is numba-accelerated
+  (`@njit` on the inner loop), benchmark vs Cython (must be within ~1.5×), then
+  drop the `_cy` variant and its `__init__` import.
+- keep the public function names identical (single implementation now).
+
+## Files
+- `fynance/features/{momentums,metrics,...}.py` (numba), delete `*_cy.pyx/.c`,
+  edit `features/__init__.py`.
+- bench note in the PR; tests already cover correctness (E3.03 sweep).
+
+## Test
+- parity with previous outputs (golden); a micro-benchmark recorded; suite green.
+
+## Done when
+- no `features/*_cy` remains; numba twins are the single source; perf acceptable.

--- a/doc/dev/plans/v2-refactor/E7-models-numba/03-drop-cython-build.md
+++ b/doc/dev/plans/v2-refactor/E7-models-numba/03-drop-cython-build.md
@@ -1,0 +1,29 @@
+---
+plan: v2-refactor/E7-models-numba
+kind: leaf
+status: todo
+complexity: medium
+deps: [1, 2]
+parallel: false
+---
+
+# E7.03 — drop Cython from the build
+
+With no `.pyx` left, simplify the build to pure-python + numba.
+
+## Scope
+- remove the `USE_CYTHON`/ext-modules machinery from `setup.py` (or delete
+  `setup.py` if `pyproject.toml` can fully own the now-pure-python build).
+- drop Cython from build deps in `pyproject.toml`; add `numba` to runtime deps.
+- update CI: no `build_ext` step; update CLAUDE.md "Commands" (no Cython build).
+- update `.github/workflows` and any `build_ext --inplace` references.
+
+## Files
+- `setup.py`, `pyproject.toml`, `.github/workflows/*.yml`, `CLAUDE.md`, docs.
+
+## Test
+- clean `pip install -e ".[dev]"` then `pytest` green with **no** compile step;
+  fresh clone import works without a C toolchain.
+
+## Done when
+- build is pure-python+numba; CI green; docs/commands updated.

--- a/doc/dev/plans/v2-refactor/E7-models-numba/04-signalmodel-conformance.md
+++ b/doc/dev/plans/v2-refactor/E7-models-numba/04-signalmodel-conformance.md
@@ -1,0 +1,29 @@
+---
+plan: v2-refactor/E7-models-numba
+kind: leaf
+status: done
+complexity: low
+deps: []
+parallel: true
+---
+
+# E7.04 — SignalModel conformance for models
+
+Make the pytorch models present a uniform `SignalModel` face (E1.04) so `signal/`
+and `strategy/` compose them without special-casing.
+
+## Scope
+- add/confirm `fit(X, y) -> self` (wrapping the train loop) and `predict(X) ->
+  ndarray` (numpy out) on `BaseNeuralNet` (or a thin adapter) so MLP/RNN/GRU/LSTM/
+  TCN/Transformer/ensemble all conform.
+- keep pytorch internal: numpy in, numpy out at the boundary.
+
+## Files
+- `fynance/models/_base.py` (+ adapter if cleaner); `tests/models/test_protocol.py`.
+
+## Test
+- each model isinstance `SignalModel` (runtime_checkable); `predict` returns numpy;
+  a tiny fit/predict round-trip per architecture.
+
+## Done when
+- all models conform; numpy boundary holds; mypy clean.

--- a/doc/dev/plans/v2-refactor/E8-strategy/00-plan.md
+++ b/doc/dev/plans/v2-refactor/E8-strategy/00-plan.md
@@ -1,0 +1,22 @@
+---
+plan: v2-refactor/E8-strategy
+kind: global
+status: done
+roadmap: "E8 strategy — optional orchestrator composing data→features→signal→portfolio→backtest→metrics"
+release_on_done: false
+---
+
+# E8 — strategy: the optional orchestrator
+
+Compose the protocol-based maillons into one runnable `Strategy` — **optional**,
+never required (the maillons stay usable standalone). Provides the end-to-end and
+walk-forward runs the UI and the example notebook drive.
+
+## Leaves
+
+| # | Leaf | Complexity | Deps |
+|---|------|-----------|------|
+| 01 | `Strategy` object (compose protocols) | high | — |
+| 02 | walk-forward run | medium | 01 |
+
+Depends on E2,E3,E4,E6,E7. Decision **D4** (API style) decided in leaf 01.

--- a/doc/dev/plans/v2-refactor/E8-strategy/01-strategy-object.md
+++ b/doc/dev/plans/v2-refactor/E8-strategy/01-strategy-object.md
@@ -1,0 +1,36 @@
+---
+plan: v2-refactor/E8-strategy
+kind: leaf
+status: done
+complexity: high
+deps: []
+parallel: false
+---
+
+# E8.01 — `Strategy` object
+
+`fynance/strategy/strategy.py` — composes a `DataSource`/`PriceSeries` →
+`FeatureTransform`(s) → `SignalModel` → signal mapper → `Allocator`/sizing →
+`backtest` → `metrics`. Each slot accepts any object conforming to its Protocol;
+each slot is **optional** (skip features, skip allocation, etc.).
+
+## Decision D4 — API style
+- Decide fluent-builder vs declarative-config. **Recommendation: fluent + dataclass
+  config** — `Strategy(features=[...], model=..., signal=..., allocator=..., cost=...)`
+  with a `.run(data) -> BacktestResult`. Document the choice in `03-decisions.md`.
+
+## API
+- `Strategy(...)` with protocol-typed slots; `.run(data) -> BacktestResult`;
+  validates wiring (shapes/contracts) with clear errors; no hidden lookahead
+  (features fit on train portion only when used inside walk-forward, E8.02).
+
+## Files
+- new `fynance/strategy/*`; `fynance/tests/strategy/test_strategy.py`.
+
+## Test
+- an end-to-end tiny run (random/sine data) produces a `BacktestResult` whose
+  `.summary()` is finite; swapping any slot for another conforming impl works;
+  a missing required slot raises a clear error.
+
+## Done when
+- `Strategy(...).run()` green end-to-end; D4 recorded as an ADR.

--- a/doc/dev/plans/v2-refactor/E8-strategy/02-walk-forward-run.md
+++ b/doc/dev/plans/v2-refactor/E8-strategy/02-walk-forward-run.md
@@ -1,0 +1,28 @@
+---
+plan: v2-refactor/E8-strategy
+kind: leaf
+status: done
+complexity: medium
+deps: [1]
+parallel: false
+---
+
+# E8.02 — walk-forward strategy run
+
+Add `Strategy.run_walk_forward(data, *, train, test, step, purge=0)` using the E2
+`walk_forward` splitter: refit features+model per window on train only, predict on
+test, stitch out-of-sample positions, backtest the concatenated OOS series.
+
+## Guarantees
+- features/model are **fit on train slice only** each window (no-lookahead);
+  OOS positions never use data past their timestamp; stitched series is contiguous.
+
+## Files
+- extend `fynance/strategy/strategy.py`; `tests/strategy/test_walk_forward.py`.
+
+## Test
+- OOS coverage == expected window union; a leakage probe (corrupting future train
+  data must not change earlier OOS positions); summary finite.
+
+## Done when
+- walk-forward run green with an explicit no-lookahead probe; closes E8.

--- a/doc/dev/plans/v2-refactor/E9-ui/00-plan.md
+++ b/doc/dev/plans/v2-refactor/E9-ui/00-plan.md
@@ -1,0 +1,21 @@
+---
+plan: v2-refactor/E9-ui
+kind: global
+status: done
+roadmap: "E9 ui — optional Streamlit playground (code a signal fn → see the tearsheet)"
+release_on_done: false
+---
+
+# E9 — UI: Streamlit playground (optional, last)
+
+Realize the "code on the left, perf on the right" vision at ~5% of an IDE's cost:
+a thin Streamlit app over `tearsheet()`. **Optional extra** (`fynance[ui]`),
+**outside** the importable package (`apps/`), built last. Not on the critical path.
+
+## Leaves
+
+| # | Leaf | Complexity | Deps |
+|---|------|-----------|------|
+| 01 | Streamlit playground app | medium | — |
+
+Depends on E5 (tearsheet) and E8 (Strategy). May trail into 2.1.

--- a/doc/dev/plans/v2-refactor/E9-ui/01-streamlit-app.md
+++ b/doc/dev/plans/v2-refactor/E9-ui/01-streamlit-app.md
@@ -1,0 +1,35 @@
+---
+plan: v2-refactor/E9-ui
+kind: leaf
+status: done
+complexity: medium
+deps: []
+parallel: false
+---
+
+# E9.01 — Streamlit playground
+
+`apps/playground/app.py` — two-column layout: left an editor (`streamlit-ace`) for
+a `signal(df) -> positions` function + a data picker; right the live `tearsheet()`.
+
+## Scope
+- left: file/data picker (loads via `fynance.data.load`), code editor seeded with a
+  template signal fn; "Run" button.
+- right: run the user's fn → `fynance.backtest.backtest` → `fynance.plot.tearsheet`
+  rendered via `st.pyplot`; metrics table from `metrics.summary`.
+- packaging: `[project.optional-dependencies] ui = ["streamlit", "streamlit-ace"]`;
+  a `fynance-playground` console-script or `streamlit run apps/playground/app.py`.
+- **Security note**: executes user code via `exec` — documented as local-only;
+  not a hosted/multi-user surface (no sandbox in 2.0).
+
+## Files
+- new `apps/playground/app.py`, `apps/playground/README.md`; `pyproject.toml` extra.
+
+## Test
+- a smoke test importing the app module's pure helpers (signal-runner) with a
+  template fn → produces a `BacktestResult` (no Streamlit runtime needed); the
+  Streamlit layer itself is manual/CI-light.
+
+## Done when
+- `streamlit run apps/playground/app.py` shows code→tearsheet locally; extra
+  documented; helper smoke test green.

--- a/doc/source/features.engineering.rst
+++ b/doc/source/features.engineering.rst
@@ -2,7 +2,7 @@
 Feature engineering
 *******************
 
-Feature-engineering and selection research tools: multi-resolution feature stacking (:func:`~fynance.features.engineering.multi_resolution`), regime-adaptive windows (:func:`~fynance.features.engineering.adaptive_roll` / :func:`~fynance.features.engineering.adaptive_volatility`), a Granger-causality test (:func:`~fynance.features.engineering.granger_causality`) and incremental moments (:func:`~fynance.features.engineering.IncrementalMoments`).
+Feature-engineering and selection research tools: multi-resolution feature stacking (:func:`~fynance.features.engineering.multi_resolution`), regime-adaptive windows (:func:`~fynance.features.engineering.adaptive_roll` / :func:`~fynance.features.engineering.adaptive_volatility`), fixed-width fractional differentiation (:func:`~fynance.features.engineering.fracdiff`), a Granger-causality test (:func:`~fynance.features.engineering.granger_causality`) and incremental moments (:func:`~fynance.features.engineering.IncrementalMoments`).
 
 .. currentmodule:: fynance.features.engineering
 
@@ -12,5 +12,6 @@ Feature-engineering and selection research tools: multi-resolution feature stack
    multi_resolution
    adaptive_roll
    adaptive_volatility
+   fracdiff
    granger_causality
    IncrementalMoments

--- a/doc/source/features.horizon.rst
+++ b/doc/source/features.horizon.rst
@@ -1,0 +1,12 @@
+****************
+Horizon returns
+****************
+
+Forward-return labels over a fixed horizon: :func:`~fynance.features.horizon.horizon_returns` builds the non-overlapping ``h``-bar forward return of a price/level series — the supervised target consumed by the factor-evaluation metrics (:mod:`fynance.metrics.factor`) and by objective-aligned training.
+
+.. currentmodule:: fynance.features.horizon
+
+.. autosummary::
+   :toctree: generated/
+
+   horizon_returns

--- a/doc/source/features.rst
+++ b/doc/source/features.rst
@@ -116,6 +116,7 @@ Common parameters across modules:
    features.cross_section
    features.engineering
    features.filters
+   features.horizon
    features.indicators
    features.labels
    features.ohlcv

--- a/doc/source/plot.rst
+++ b/doc/source/plot.rst
@@ -17,6 +17,9 @@ performance report. Each plot returns an ``Axes``/``Figure`` and never calls
    plot_drawdown
    plot_returns_hist
    plot_rolling_sharpe
+   plot_contribution
+   plot_turnover
+   plot_cost_decomposition
    plot_exposure
 
 Factor tear-sheet

--- a/doc/source/portfolio.sizing.rst
+++ b/doc/source/portfolio.sizing.rst
@@ -2,7 +2,7 @@
 Position sizing
 ***************
 
-Position sizing and transaction-cost primitives for realistic backtests: fractional Kelly (:func:`~fynance.portfolio.sizing.kelly_fraction`), volatility targeting (:func:`~fynance.portfolio.sizing.vol_target`) and turnover-based transaction costs (:func:`~fynance.portfolio.sizing.transaction_cost`).
+Position sizing and transaction-cost primitives for realistic backtests: fractional Kelly (:func:`~fynance.portfolio.sizing.kelly_fraction`), volatility targeting for a single series (:func:`~fynance.portfolio.sizing.vol_target`) or a whole ``(T, N)`` book (:func:`~fynance.portfolio.sizing.book_vol_target`) and turnover-based transaction costs (:func:`~fynance.portfolio.sizing.transaction_cost`).
 
 .. currentmodule:: fynance.portfolio.sizing
 
@@ -11,4 +11,5 @@ Position sizing and transaction-cost primitives for realistic backtests: fractio
 
    kelly_fraction
    vol_target
+   book_vol_target
    transaction_cost

--- a/fynance/backtest/cost.py
+++ b/fynance/backtest/cost.py
@@ -308,11 +308,14 @@ class CompositeCost:
         key already produced by an earlier model recurs, the *later*
         occurrence is disambiguated by prefixing it with its owning class
         name, e.g. ``"transaction"`` then ``"MarketImpactCost.transaction"``.
-        The merged values sum to :meth:`__call__`.
+        A third collision on the same class+key (e.g. several stacked
+        ``ProportionalCost``) is further disambiguated by the model's index,
+        ``"ProportionalCost[2].transaction"``, so no contribution is ever
+        overwritten. The merged values always sum to :meth:`__call__`.
         """
         merged: dict[str, NDArray[np.float64]] = {}
 
-        for model in self.models:
+        for i, model in enumerate(self.models):
             cls_name = type(model).__name__
             if hasattr(model, "components"):
                 comps = model.components(weights)
@@ -321,9 +324,12 @@ class CompositeCost:
                 comps = {cls_name: model(weights)}
 
             for key, value in comps.items():
-                if key in merged:
-                    key = f"{cls_name}.{key}"
+                out_key = key
+                if out_key in merged:
+                    out_key = f"{cls_name}.{key}"
+                if out_key in merged:
+                    out_key = f"{cls_name}[{i}].{key}"
 
-                merged[key] = np.asarray(value, dtype=np.float64)
+                merged[out_key] = np.asarray(value, dtype=np.float64)
 
         return merged

--- a/fynance/data/split.py
+++ b/fynance/data/split.py
@@ -263,7 +263,10 @@ def combinatorial_purged_cv(
             test_mask[s:e] = True
             excl_mask[max(0, s - purge):s] = True
             excl_mask[e:min(T, e + purge)] = True
-            excl_mask[e:min(T, e + embargo)] = True
+            # Embargo stacks *beyond* the post-test purge (de Prado), so it
+            # starts at e + purge — not at e, which would merely overlap the
+            # purge and leave min(purge, embargo) future-adjacent bars in train.
+            excl_mask[min(T, e + purge):min(T, e + purge + embargo)] = True
 
         train_mask = ~test_mask & ~excl_mask
         train_idx = np.nonzero(train_mask)[0].astype(np.int64)

--- a/fynance/models/conformal.py
+++ b/fynance/models/conformal.py
@@ -152,6 +152,8 @@ class ConformalWrapper:
         """ Initialize the wrapper (see class docstring for parameters). """
         if not 0 < alpha < 1:
             raise ValueError(f"alpha must be in (0, 1), got {alpha}")
+        if window <= 0:
+            raise ValueError(f"window must be a positive integer, got {window}")
 
         self.model = model
         self.alpha = alpha

--- a/fynance/models/uncertainty.py
+++ b/fynance/models/uncertainty.py
@@ -202,8 +202,6 @@ class MCDropout:
     Ghahramani, 2016, "Dropout as a Bayesian Approximation"). The spread across
     those passes — :meth:`predict_std` — is the epistemic-uncertainty proxy.
 
-    Technique
-    ---------
     A plain ``model.eval()`` freezes dropout too (no stochasticity left to
     sample from). :meth:`predict` / :meth:`predict_std` instead first put the
     *whole* model in eval mode (so batch-norm and similar layers behave as at

--- a/fynance/portfolio/allocation.py
+++ b/fynance/portfolio/allocation.py
@@ -999,6 +999,12 @@ def MDP(
         return np.ones([1, 1])
 
     up_bound = max(up_bound, 1 / N)
+    # Clamp low_bound so the box stays compatible with the sum-to-one
+    # constraint: with low_bound > 1/N every feasible weight already exceeds
+    # its share, the box+equality set is infeasible and SLSQP would silently
+    # return weights summing to more than one (as ERC/RBP/MVP_uc already
+    # guard against).
+    low_bound = min(low_bound, 1 / N)
 
     if cov is None:
         # Set function to minimize: diversified_ratio recomputes the

--- a/fynance/portfolio/sizing.py
+++ b/fynance/portfolio/sizing.py
@@ -208,11 +208,22 @@ def book_vol_target(
     r[1:] = X[1:] / X[:-1] - 1.0
     rb = np.zeros(X.shape[0])
     rb[1:] = np.sum(W[:-1] * r[1:], axis=1)
-    L = 100.0 * np.cumprod(1.0 + rb)
+
+    # Book-wipeout guard (mirrors rebalance._drift_step): a one-bar book return
+    # <= -1 drives the synthetic level non-positive, so ``realized_volatility``
+    # would take log() of a negative number (NaN + RuntimeWarning). Floor the
+    # growth factor so the level stays positive — identical to ``1 + rb`` for
+    # any valid book where every growth factor is already positive — and force
+    # zero leverage from the first wipeout on (a wiped-out book stays wiped).
+    growth = 1.0 + rb
+    wiped = np.flatnonzero(growth <= 0.0)
+    L = 100.0 * np.cumprod(np.maximum(growth, 1e-12))
 
     vol = np.asarray(realized_volatility(L, w=w, period=period))
     with np.errstate(divide='ignore', invalid='ignore'):
         lev = np.where(vol > 0, target_vol / vol, 0.0)
+    if wiped.size:
+        lev[wiped[0]:] = 0.0
 
     return np.clip(lev, 0.0, max_leverage)
 

--- a/fynance/tests/backtest/test_cost.py
+++ b/fynance/tests/backtest/test_cost.py
@@ -249,3 +249,19 @@ def test_composite_components_merges_holding_terms():
     )
     comps = cost.components(w)
     assert set(comps) == {"transaction", "borrow", "financing", "cash"}
+
+
+def test_composite_components_no_overwrite_on_triple_same_class():
+    # Regression: three stacked models sharing class name AND component key
+    # must each keep their contribution (no silent overwrite), and the merged
+    # components must still sum to the composite total.
+    w = np.array([[1.0, 0.0], [0.4, 0.6], [0.4, 0.6]])
+    comp = CompositeCost(
+        [ProportionalCost(0.001), ProportionalCost(0.002), ProportionalCost(0.003)]
+    )
+    parts = comp.components(w)
+    assert len(parts) == 3  # no collision dropped a component
+    stacked = np.zeros(w.shape[0])
+    for v in parts.values():
+        stacked = stacked + v
+    np.testing.assert_allclose(stacked, comp(w), rtol=1e-12)

--- a/fynance/tests/data/test_split.py
+++ b/fynance/tests/data/test_split.py
@@ -195,3 +195,20 @@ def test_cpcv_purge_no_train_within_h_of_test_boundary(h):
             for offset in range(1, h + 1):
                 assert start - offset not in train_set
                 assert end + offset - 1 not in train_set
+
+
+def test_cpcv_embargo_stacks_on_purge():
+    # Regression: embargo must be applied *beyond* the post-test purge, not
+    # overlap it. With purge=2 and embargo=2, the post-test exclusion after a
+    # test group ending at bar e must span [e, e+4), not [e, e+2).
+    folds = list(
+        combinatorial_purged_cv(20, n_groups=4, n_test_groups=1, purge=2, embargo=2)
+    )
+    # Groups are [0,5),[5,10),[10,15),[15,20); pick the combo whose test is
+    # group 1 = [5, 10) so both boundaries sit inside the series.
+    train, test = next((tr, te) for tr, te in folds if te[0] == 5)
+    assert test.tolist() == [5, 6, 7, 8, 9]
+    # bars 10,11 purged; bars 12,13 embargoed -> none may be in train.
+    for leaked in (10, 11, 12, 13):
+        assert leaked not in train
+    assert 14 in train  # first bar past purge+embargo is back in train

--- a/fynance/tests/models/test_conformal.py
+++ b/fynance/tests/models/test_conformal.py
@@ -313,3 +313,12 @@ def test_smoke_conformal_wrapper_with_tiny_torch_mlp():
     interval = wrapper.predict_interval(X[-5:])
     assert interval.shape == (5, 2)
     assert np.all(interval[:, 1] > interval[:, 0])
+
+
+def test_conformal_non_positive_window_raises():
+    # Regression: window <= 0 must raise a clear ValueError at construction,
+    # not crash later with an obscure IndexError on an empty residual array.
+    with pytest.raises(ValueError, match="window"):
+        ConformalWrapper(MultiLayerPerceptron, alpha=0.1, window=0)
+    with pytest.raises(ValueError, match="window"):
+        ConformalWrapper(MultiLayerPerceptron, alpha=0.1, window=-5)

--- a/fynance/tests/portfolio/test_allocation.py
+++ b/fynance/tests/portfolio/test_allocation.py
@@ -689,3 +689,13 @@ def test_rolling_allocation_cov_seam():
     active = np.flatnonzero(np.abs(w_mat).sum(axis=1) > 1e-9)
     assert active.size > 0
     assert np.allclose(w_mat[active].sum(axis=1), 1.0, atol=1e-4)
+
+
+def test_mdp_high_low_bound_still_sums_to_one():
+    # Regression: MDP must clamp low_bound to 1/N like ERC/RBP/MVP_uc, so an
+    # infeasible box (low_bound > 1/N) cannot silently yield weights that
+    # violate the sum-to-one constraint.
+    rng = np.random.default_rng(0)
+    X = rng.normal(0.0, 0.01, size=(300, 5))
+    w = MDP(X, low_bound=0.3)  # 0.3 > 1/5 = 0.2 -> would be infeasible unclamped
+    assert np.isclose(w.sum(), 1.0, atol=1e-6)

--- a/fynance/tests/portfolio/test_sizing.py
+++ b/fynance/tests/portfolio/test_sizing.py
@@ -151,3 +151,32 @@ def test_book_vol_target_shape_mismatch():
 
     with pytest.raises(ValueError):
         book_vol_target(np.ones((T - 1, 4)), X)
+
+
+def test_book_vol_target_wipeout_is_zero_no_warning():
+    # Regression: a leveraged book with a >100% one-bar loss drives the
+    # synthetic level non-positive; leverage must go to zero from the wipeout
+    # on, with no NaN and no RuntimeWarning escaping.
+    X = np.array([[100.0, 100.0], [100.0, 100.0], [40.0, 40.0],
+                  [42.0, 42.0], [41.0, 41.0], [43.0, 43.0], [44.0, 44.0]])
+    W = np.ones((7, 2))  # 2x-leveraged long book (rb[2] = -1.2)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        lev = book_vol_target(W, X, target_vol=0.1, w=3)
+    assert np.all(np.isfinite(lev))
+    assert np.all(lev[2:] == 0.0)  # wiped out at bar 2, stays wiped
+
+
+def test_book_vol_target_valid_book_unchanged_by_guard():
+    # The wipeout floor must be a no-op for any valid book (all growth > 0):
+    # identical output to the plain 1+rb path.
+    rng = np.random.default_rng(0)
+    X = 100.0 * np.cumprod(1.0 + rng.normal(0.0, 0.01, size=(300, 4)), axis=0)
+    W = np.full((300, 4), 0.25)
+    lev = book_vol_target(W, X, target_vol=0.15, w=21)
+    r = np.zeros_like(X)
+    r[1:] = X[1:] / X[:-1] - 1.0
+    rb = np.zeros(300)
+    rb[1:] = np.sum(W[:-1] * r[1:], axis=1)
+    assert np.all(1.0 + rb > 0.0)  # valid book, no wipeout
+    assert np.all(np.isfinite(lev))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fynance"
-version = "2.13.0"
+version = "2.13.1"
 description = "Pure-Python (Numba-accelerated) machine learning, econometrics and statistical tools for financial analysis and backtesting"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
> Rolling **develop → master** release PR for **v2.13.1** (patch). Ships the
> 5 post-review bug fixes (PR #272) plus doc/config updates on top of v2.13.0.
> Merge, then tag (commands below) to publish on PyPI + GitHub Release.

---

## [2.13.1] - 2026-07-06

### Fixed

- **Post-review corrections** (5 issues from the v2.13.0 adversarial review, all
  bounded to degenerate/rare inputs, each with a regression test):
  `combinatorial_purged_cv` now stacks the embargo *beyond* the post-test purge
  (`e+purge : e+purge+embargo`) instead of overlapping it, so no future-adjacent
  bar leaks back into train when both `purge>0` and `embargo>0`; `MDP` clamps
  `low_bound` to `1/N` like the sibling allocators (an infeasible box no longer
  silently yields weights summing to more than one); `book_vol_target` guards a
  book wipeout (one-bar book return <= -1) so leverage goes to zero with no NaN
  or `RuntimeWarning`; `CompositeCost.components` disambiguates a third
  same-class same-key collision by model index (no component silently
  overwritten, sum invariant preserved); `ConformalWrapper` rejects a
  non-positive `window` with a clear `ValueError` at construction.

## Tag after merging
```
git fetch origin && git tag v2.13.1 origin/master && git push origin v2.13.1
```
