### PR TITLE
fix(backtest): matplotlib LineWidth kwarg -> linewidth

### DIFF
--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -80,6 +80,28 @@ c'est bien ici que ça vit, la campagne elle-même reste dans le repo privé.
 
 ## 4. Outillage / CI (maintenance)
 
+- [ ] **`fynance.backtest` dynamic-plot cassé sur matplotlib récent (overhaul).**
+  Le module de plot dynamique (`BacktestNeuralNet`, `dynamic_plot_backtest`,
+  `plot_backtest`, `plot_tools`) a bit-rotté contre matplotlib moderne + une
+  dérive d'API interne. Bugs identifiés en le consommant depuis fynance-research
+  (matplotlib 3.10, 2026-07-13) :
+  1. **[FAIT]** kwarg `LineWidth=` (camelCase, supprimé par mpl ≥ 3.7) →
+     `AttributeError Line2D.set()`. Corrigé en `linewidth=` (10 occurrences,
+     `plot_backtest.py` + `plot_tools.py`), branche `fix/mpl-linewidth-kwargs`.
+  2. **[À FAIRE]** `PlotBackTest.plot` forwarde les kwargs de LIGNE
+     (`label`, `color`) de `test_plot_kw`/`eval_plot_kw`/`train_plot_kw` dans
+     `ax.legend(**kwargs)` → `TypeError: Legend.__init__() got an unexpected
+     keyword argument 'label'`. Dérive d'API : le parent attend `names` + une
+     palette seaborn (`col`), la couche dynamique (`DynaPlot*`) passe `label` +
+     une couleur solide (`color`). Il faut réaligner l'interface
+     parent/enfant (consommer `label`/`color` explicitement, ne laisser filer
+     que les vrais kwargs de légende) plutôt que rustiner.
+  Faire une passe propre de tout le module avec un **test de non-régression**
+  (smoke `BacktestNeuralNet(plot_loss=True, plot_perf=True).plot_loss(...)`
+  sous backend Agg) pour figer la compat matplotlib. En attendant, préférer les
+  fonctions modernes `fynance.plot.*` (`plot_equity`, `plot_rolling_sharpe`,
+  `plot_drawdown`) qui sont saines.
+
 - [ ] **Actions GitHub sur Node.js 20 déprécié.** Le run `release.yml` avertit
   que `actions/checkout@v4` et `softprops/action-gh-release@v2` ciblent Node 20
   (forcé sur Node 24 par les runners pour l'instant, cassera à terme). Bumper

--- a/fynance/backtest/plot_backtest.py
+++ b/fynance/backtest/plot_backtest.py
@@ -160,7 +160,7 @@ class PlotBackTest:
         col = sns.color_palette(col, N)
 
         # Set graphs
-        h = self.ax.plot(x, y, LineWidth=lw)
+        h = self.ax.plot(x, y, linewidth=lw)
 
         # Set name lines
         if names is None:

--- a/fynance/backtest/plot_tools.py
+++ b/fynance/backtest/plot_tools.py
@@ -117,19 +117,19 @@ def display_perf(
         x_axis,
         100 * perf_est,
         color=sns.xkcd_rgb["pale red"],
-        LineWidth=2.
+        linewidth=2.
     )
     ax_perf.plot(
         x_axis,
         100 * perf_ivo,
         color=sns.xkcd_rgb["medium green"],
-        LineWidth=1.8
+        linewidth=1.8
     )
     ax_perf.plot(
         x_axis,
         100 * perf_idx,
         color=sns.xkcd_rgb["denim blue"],
-        LineWidth=1.5
+        linewidth=1.5
     )
 
     # Set notify motion function
@@ -170,19 +170,19 @@ def display_perf(
             x_axis,
             100 * drawdown(perf_est),
             color=sns.xkcd_rgb["pale red"],
-            LineWidth=1.4
+            linewidth=1.4
         )
         ax_dd.plot(
             x_axis,
             100 * drawdown(perf_ivo),
             color=sns.xkcd_rgb["medium green"],
-            LineWidth=1.2
+            linewidth=1.2
         )
         ax_dd.plot(
             x_axis,
             100 * drawdown(perf_idx),
             color=sns.xkcd_rgb["denim blue"],
-            LineWidth=1.
+            linewidth=1.
         )
         ax_dd.set_ylabel('% DrawDown')
         ax_dd.set_title('DrawDown in percentage')
@@ -193,19 +193,19 @@ def display_perf(
             x_axis,
             roll_sharpe(perf_est, period=period, w=win),
             color=sns.xkcd_rgb["pale red"],
-            LineWidth=1.4
+            linewidth=1.4
         )
         ax_roll.plot(
             x_axis,
             roll_sharpe(perf_ivo, period=period, w=win),
             color=sns.xkcd_rgb["medium green"],
-            LineWidth=1.2
+            linewidth=1.2
         )
         ax_roll.plot(
             x_axis,
             roll_sharpe(perf_idx, period=period, w=win),
             color=sns.xkcd_rgb["denim blue"],
-            LineWidth=1.
+            linewidth=1.
         )
         ax_roll.set_ylabel('Sharpe ratio')
         ax_roll.set_yscale('log')


### PR DESCRIPTION
## Problem
`BacktestNeuralNet` (and the whole `backtest/` dynamic-plot module: `dynamic_plot_backtest`, `plot_backtest`, `plot_tools`) passed the camelCase `LineWidth=` matplotlib kwarg — an alias **removed in matplotlib ≥ 3.7**. On matplotlib 3.10 the first `plot_loss`/`plot_perf`/`plot_accuracy` raises:

```
AttributeError: Line2D.set() got an unexpected keyword argument 'LineWidth'
```

Found while consuming `BacktestNeuralNet` to visualize the loss/perf of a rolling NN.

## Fix
`LineWidth=` → `linewidth=` (10 occurrences, `plot_backtest.py` + `plot_tools.py`).

## Known follow-up (tracked on the roadmap, NOT in this PR)
The same module has a **second** modern-matplotlib break + internal API drift: `PlotBackTest.plot` forwards line kwargs (`label`, `color`) from `test/eval/train_plot_kw` into `ax.legend(**kwargs)` → `TypeError: Legend.__init__() got an unexpected keyword argument 'label'`. The parent expects `names` + a seaborn palette while the dynamic layer passes `label` + a solid color. This needs a proper overhaul of the module + a non-regression smoke test (`BacktestNeuralNet(plot_loss=True, plot_perf=True).plot_loss(...)` under Agg). See `doc/dev/07-roadmap.md` §4. Until then, the modern `fynance.plot.*` functions (`plot_equity`, `plot_rolling_sharpe`, `plot_drawdown`) are unaffected.